### PR TITLE
feat: live landing page, Composio agent integration & platform hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,18 @@ SHOPIFY_SYNC_INVENTORY=true
 SHOPIFY_INVENTORY_LOCATION_ID=
 
 # ===========================================
+# COMPOSIO (AI Agent Tool Router)
+# ===========================================
+# Get your API key from: https://app.composio.dev → Settings → API Keys
+COMPOSIO_API_KEY=your-composio-api-key
+COMPOSIO_EXTERNAL_USER_ID=your-external-user-id
+
+# ===========================================
+# OPENAI (Required for Composio OpenAI Agents)
+# ===========================================
+OPENAI_API_KEY=your-openai-api-key
+
+# ===========================================
 # LOGGING
 # ===========================================
 LOG_LEVEL=info

--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,8 @@ NODE_ENV=development
 # ===========================================
 # DATABASE (PostgreSQL - Local by default)
 # ===========================================
-# Local PostgreSQL (matches docker-compose.yml)
-DATABASE_URL=postgresql://starter_user:local_dev_password@localhost:5432/starter_db
+# Local PostgreSQL (matches docker-compose.yml — port 5434 maps to container 5432)
+DATABASE_URL=postgresql://starter_user:local_dev_password@localhost:5434/starter_db
 
 # For production, use your PostgreSQL connection string:
 # DATABASE_URL=postgresql://user:password@host:5432/database

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm lint-staged

--- a/apps/backend/src/ai/orchestration/__init__.py
+++ b/apps/backend/src/ai/orchestration/__init__.py
@@ -10,6 +10,14 @@ from .agent_registry import (
 from .supervisor_agent import SupervisorAgent, get_supervisor_agent
 from .supervisor_state import SupervisorState
 
+# Resolve forward reference: AgentMetadata.agent_card uses AgentCard which is
+# only available under TYPE_CHECKING in agent_registry.py. Importing AgentCard
+# here and calling model_rebuild() lets Pydantic resolve the annotation at
+# runtime, fixing the "AgentMetadata is not fully defined" error.
+from src.ai.protocol.models import AgentCard as _AgentCard  # noqa: F401
+
+AgentMetadata.model_rebuild()
+
 __all__ = [
     "AgentRegistry",
     "AgentMetadata",

--- a/apps/backend/src/api/main.py
+++ b/apps/backend/src/api/main.py
@@ -25,6 +25,7 @@ from .exceptions import (
 )
 from .middleware.auth import AuthMiddleware
 from .middleware.rate_limit import limiter
+from .middleware.request_id import RequestIdMiddleware
 from .middleware.security_headers import SecurityHeadersMiddleware
 from .routes import (
     activities,  # CRM activities
@@ -372,6 +373,7 @@ app.add_middleware(
 # Custom middleware
 app.add_middleware(SecurityHeadersMiddleware)
 app.add_middleware(AuthMiddleware)
+app.add_middleware(RequestIdMiddleware)
 
 # Performance monitoring middleware
 from src.api.middleware.performance import PerformanceMiddleware, get_performance_metrics

--- a/apps/backend/src/api/main.py
+++ b/apps/backend/src/api/main.py
@@ -55,6 +55,7 @@ from .routes import (
     prd,
     products,
     prometheus_metrics,  # Prometheus metrics endpoint
+    public_stats,  # Public landing page stats (no auth required)
     purchase_orders,
     quotes,
     reconciliation_dashboard,
@@ -383,6 +384,7 @@ app.add_middleware(PerformanceMiddleware, metrics=performance_metrics)
 
 # Include routers
 app.include_router(health.router, tags=["Health"])
+app.include_router(public_stats.router, tags=["Public"])
 app.include_router(prometheus_metrics.router, tags=["Monitoring"])  # Prometheus metrics
 app.include_router(config.router, tags=["Configuration"])
 app.include_router(approvals.router, tags=["Approvals"])

--- a/apps/backend/src/api/middleware/auth.py
+++ b/apps/backend/src/api/middleware/auth.py
@@ -28,6 +28,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
         "/api/auth/logout",
         "/api/auth/forgot-password",
         "/api/auth/reset-password",
+        "/api/public/stats",  # Landing page showcase data (aggregate counts only)
     }
 
     async def dispatch(

--- a/apps/backend/src/api/middleware/request_id.py
+++ b/apps/backend/src/api/middleware/request_id.py
@@ -1,0 +1,43 @@
+"""Request ID middleware for distributed tracing."""
+
+import uuid
+
+import structlog
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+
+logger = structlog.get_logger(__name__)
+
+
+class RequestIdMiddleware(BaseHTTPMiddleware):
+    """Middleware that generates/propagates a unique request ID for every request.
+
+    - Accepts an incoming ``X-Request-ID`` header from the client (for end-to-end
+      correlation) or generates a new UUID4 if none is provided.
+    - Stores the ID on ``request.state.request_id`` so downstream handlers and
+      other middleware can access it.
+    - Binds the ID into the structlog contextvars so **all** log lines emitted
+      during the request automatically include ``request_id``.
+    - Adds the ID to the response ``X-Request-ID`` header for client correlation.
+    """
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        # Accept client-provided request ID or generate a new one
+        request_id = request.headers.get("X-Request-ID") or str(uuid.uuid4())
+
+        # Store on request state for downstream access
+        request.state.request_id = request_id
+
+        # Bind to structlog context so every log line includes request_id
+        structlog.contextvars.bind_contextvars(request_id=request_id)
+
+        try:
+            response = await call_next(request)
+        finally:
+            # Always clear contextvars to prevent leaking between requests
+            structlog.contextvars.unbind_contextvars("request_id")
+
+        # Echo request ID back in response headers
+        response.headers["X-Request-ID"] = request_id
+
+        return response

--- a/apps/backend/src/api/routes/public_stats.py
+++ b/apps/backend/src/api/routes/public_stats.py
@@ -1,0 +1,119 @@
+"""
+Public statistics endpoint for the landing page showcase.
+
+Returns only aggregate counts — no PII, no customer names, no order details.
+Equivalent risk level to the public /health endpoint.
+"""
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy import String, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.config.database import get_async_db
+from src.db.demo_models import (
+    Customer,
+    Order,
+    Product,
+    Quote,
+)
+
+router = APIRouter(prefix="/api/public", tags=["Public"])
+
+
+class PublicStats(BaseModel):
+    """Aggregate statistics for the landing page. No PII."""
+
+    total_products: int
+    total_customers: int
+    active_orders: int
+    pending_quotes: int
+    total_revenue_this_month: str
+    low_stock_alerts: int
+    product_categories: int
+    warehouse_count: int
+    fetched_at: str
+
+
+@router.get("/stats", response_model=PublicStats)
+async def get_public_stats(
+    db: Annotated[AsyncSession, Depends(get_async_db)],
+) -> PublicStats:
+    """Get aggregate platform statistics for the public landing page.
+
+    Returns only counts and totals — no personally identifiable information.
+    """
+    now = datetime.now(UTC)
+    month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+    # Total active products
+    products_result = await db.execute(
+        select(func.count(Product.id)).where(Product.is_active)
+    )
+    total_products = products_result.scalar() or 0
+
+    # Distinct product categories
+    categories_result = await db.execute(
+        select(func.count(func.distinct(Product.category))).where(Product.is_active)
+    )
+    product_categories = categories_result.scalar() or 0
+
+    # Total active customers
+    customers_result = await db.execute(
+        select(func.count(Customer.id)).where(Customer.is_active)
+    )
+    total_customers = customers_result.scalar() or 0
+
+    # Active orders (pending, confirmed, processing, shipped)
+    active_orders_result = await db.execute(
+        select(func.count(Order.id)).where(
+            func.cast(Order.status, String).in_(
+                ["pending", "confirmed", "processing", "shipped"]
+            )
+        )
+    )
+    active_orders = active_orders_result.scalar() or 0
+
+    # Pending quotes (draft, pending, sent)
+    pending_quotes_result = await db.execute(
+        select(func.count(Quote.id)).where(
+            func.cast(Quote.status, String).in_(["draft", "pending", "sent"])
+        )
+    )
+    pending_quotes = pending_quotes_result.scalar() or 0
+
+    # Revenue this month (delivered orders)
+    revenue_result = await db.execute(
+        select(func.sum(Order.total))
+        .where(Order.order_date >= month_start)
+        .where(func.cast(Order.status, String) == "delivered")
+    )
+    total_revenue = revenue_result.scalar() or Decimal(0)
+
+    # Low stock alerts (active products with stock <= 10)
+    low_stock_result = await db.execute(
+        select(func.count(Product.id))
+        .where(Product.is_active)
+        .where(Product.stock <= 10)
+    )
+    low_stock_alerts = low_stock_result.scalar() or 0
+
+    # Warehouse locations: Brisbane HQ, Sydney Branch, Melbourne Branch
+    # This is a known business constant (free-text field has inconsistent values)
+    warehouse_count = 3
+
+    return PublicStats(
+        total_products=total_products,
+        total_customers=total_customers,
+        active_orders=active_orders,
+        pending_quotes=pending_quotes,
+        total_revenue_this_month=str(total_revenue),
+        low_stock_alerts=low_stock_alerts,
+        product_categories=product_categories,
+        warehouse_count=warehouse_count,
+        fetched_at=now.isoformat(),
+    )

--- a/apps/backend/src/config/database.py
+++ b/apps/backend/src/config/database.py
@@ -27,8 +27,8 @@ def get_database_url(async_mode: bool = False) -> str:
     """
     settings = get_settings()
 
-    # Default to local PostgreSQL if not configured
-    db_url = settings.database_url or "postgresql://starter_user:local_dev_password@localhost:5432/starter_db"
+    # Default to local PostgreSQL if not configured (port 5434 matches docker-compose.yml)
+    db_url = settings.database_url or "postgresql://starter_user:local_dev_password@localhost:5434/starter_db"
 
     # Convert to async URL if needed
     if async_mode and not db_url.startswith("postgresql+asyncpg"):

--- a/apps/backend/src/config/settings.py
+++ b/apps/backend/src/config/settings.py
@@ -121,8 +121,9 @@ class Settings(BaseSettings):
     # CORS_ORIGINS='["https://your-domain.com","https://www.your-domain.com"]'
 
     # Database (PostgreSQL)
+    # Default port 5434 matches docker-compose.yml external mapping (5434:5432)
     database_url: str = Field(
-        default="postgresql://starter_user:local_dev_password@localhost:5432/starter_db",
+        default="postgresql://starter_user:local_dev_password@localhost:5434/starter_db",
         description="PostgreSQL connection URL",
     )
 
@@ -148,7 +149,7 @@ class Settings(BaseSettings):
 
     # Database password for Docker secrets (separate from DATABASE_URL)
     database_host: str = Field(default="localhost", description="Database host")
-    database_port: int = Field(default=5432, description="Database port")
+    database_port: int = Field(default=5434, description="Database port (5434 matches docker-compose)")
     database_name: str = Field(default="starter_db", description="Database name")
     database_user: str = Field(default="starter_user", description="Database user")
     database_password: str = Field(default="", description="Database password (supports Docker secrets)")

--- a/apps/web/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/page.tsx
@@ -27,6 +27,8 @@ import { SalesInsightsWidget } from "@/components/dashboard/SalesInsightsWidget"
 import { OrderPatternsWidget } from "@/components/dashboard/OrderPatternsWidget";
 // PHASE 7: Cin7 Sync Status Widget
 import { Cin7SyncStatusWidget } from "@/components/dashboard/Cin7SyncStatusWidget";
+// NODEJS-Updates: Agent performance metrics widget
+import { AgentMetricsWidget } from "@/components/dashboard/AgentMetricsWidget";
 import { format } from "date-fns";
 import { motion } from "framer-motion";
 
@@ -378,6 +380,11 @@ export default function DashboardPage() {
         {/* PHASE 7: Cin7 Sync Status - 1 column */}
         <BentoCard variant="elevated" span={1} className="min-h-[350px]">
           <Cin7SyncStatusWidget />
+        </BentoCard>
+
+        {/* NODEJS-Updates: Agent Performance Metrics - 1 column */}
+        <BentoCard variant="glass" span={1} className="min-h-[350px]">
+          <AgentMetricsWidget />
         </BentoCard>
 
         {/* PHASE C: AI Order Patterns Widget - Spans 2 columns */}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,7 +1,17 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { LoginForm } from "@/components/auth/login-form";
+import {
+  LiveStatsBar,
+  type PublicStats,
+} from "@/components/landing/LiveStatsBar";
 import {
   Package,
   Users,
@@ -12,12 +22,34 @@ import {
   ChevronRight,
   CheckCircle2,
   LogIn,
+  AlertTriangle,
 } from "lucide-react";
 
-export default function Home() {
+const BACKEND_URL =
+  process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:8000";
+
+/**
+ * Fetch public stats from the backend (server-side, no auth required).
+ * Returns null gracefully if the backend is unreachable.
+ */
+async function getPublicStats(): Promise<PublicStats | null> {
+  try {
+    const res = await fetch(`${BACKEND_URL}/api/public/stats`, {
+      next: { revalidate: 60 },
+    });
+    if (!res.ok) return null;
+    return res.json();
+  } catch {
+    return null;
+  }
+}
+
+export default async function Home() {
+  const stats = await getPublicStats();
+
   return (
     <div className="min-h-screen bg-background text-foreground">
-      {/* Hero Section */}
+      {/* Header */}
       <header className="border-b">
         <div className="container mx-auto px-6 py-4 flex items-center justify-between">
           <div className="flex items-center gap-2">
@@ -62,6 +94,9 @@ export default function Home() {
           </div>
         </section>
 
+        {/* Live Stats Bar */}
+        <LiveStatsBar stats={stats} />
+
         {/* Features Grid */}
         <section className="border-t bg-muted/40">
           <div className="container mx-auto px-6 py-16 md:py-20">
@@ -72,11 +107,26 @@ export default function Home() {
                   <div className="p-2.5 rounded-lg bg-primary/10">
                     <ShoppingCart className="w-5 h-5 text-primary" />
                   </div>
-                  <h3 className="text-xl font-semibold">Orders &amp; Quotes</h3>
+                  <h3 className="text-xl font-semibold">
+                    Orders &amp; Quotes
+                  </h3>
                 </div>
                 <p className="text-muted-foreground mb-5">
-                  Create quotes, convert to orders, track fulfilment and manage
-                  line items across all product categories.
+                  {stats ? (
+                    <>
+                      <span className="text-foreground font-semibold">
+                        {stats.active_orders} orders
+                      </span>{" "}
+                      in progress and{" "}
+                      <span className="text-foreground font-semibold">
+                        {stats.pending_quotes} quotes
+                      </span>{" "}
+                      open. Create quotes, convert to orders, track fulfilment
+                      and manage line items across all product categories.
+                    </>
+                  ) : (
+                    "Create quotes, convert to orders, track fulfilment and manage line items across all product categories."
+                  )}
                 </p>
                 <div className="space-y-2.5">
                   <div className="flex items-center gap-2 text-sm">
@@ -103,8 +153,17 @@ export default function Home() {
                   <h3 className="text-xl font-semibold">Customers</h3>
                 </div>
                 <p className="text-muted-foreground">
-                  Customer directory with contact details, order history and
-                  account management.
+                  {stats ? (
+                    <>
+                      <span className="text-foreground font-semibold">
+                        {stats.total_customers} active accounts
+                      </span>{" "}
+                      with contact details, order history and account
+                      management.
+                    </>
+                  ) : (
+                    "Customer directory with contact details, order history and account management."
+                  )}
                 </p>
               </div>
 
@@ -117,8 +176,21 @@ export default function Home() {
                   <h3 className="text-xl font-semibold">Products</h3>
                 </div>
                 <p className="text-muted-foreground">
-                  Full product catalogue covering heavy machinery, power tools,
-                  safety equipment and more.
+                  {stats ? (
+                    <>
+                      <span className="text-foreground font-semibold">
+                        {stats.total_products} products
+                      </span>{" "}
+                      across{" "}
+                      <span className="text-foreground font-semibold">
+                        {stats.product_categories} categories
+                      </span>{" "}
+                      including heavy machinery, power tools, safety equipment
+                      and more.
+                    </>
+                  ) : (
+                    "Full product catalogue covering heavy machinery, power tools, safety equipment and more."
+                  )}
                 </p>
               </div>
 
@@ -133,8 +205,18 @@ export default function Home() {
                   </h3>
                 </div>
                 <p className="text-muted-foreground mb-5">
-                  Stock levels, transfers between locations, purchase orders and
-                  backorder management across all three warehouses.
+                  {stats && stats.low_stock_alerts > 0 ? (
+                    <>
+                      Stock levels, transfers and purchase orders across all
+                      three warehouses.{" "}
+                      <span className="inline-flex items-center gap-1 text-amber-600 font-medium">
+                        <AlertTriangle className="w-3.5 h-3.5" />
+                        {stats.low_stock_alerts} low stock alerts
+                      </span>
+                    </>
+                  ) : (
+                    "Stock levels, transfers between locations, purchase orders and backorder management across all three warehouses."
+                  )}
                 </p>
                 <div className="grid grid-cols-3 gap-4">
                   {[
@@ -165,8 +247,23 @@ export default function Home() {
                   <h3 className="text-xl font-semibold">Reporting</h3>
                 </div>
                 <p className="text-muted-foreground">
-                  Revenue, stock health, order status and performance dashboards
-                  with live data.
+                  {stats ? (
+                    <>
+                      Revenue, stock health, order status and performance
+                      dashboards tracking{" "}
+                      <span className="text-foreground font-semibold">
+                        ${Number(
+                          stats.total_revenue_this_month
+                        ).toLocaleString("en-AU", {
+                          minimumFractionDigits: 0,
+                          maximumFractionDigits: 0,
+                        })}
+                      </span>{" "}
+                      this month with live data.
+                    </>
+                  ) : (
+                    "Revenue, stock health, order status and performance dashboards with live data."
+                  )}
                 </p>
               </div>
             </div>
@@ -182,9 +279,7 @@ export default function Home() {
                   <div className="mx-auto mb-2 p-2.5 rounded-lg bg-primary/10 w-fit">
                     <LogIn className="w-5 h-5 text-primary" />
                   </div>
-                  <CardTitle className="text-2xl font-bold">
-                    Sign In
-                  </CardTitle>
+                  <CardTitle className="text-2xl font-bold">Sign In</CardTitle>
                   <CardDescription>
                     Sign in to your account to access the platform
                   </CardDescription>

--- a/apps/web/components/dashboard/AgentMetricsWidget.tsx
+++ b/apps/web/components/dashboard/AgentMetricsWidget.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { memo } from "react";
+import { Bot, AlertTriangle, CheckCircle2, XCircle, Activity, ShieldAlert } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { useAutonomyMetrics } from "@/lib/hooks/use-autonomy-metrics";
+
+const STATUS_STYLES: Record<string, { color: string; bgColor: string; label: string }> = {
+  healthy: { color: "text-green-600", bgColor: "bg-green-100 border-green-300", label: "Healthy" },
+  degraded: { color: "text-yellow-600", bgColor: "bg-yellow-100 border-yellow-300", label: "Degraded" },
+  unhealthy: { color: "text-red-600", bgColor: "bg-red-100 border-red-300", label: "Unhealthy" },
+};
+
+function formatPercent(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+export const AgentMetricsWidget = memo(function AgentMetricsWidget() {
+  const { metrics, health, anomalies, loading, error } = useAutonomyMetrics(24);
+
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Bot className="h-5 w-5" />
+            Agent Performance
+          </CardTitle>
+          <CardDescription>Loading agent metrics...</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Bot className="h-5 w-5" />
+            Agent Performance
+          </CardTitle>
+          <CardDescription className="text-destructive">{error}</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  const statusStyle = STATUS_STYLES[health?.status ?? "healthy"];
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <Bot className="h-5 w-5" />
+              Agent Performance
+            </CardTitle>
+            <CardDescription>24h autonomous agent metrics</CardDescription>
+          </div>
+          {health && (
+            <Badge variant="outline" className={`text-sm font-bold ${statusStyle.bgColor}`}>
+              {statusStyle.label}
+            </Badge>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent>
+        {metrics && (
+          <>
+            {/* Key Metrics Grid */}
+            <div className="mb-4 grid grid-cols-3 gap-3 text-center">
+              <div className="rounded-lg border p-2">
+                <p className="text-xs text-muted-foreground">Success Rate</p>
+                <p className={`text-lg font-bold ${metrics.auto_merge_success_rate >= 0.9 ? "text-green-600" : metrics.auto_merge_success_rate >= 0.7 ? "text-yellow-600" : "text-red-600"}`}>
+                  {formatPercent(metrics.auto_merge_success_rate)}
+                </p>
+              </div>
+              <div className="rounded-lg border p-2">
+                <p className="text-xs text-muted-foreground">Test Pass</p>
+                <p className={`text-lg font-bold ${metrics.test_pass_rate >= 0.95 ? "text-green-600" : metrics.test_pass_rate >= 0.8 ? "text-yellow-600" : "text-red-600"}`}>
+                  {formatPercent(metrics.test_pass_rate)}
+                </p>
+              </div>
+              <div className="rounded-lg border p-2">
+                <p className="text-xs text-muted-foreground">Avg Duration</p>
+                <p className="text-lg font-bold">{formatDuration(metrics.avg_duration_ms)}</p>
+              </div>
+            </div>
+
+            {/* Action Summary */}
+            <div className="space-y-2 mb-4">
+              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                Actions (24h)
+              </p>
+              <div className="grid grid-cols-2 gap-2 text-sm">
+                <div className="flex items-center gap-2">
+                  <Activity className="h-3.5 w-3.5 text-muted-foreground" />
+                  <span className="text-muted-foreground">Total:</span>
+                  <span className="font-medium">{metrics.total_actions}</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <CheckCircle2 className="h-3.5 w-3.5 text-green-600" />
+                  <span className="text-muted-foreground">Merged:</span>
+                  <span className="font-medium">{metrics.total_auto_merged}</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <XCircle className="h-3.5 w-3.5 text-red-600" />
+                  <span className="text-muted-foreground">Rejected:</span>
+                  <span className="font-medium">{metrics.total_rejected}</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <ShieldAlert className="h-3.5 w-3.5 text-orange-600" />
+                  <span className="text-muted-foreground">Blocked:</span>
+                  <span className="font-medium">{metrics.total_blocked}</span>
+                </div>
+              </div>
+            </div>
+
+            {/* Risk Distribution */}
+            {Object.keys(metrics.risk_distribution).length > 0 && (
+              <div className="space-y-2 mb-4">
+                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                  Risk Distribution
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {Object.entries(metrics.risk_distribution).map(([level, count]) => (
+                    <Badge key={level} variant="secondary" className="text-xs">
+                      {level}: {count}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+
+        {/* Anomalies */}
+        {anomalies && anomalies.has_anomalies && (
+          <div className="space-y-2">
+            <p className="text-xs font-medium text-destructive uppercase tracking-wider flex items-center gap-1">
+              <AlertTriangle className="h-3 w-3" />
+              Anomalies Detected ({anomalies.anomaly_count})
+            </p>
+            <div className="space-y-1">
+              {anomalies.anomalies.slice(0, 3).map((anomaly, idx) => (
+                <p key={idx} className="text-xs text-destructive/80 truncate">
+                  {anomaly}
+                </p>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* No data state */}
+        {metrics && metrics.total_actions === 0 && (
+          <div className="text-center py-4 text-muted-foreground">
+            <Bot className="h-8 w-8 mx-auto mb-2 opacity-50" />
+            <p className="text-sm">No agent activity</p>
+            <p className="text-xs mt-1">Metrics will appear when agents execute tasks</p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+});

--- a/apps/web/components/landing/AnimatedCounter.tsx
+++ b/apps/web/components/landing/AnimatedCounter.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import {
+  useMotionValue,
+  useSpring,
+  useInView,
+  useTransform,
+  motion,
+} from "framer-motion";
+
+interface AnimatedCounterProps {
+  /** Target number to count up to */
+  value: number;
+  /** Text before the number (e.g. "$") */
+  prefix?: string;
+  /** Text after the number (e.g. "+") */
+  suffix?: string;
+  /** Animation duration in seconds */
+  duration?: number;
+  /** Format as compact (e.g. 125K instead of 125,000) */
+  compact?: boolean;
+}
+
+export function AnimatedCounter({
+  value,
+  prefix = "",
+  suffix = "",
+  duration = 1.5,
+  compact = false,
+}: AnimatedCounterProps) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const motionValue = useMotionValue(0);
+  const springValue = useSpring(motionValue, {
+    damping: 40,
+    stiffness: 100,
+    duration: duration * 1000,
+  });
+  const isInView = useInView(ref, { once: true, margin: "-50px" });
+
+  const display = useTransform(springValue, (latest) => {
+    const rounded = Math.round(latest);
+    if (compact && rounded >= 1000) {
+      return `${prefix}${(rounded / 1000).toFixed(rounded >= 10000 ? 0 : 1)}K${suffix}`;
+    }
+    return `${prefix}${new Intl.NumberFormat("en-AU").format(rounded)}${suffix}`;
+  });
+
+  useEffect(() => {
+    if (isInView) {
+      motionValue.set(value);
+    }
+  }, [isInView, value, motionValue]);
+
+  return <motion.span ref={ref}>{display}</motion.span>;
+}

--- a/apps/web/components/landing/LiveStatsBar.tsx
+++ b/apps/web/components/landing/LiveStatsBar.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { memo } from "react";
+import { motion } from "framer-motion";
+import {
+  Package,
+  Users,
+  ShoppingCart,
+  DollarSign,
+  FileText,
+  LayoutGrid,
+} from "lucide-react";
+import { AnimatedCounter } from "./AnimatedCounter";
+
+export interface PublicStats {
+  total_products: number;
+  total_customers: number;
+  active_orders: number;
+  pending_quotes: number;
+  total_revenue_this_month: string;
+  low_stock_alerts: number;
+  product_categories: number;
+  warehouse_count: number;
+  fetched_at: string;
+}
+
+interface LiveStatsBarProps {
+  stats: PublicStats | null;
+}
+
+const statItems = [
+  {
+    key: "total_products" as const,
+    label: "Products",
+    icon: Package,
+  },
+  {
+    key: "total_customers" as const,
+    label: "Customers",
+    icon: Users,
+  },
+  {
+    key: "active_orders" as const,
+    label: "Active Orders",
+    icon: ShoppingCart,
+  },
+  {
+    key: "total_revenue_this_month" as const,
+    label: "Revenue (Month)",
+    icon: DollarSign,
+  },
+  {
+    key: "pending_quotes" as const,
+    label: "Open Quotes",
+    icon: FileText,
+  },
+  {
+    key: "product_categories" as const,
+    label: "Categories",
+    icon: LayoutGrid,
+  },
+];
+
+const containerVariants = {
+  hidden: {},
+  visible: {
+    transition: {
+      staggerChildren: 0.1,
+    },
+  },
+};
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 20 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.5 } },
+};
+
+export const LiveStatsBar = memo(function LiveStatsBar({
+  stats,
+}: LiveStatsBarProps) {
+  if (!stats) return null;
+
+  const revenueNum = parseFloat(stats.total_revenue_this_month) || 0;
+
+  return (
+    <section className="border-t border-b bg-muted/30">
+      <div className="container mx-auto px-6 py-10 md:py-12">
+        {/* Header with live indicator */}
+        <div className="flex items-center justify-center gap-2 mb-8">
+          <span className="relative flex h-2.5 w-2.5">
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
+            <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-green-500" />
+          </span>
+          <span className="text-sm font-medium text-muted-foreground tracking-wide uppercase">
+            Live Platform Data
+          </span>
+        </div>
+
+        {/* Stats grid */}
+        <motion.div
+          className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4 md:gap-6"
+          variants={containerVariants}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, margin: "-80px" }}
+        >
+          {statItems.map((item) => {
+            const Icon = item.icon;
+            const isRevenue = item.key === "total_revenue_this_month";
+
+            return (
+              <motion.div
+                key={item.key}
+                variants={itemVariants}
+                className="text-center p-4 rounded-xl border bg-card hover:shadow-md transition-shadow"
+              >
+                <div className="mx-auto mb-2.5 p-2 rounded-lg bg-primary/10 w-fit">
+                  <Icon className="w-4 h-4 text-primary" />
+                </div>
+                <div className="text-2xl md:text-3xl font-bold tracking-tight text-foreground">
+                  {isRevenue ? (
+                    <AnimatedCounter
+                      value={revenueNum}
+                      prefix="$"
+                      compact
+                    />
+                  ) : (
+                    <AnimatedCounter
+                      value={stats[item.key] as number}
+                    />
+                  )}
+                </div>
+                <div className="text-xs text-muted-foreground mt-1 font-medium">
+                  {item.label}
+                </div>
+              </motion.div>
+            );
+          })}
+        </motion.div>
+      </div>
+    </section>
+  );
+});

--- a/apps/web/lib/api/auth.ts
+++ b/apps/web/lib/api/auth.ts
@@ -43,7 +43,7 @@ export interface RegisterResponse {
 /**
  * Check if we should use Supabase Auth (production) or FastAPI (local dev)
  */
-function useSupabaseAuth(): boolean {
+function isSupabaseAuthEnabled(): boolean {
   // Use Supabase Auth when NEXT_PUBLIC_SUPABASE_URL is configured
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || "";
   return supabaseUrl.length > 0 && supabaseUrl.includes("supabase.co");
@@ -59,7 +59,7 @@ export const authApi = {
   async login(credentials: LoginRequest): Promise<LoginResponse> {
     const { rememberMe = true } = credentials;
 
-    if (useSupabaseAuth()) {
+    if (isSupabaseAuthEnabled()) {
       // Supabase Auth
       const { data, error } = await getSupabase().auth.signInWithPassword({
         email: credentials.email,
@@ -121,7 +121,7 @@ export const authApi = {
    * Register a new user
    */
   async register(data: RegisterRequest): Promise<RegisterResponse> {
-    if (useSupabaseAuth()) {
+    if (isSupabaseAuthEnabled()) {
       const { data: authData, error } = await getSupabase().auth.signUp({
         email: data.email,
         password: data.password,
@@ -158,7 +158,7 @@ export const authApi = {
       sessionStorage.removeItem("auth_token");
     }
 
-    if (useSupabaseAuth()) {
+    if (isSupabaseAuthEnabled()) {
       await getSupabase().auth.signOut();
     } else {
       try {
@@ -173,7 +173,7 @@ export const authApi = {
    * Get current user
    */
   async getCurrentUser(): Promise<User | null> {
-    if (useSupabaseAuth()) {
+    if (isSupabaseAuthEnabled()) {
       const { data: { user } } = await getSupabase().auth.getUser();
       if (!user) return null;
 
@@ -198,7 +198,7 @@ export const authApi = {
    * Update current user profile
    */
   async updateProfile(data: Partial<User>): Promise<User> {
-    if (useSupabaseAuth()) {
+    if (isSupabaseAuthEnabled()) {
       const { data: authData, error } = await getSupabase().auth.updateUser({
         data: { full_name: data.full_name },
       });
@@ -225,7 +225,7 @@ export const authApi = {
     _currentPassword: string,
     newPassword: string
   ): Promise<{ message: string }> {
-    if (useSupabaseAuth()) {
+    if (isSupabaseAuthEnabled()) {
       const { error } = await getSupabase().auth.updateUser({
         password: newPassword,
       });
@@ -244,7 +244,7 @@ export const authApi = {
    * Request password reset
    */
   async requestPasswordReset(email: string): Promise<{ message: string }> {
-    if (useSupabaseAuth()) {
+    if (isSupabaseAuthEnabled()) {
       const { error } = await getSupabase().auth.resetPasswordForEmail(email);
       if (error) throw new Error(error.message);
       return { message: "If an account exists with that email, a password reset link has been sent." };
@@ -260,7 +260,7 @@ export const authApi = {
     _token: string,
     newPassword: string
   ): Promise<{ message: string }> {
-    if (useSupabaseAuth()) {
+    if (isSupabaseAuthEnabled()) {
       const { error } = await getSupabase().auth.updateUser({
         password: newPassword,
       });

--- a/apps/web/lib/api/auth.ts
+++ b/apps/web/lib/api/auth.ts
@@ -4,7 +4,7 @@
  * Uses Supabase Auth for production, falls back to FastAPI backend for local dev.
  */
 
-import { supabase } from "@/lib/supabase/client";
+import { getSupabase } from "@/lib/supabase/client";
 import { apiClient } from "./client";
 
 export interface User {
@@ -61,7 +61,7 @@ export const authApi = {
 
     if (useSupabaseAuth()) {
       // Supabase Auth
-      const { data, error } = await supabase.auth.signInWithPassword({
+      const { data, error } = await getSupabase().auth.signInWithPassword({
         email: credentials.email,
         password: credentials.password,
       });
@@ -122,7 +122,7 @@ export const authApi = {
    */
   async register(data: RegisterRequest): Promise<RegisterResponse> {
     if (useSupabaseAuth()) {
-      const { data: authData, error } = await supabase.auth.signUp({
+      const { data: authData, error } = await getSupabase().auth.signUp({
         email: data.email,
         password: data.password,
         options: {
@@ -159,7 +159,7 @@ export const authApi = {
     }
 
     if (useSupabaseAuth()) {
-      await supabase.auth.signOut();
+      await getSupabase().auth.signOut();
     } else {
       try {
         await apiClient.post("/api/auth/logout");
@@ -174,7 +174,7 @@ export const authApi = {
    */
   async getCurrentUser(): Promise<User | null> {
     if (useSupabaseAuth()) {
-      const { data: { user } } = await supabase.auth.getUser();
+      const { data: { user } } = await getSupabase().auth.getUser();
       if (!user) return null;
 
       return {
@@ -199,7 +199,7 @@ export const authApi = {
    */
   async updateProfile(data: Partial<User>): Promise<User> {
     if (useSupabaseAuth()) {
-      const { data: authData, error } = await supabase.auth.updateUser({
+      const { data: authData, error } = await getSupabase().auth.updateUser({
         data: { full_name: data.full_name },
       });
 
@@ -226,7 +226,7 @@ export const authApi = {
     newPassword: string
   ): Promise<{ message: string }> {
     if (useSupabaseAuth()) {
-      const { error } = await supabase.auth.updateUser({
+      const { error } = await getSupabase().auth.updateUser({
         password: newPassword,
       });
 
@@ -245,7 +245,7 @@ export const authApi = {
    */
   async requestPasswordReset(email: string): Promise<{ message: string }> {
     if (useSupabaseAuth()) {
-      const { error } = await supabase.auth.resetPasswordForEmail(email);
+      const { error } = await getSupabase().auth.resetPasswordForEmail(email);
       if (error) throw new Error(error.message);
       return { message: "If an account exists with that email, a password reset link has been sent." };
     }
@@ -261,7 +261,7 @@ export const authApi = {
     newPassword: string
   ): Promise<{ message: string }> {
     if (useSupabaseAuth()) {
-      const { error } = await supabase.auth.updateUser({
+      const { error } = await getSupabase().auth.updateUser({
         password: newPassword,
       });
 

--- a/apps/web/lib/api/autonomy.ts
+++ b/apps/web/lib/api/autonomy.ts
@@ -1,0 +1,76 @@
+/**
+ * Autonomy Metrics API Client
+ *
+ * TypeScript client for the /api/autonomy/* backend endpoints.
+ * Provides agent performance metrics, health status, and anomaly detection.
+ */
+
+import { apiClient } from "./client";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AutonomyMetrics {
+  total_actions: number;
+  total_prs_created: number;
+  total_auto_merged: number;
+  total_rejected: number;
+  total_blocked: number;
+  auto_merge_success_rate: number;
+  test_pass_rate: number;
+  protected_file_violations: number;
+  rate_limit_hits: number;
+  circuit_breaker_trips: number;
+  auto_merge_reversions: number;
+  risk_distribution: Record<string, number>;
+  avg_duration_ms: number;
+}
+
+export interface AutonomyHealth {
+  status: "healthy" | "degraded" | "unhealthy";
+  metrics: {
+    success_rate: number;
+    error_rate: number;
+    test_pass_rate: number;
+    total_actions: number;
+    total_auto_merged: number;
+  };
+  issues: string[];
+  timestamp: string;
+}
+
+export interface AutonomyAnomalies {
+  window_hours: number;
+  anomalies: string[];
+  has_anomalies: boolean;
+  anomaly_count: number;
+}
+
+// ---------------------------------------------------------------------------
+// API Functions
+// ---------------------------------------------------------------------------
+
+export async function getAutonomyMetrics(
+  windowHours: number = 24
+): Promise<AutonomyMetrics> {
+  return apiClient.get<AutonomyMetrics>(
+    `/api/autonomy/metrics?window_hours=${windowHours}`
+  );
+}
+
+export async function getAutonomyHealth(
+  windowHours: number = 1
+): Promise<AutonomyHealth> {
+  return apiClient.get<AutonomyHealth>(
+    `/api/autonomy/health?window_hours=${windowHours}`
+  );
+}
+
+export async function getAutonomyAnomalies(
+  windowHours: number = 24
+): Promise<AutonomyAnomalies> {
+  return apiClient.get<AutonomyAnomalies>(
+    `/api/autonomy/anomalies?window_hours=${windowHours}`
+  );
+}

--- a/apps/web/lib/api/client.ts
+++ b/apps/web/lib/api/client.ts
@@ -3,9 +3,27 @@
  *
  * Replaces Supabase client with direct fetch calls to FastAPI.
  * Handles JWT authentication via cookies.
+ *
+ * Enhancements (NODEJS-Updates):
+ * - X-Request-ID header for distributed tracing
+ * - Automatic retry with exponential backoff on 5xx / network errors
+ * - AbortController timeout (30s default)
+ * - Automatic token refresh on 401
  */
 
 const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || "";
+
+/** Default request timeout in milliseconds */
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/** Maximum number of retries for transient failures */
+const MAX_RETRIES = 3;
+
+/** Initial retry delay in milliseconds (doubles each attempt) */
+const INITIAL_RETRY_DELAY_MS = 500;
+
+/** HTTP methods that are safe to retry (idempotent) */
+const RETRYABLE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 
 export interface ApiError {
   detail: string;
@@ -72,57 +90,195 @@ function decodeJWT(token: string): JWTPayload | null {
 }
 
 /**
- * Make an authenticated API request
+ * Attempt to refresh the JWT access token using the refresh endpoint.
+ * Returns true if the token was successfully refreshed.
+ */
+async function attemptTokenRefresh(): Promise<boolean> {
+  try {
+    const response = await fetch(`${BACKEND_URL}/api/auth/refresh`, {
+      method: "POST",
+      credentials: "include",
+    });
+
+    if (response.ok) {
+      const data = await response.json();
+      if (data.access_token) {
+        // Store the new token in the same location as the original
+        if (localStorage.getItem("auth_token")) {
+          localStorage.setItem("auth_token", data.access_token);
+        } else if (sessionStorage.getItem("auth_token")) {
+          sessionStorage.setItem("auth_token", data.access_token);
+        }
+        return true;
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Determine whether a failed request should be retried.
+ */
+function shouldRetry(
+  method: string,
+  status: number | null,
+  retryCount: number
+): boolean {
+  if (retryCount >= MAX_RETRIES) return false;
+
+  // Network error (status is null) — always retry
+  if (status === null) return true;
+
+  // Only retry idempotent methods on server errors
+  if (status >= 500 && status < 600 && RETRYABLE_METHODS.has(method.toUpperCase())) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Sleep for the exponential backoff delay.
+ */
+function retryDelay(attempt: number): Promise<void> {
+  const delay = INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt);
+  return new Promise((resolve) => setTimeout(resolve, delay));
+}
+
+/**
+ * Make an authenticated API request with retry, timeout, and request tracing.
  */
 async function fetchApi<T>(
   endpoint: string,
-  options: RequestInit = {}
+  options: RequestInit = {},
+  timeout: number = DEFAULT_TIMEOUT_MS
 ): Promise<T> {
-  const token = getAuthToken();
+  const requestId =
+    typeof crypto !== "undefined" && crypto.randomUUID
+      ? crypto.randomUUID()
+      : `req-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-    ...options.headers,
-  };
+  const method = (options.method || "GET").toUpperCase();
 
-  if (token) {
-    headers["Authorization"] = `Bearer ${token}`;
+  const buildHeaders = (): HeadersInit => {
+    const token = getAuthToken();
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      "X-Request-ID": requestId,
+      ...(options.headers as Record<string, string> | undefined),
+    };
 
-    // Extract user_id from JWT and add to X-User-Id header (for auth middleware)
-    const payload = decodeJWT(token);
-    if (payload && payload.user_id) {
-      headers["X-User-Id"] = payload.user_id;
+    if (token) {
+      headers["Authorization"] = `Bearer ${token}`;
+
+      const payload = decodeJWT(token);
+      if (payload && payload.user_id) {
+        headers["X-User-Id"] = payload.user_id;
+      }
     }
-  }
+
+    return headers;
+  };
 
   const url = endpoint.startsWith("http")
     ? endpoint
     : `${BACKEND_URL}${endpoint}`;
 
-  const response = await fetch(url, {
-    ...options,
-    headers,
-    credentials: "include", // Include cookies
-  });
+  let lastError: ApiClientError | null = null;
 
-  if (!response.ok) {
-    const error: ApiError = await response.json().catch(() => ({
-      detail: `HTTP ${response.status}: ${response.statusText}`,
-    }));
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    // Wait before retry (skip on first attempt)
+    if (attempt > 0) {
+      await retryDelay(attempt - 1);
+    }
 
-    throw new ApiClientError(
-      error.detail,
-      response.status,
-      error.error_code
-    );
+    // Create a fresh AbortController for each attempt
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+    try {
+      const response = await fetch(url, {
+        ...options,
+        method,
+        headers: buildHeaders(),
+        credentials: "include",
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      // --- 401 Unauthorized: attempt token refresh (once) ---
+      if (response.status === 401 && attempt === 0) {
+        const refreshed = await attemptTokenRefresh();
+        if (refreshed) {
+          // Retry immediately with the new token (counts as attempt 1)
+          continue;
+        }
+      }
+
+      // --- 5xx server error: maybe retry ---
+      if (response.status >= 500 && shouldRetry(method, response.status, attempt)) {
+        const error: ApiError = await response.json().catch(() => ({
+          detail: `HTTP ${response.status}: ${response.statusText}`,
+        }));
+        lastError = new ApiClientError(error.detail, response.status, error.error_code);
+        continue;
+      }
+
+      // --- Non-OK response: throw ---
+      if (!response.ok) {
+        const error: ApiError = await response.json().catch(() => ({
+          detail: `HTTP ${response.status}: ${response.statusText}`,
+        }));
+        throw new ApiClientError(error.detail, response.status, error.error_code);
+      }
+
+      // --- 204 No Content ---
+      if (response.status === 204) {
+        return {} as T;
+      }
+
+      return response.json();
+    } catch (error) {
+      clearTimeout(timeoutId);
+
+      // Timeout via AbortController
+      if (error instanceof DOMException && error.name === "AbortError") {
+        throw new ApiClientError(
+          `Request timeout after ${timeout}ms [${requestId}]`,
+          408,
+          "REQUEST_TIMEOUT"
+        );
+      }
+
+      // Already an ApiClientError (from non-OK handling above) — rethrow
+      if (error instanceof ApiClientError) {
+        throw error;
+      }
+
+      // Network error — retry if eligible
+      if (shouldRetry(method, null, attempt)) {
+        lastError = new ApiClientError(
+          `Network error: ${(error as Error).message} [${requestId}]`,
+          0,
+          "NETWORK_ERROR"
+        );
+        continue;
+      }
+
+      // Exhausted retries or non-retryable
+      throw new ApiClientError(
+        `Network error: ${(error as Error).message} [${requestId}]`,
+        0,
+        "NETWORK_ERROR"
+      );
+    }
   }
 
-  // Handle 204 No Content
-  if (response.status === 204) {
-    return {} as T;
-  }
-
-  return response.json();
+  // If we exhausted retries, throw the last error
+  throw lastError ?? new ApiClientError("Request failed after retries", 0, "RETRY_EXHAUSTED");
 }
 
 /**

--- a/apps/web/lib/api/client.ts
+++ b/apps/web/lib/api/client.ts
@@ -94,6 +94,9 @@ function decodeJWT(token: string): JWTPayload | null {
  * Returns true if the token was successfully refreshed.
  */
 async function attemptTokenRefresh(): Promise<boolean> {
+  // Token refresh requires browser APIs (localStorage/sessionStorage)
+  if (typeof window === "undefined") return false;
+
   try {
     const response = await fetch(`${BACKEND_URL}/api/auth/refresh`, {
       method: "POST",
@@ -244,8 +247,13 @@ async function fetchApi<T>(
     } catch (error) {
       clearTimeout(timeoutId);
 
-      // Timeout via AbortController
-      if (error instanceof DOMException && error.name === "AbortError") {
+      // Timeout via AbortController (SSR-safe: DOMException may not exist in Node.js)
+      if (
+        error &&
+        typeof error === "object" &&
+        "name" in error &&
+        (error as { name: string }).name === "AbortError"
+      ) {
         throw new ApiClientError(
           `Request timeout after ${timeout}ms [${requestId}]`,
           408,

--- a/apps/web/lib/hooks/use-autonomy-metrics.ts
+++ b/apps/web/lib/hooks/use-autonomy-metrics.ts
@@ -1,0 +1,70 @@
+/**
+ * React hook for fetching and polling autonomy metrics.
+ *
+ * Fetches metrics, health, and anomalies from the /api/autonomy/* endpoints
+ * and auto-refreshes every 30 seconds.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  getAutonomyMetrics,
+  getAutonomyHealth,
+  getAutonomyAnomalies,
+  type AutonomyMetrics,
+  type AutonomyHealth,
+  type AutonomyAnomalies,
+} from "@/lib/api/autonomy";
+
+/** Polling interval in milliseconds (30 seconds) */
+const POLL_INTERVAL_MS = 30_000;
+
+interface UseAutonomyMetricsReturn {
+  metrics: AutonomyMetrics | null;
+  health: AutonomyHealth | null;
+  anomalies: AutonomyAnomalies | null;
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+export function useAutonomyMetrics(
+  windowHours: number = 24
+): UseAutonomyMetricsReturn {
+  const [metrics, setMetrics] = useState<AutonomyMetrics | null>(null);
+  const [health, setHealth] = useState<AutonomyHealth | null>(null);
+  const [anomalies, setAnomalies] = useState<AutonomyAnomalies | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAll = useCallback(async () => {
+    try {
+      const [metricsData, healthData, anomaliesData] = await Promise.all([
+        getAutonomyMetrics(windowHours),
+        getAutonomyHealth(Math.min(windowHours, 24)),
+        getAutonomyAnomalies(windowHours),
+      ]);
+
+      setMetrics(metricsData);
+      setHealth(healthData);
+      setAnomalies(anomaliesData);
+      setError(null);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Failed to load autonomy metrics");
+    } finally {
+      setLoading(false);
+    }
+  }, [windowHours]);
+
+  // Initial fetch
+  useEffect(() => {
+    fetchAll();
+  }, [fetchAll]);
+
+  // Polling
+  useEffect(() => {
+    const interval = setInterval(fetchAll, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [fetchAll]);
+
+  return { metrics, health, anomalies, loading, error, refresh: fetchAll };
+}

--- a/apps/web/lib/supabase/client.ts
+++ b/apps/web/lib/supabase/client.ts
@@ -1,6 +1,38 @@
-import { createClient } from "@supabase/supabase-js";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+/**
+ * Lazy-initialized Supabase client.
+ *
+ * The client is only created when `getSupabase()` is called, avoiding a crash
+ * at module-load time when NEXT_PUBLIC_SUPABASE_URL is not configured (e.g.
+ * local dev pointing at FastAPI instead of Supabase).
+ */
+let _supabase: SupabaseClient | null = null;
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export function getSupabase(): SupabaseClient {
+  if (!_supabase) {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+    if (!supabaseUrl || !supabaseAnonKey) {
+      throw new Error(
+        "Supabase environment variables are not configured. " +
+          "Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY, " +
+          "or use FastAPI auth for local development."
+      );
+    }
+
+    _supabase = createClient(supabaseUrl, supabaseAnonKey);
+  }
+  return _supabase;
+}
+
+/**
+ * @deprecated Use `getSupabase()` instead. This eager export is kept for
+ * backward compatibility but will throw at import time if env vars are missing.
+ */
+export const supabase = new Proxy({} as SupabaseClient, {
+  get(_target, prop) {
+    return (getSupabase() as unknown as Record<string | symbol, unknown>)[prop];
+  },
+});

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -6,8 +6,6 @@ const nextConfig: NextConfig = {
   transpilePackages: ["@shared"],
   // Enable standalone output for Docker builds
   output: "standalone",
-  // ESLint enabled during builds for code quality
-  // typescript: Type checking enabled during builds for type safety
   experimental: {
     typedRoutes: true,
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
     "dev": "node ./scripts/dev-with-fallback.mjs",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint app/ components/ lib/ hooks/",
     "type-check": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@composio/core": "^0.6.3",
+        "@composio/openai-agents": "^0.6.3",
+        "@openai/agents": "^0.4.10",
         "mcp-linear": "^0.1.8"
       },
       "devDependencies": {
@@ -22,6 +25,82 @@
       "engines": {
         "node": ">=20.0.0",
         "pnpm": ">=9.0.0"
+      }
+    },
+    "node_modules/@composio/client": {
+      "version": "0.1.0-alpha.56",
+      "resolved": "https://registry.npmjs.org/@composio/client/-/client-0.1.0-alpha.56.tgz",
+      "integrity": "sha512-hNgChB5uhdvT4QXNzzfUuvtG6vrfanQQFY2hPyKwbeR4x6mEmIGFiZ4y2qynErdUWldAZiB/7pY/MBMg6Q9E0g==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@composio/core": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@composio/core/-/core-0.6.3.tgz",
+      "integrity": "sha512-PZm4LQGMaaDFHWUouMHqKPg5fNfgjM2l0zF0Vw/vfWJ34KYyo1ne6YjhGvBDmOIKPByT6Dal4/ff7AHpjedL/w==",
+      "license": "ISC",
+      "dependencies": {
+        "@composio/client": "0.1.0-alpha.56",
+        "@composio/json-schema-to-zod": "0.1.20",
+        "@types/json-schema": "^7.0.15",
+        "chalk": "^4.1.2",
+        "openai": "^6.16.0",
+        "pusher-js": "^8.4.0",
+        "semver": "^7.7.2",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    },
+    "node_modules/@composio/core/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@composio/core/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@composio/json-schema-to-zod": {
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/@composio/json-schema-to-zod/-/json-schema-to-zod-0.1.20.tgz",
+      "integrity": "sha512-d4V34itLrUWG/VBh7ciznKcxF/T22MBLHmuEzHoX0zsBOHsUmjYz5qtDh20S2p3FE+HHvLZxpXiv8yfdd4yI+Q==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": ">=3.25.76 <5"
+      }
+    },
+    "node_modules/@composio/openai-agents": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@composio/openai-agents/-/openai-agents-0.6.3.tgz",
+      "integrity": "sha512-X0Xk9PXeH+VbaoiAZT5iMXF44RYT7+4uCvMSf/ydboAxh6XoObhDmtpwGy28l2YSCs6W9qtISu/VI30ytUpuPA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "@composio/core": "0.6.3",
+        "@openai/agents": "^0.1.3",
+        "zod": "^4.1.0"
       }
     },
     "node_modules/@graphql-typed-document-node/core": {
@@ -100,14 +179,94 @@
         }
       }
     },
+    "node_modules/@openai/agents": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/@openai/agents/-/agents-0.4.10.tgz",
+      "integrity": "sha512-Hw/1VK4FagUHG3OU3SwcPrHHplSyok/O2w/p8utwGmeOT/uy/21j/JLukCIXBe9WHZf1MtP6YSxJ35OrSebVng==",
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.4.10",
+        "@openai/agents-openai": "0.4.10",
+        "@openai/agents-realtime": "0.4.10",
+        "debug": "^4.4.0",
+        "openai": "^6.20.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@openai/agents-core": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/@openai/agents-core/-/agents-core-0.4.10.tgz",
+      "integrity": "sha512-U2uu22OZGFZ53Ogm5Qtzymg1Oc1FFNdkh+fg0QWDJ7mERQU5G4LzhbTiwS/jylVgKPj74e2uBb8oj/X5rHwxDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "openai": "^6.20.0"
+      },
+      "optionalDependencies": {
+        "@modelcontextprotocol/sdk": "^1.26.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@openai/agents-openai": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/@openai/agents-openai/-/agents-openai-0.4.10.tgz",
+      "integrity": "sha512-z0HxNpchPRhAugDeO7mwzj7i8QcEEfWppXYTVbyYYbbN6zni5uIFm2N9t7fxbGXtaKCT7s7Io6aKrOsifRXncw==",
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.4.10",
+        "debug": "^4.4.0",
+        "openai": "^6.20.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@openai/agents-realtime": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/@openai/agents-realtime/-/agents-realtime-0.4.10.tgz",
+      "integrity": "sha512-cUU7tUgWJEZpewHfK+O4Gi36TMst7AStC1RKBm7uwm2t7WYQRIxY042Ykl6sou1wsLg/dXlY2UM07lZPN7TT5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.4.10",
+        "@types/ws": "^8.18.1",
+        "debug": "^4.4.0",
+        "ws": "^8.18.1"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.6.tgz",
       "integrity": "sha512-qm+G8HuG6hOHQigsi7VGuLjUVu6TtBo/F05zvX04Mw2uCg9Dv0Qxy3Qw7j41SidlTcl5D/5yg0SEZqOB+EqZnQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/accepts": {
@@ -318,6 +477,24 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -817,6 +994,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.x"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-symbols": {
@@ -1367,6 +1553,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openai": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.22.0.tgz",
+      "integrity": "sha512-7Yvy17F33Bi9RutWbsaYt5hJEEJ/krRPOrwan+f9aCPuMat1WVsb2VNSII5W1EksKT6fF69TG/xj4XzodK3JZw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1457,6 +1664,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pusher-js": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pusher-js/-/pusher-js-8.4.0.tgz",
+      "integrity": "sha512-wp3HqIIUc1GRyu1XrP6m2dgyE9MoCsXVsWNlohj0rjSkLf+a0jLvEyVubdg58oMk7bhjBWnFClgp8jfAa6Ak4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tweetnacl": "^1.0.3"
       }
     },
     "node_modules/qs": {
@@ -1568,6 +1784,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -1809,6 +2037,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1939,6 +2179,12 @@
         "win32"
       ]
     },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -1971,7 +2217,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unfetch": {
@@ -2052,6 +2297,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yaml": {
       "version": "2.8.2",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@composio/core": "^0.6.3",
     "@composio/openai-agents": "^0.6.3",
     "@openai/agents": "^0.4.10",
+    "dotenv": "^17.3.1",
     "mcp-linear": "^0.1.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
     ]
   },
   "dependencies": {
+    "@composio/core": "^0.6.3",
+    "@composio/openai-agents": "^0.6.3",
+    "@openai/agents": "^0.4.10",
     "mcp-linear": "^0.1.8"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@composio/core':
+        specifier: ^0.6.3
+        version: 0.6.3(ws@8.18.3)(zod@3.25.76)
+      '@composio/openai-agents':
+        specifier: ^0.6.3
+        version: 0.6.3(@composio/core@0.6.3(ws@8.18.3)(zod@3.25.76))(@openai/agents@0.4.10(ws@8.18.3)(zod@3.25.76))(zod@3.25.76)
+      '@openai/agents':
+        specifier: ^0.4.10
+        version: 0.4.10(ws@8.18.3)(zod@3.25.76)
+      dotenv:
+        specifier: ^17.3.1
+        version: 17.3.1
       mcp-linear:
         specifier: ^0.1.8
         version: 0.1.8
@@ -385,6 +397,26 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@composio/client@0.1.0-alpha.56':
+    resolution: {integrity: sha512-hNgChB5uhdvT4QXNzzfUuvtG6vrfanQQFY2hPyKwbeR4x6mEmIGFiZ4y2qynErdUWldAZiB/7pY/MBMg6Q9E0g==}
+
+  '@composio/core@0.6.3':
+    resolution: {integrity: sha512-PZm4LQGMaaDFHWUouMHqKPg5fNfgjM2l0zF0Vw/vfWJ34KYyo1ne6YjhGvBDmOIKPByT6Dal4/ff7AHpjedL/w==}
+    peerDependencies:
+      zod: ^3.25 || ^4
+
+  '@composio/json-schema-to-zod@0.1.20':
+    resolution: {integrity: sha512-d4V34itLrUWG/VBh7ciznKcxF/T22MBLHmuEzHoX0zsBOHsUmjYz5qtDh20S2p3FE+HHvLZxpXiv8yfdd4yI+Q==}
+    peerDependencies:
+      zod: '>=3.25.76 <5'
+
+  '@composio/openai-agents@0.6.3':
+    resolution: {integrity: sha512-X0Xk9PXeH+VbaoiAZT5iMXF44RYT7+4uCvMSf/ydboAxh6XoObhDmtpwGy28l2YSCs6W9qtISu/VI30ytUpuPA==}
+    peerDependencies:
+      '@composio/core': 0.6.3
+      '@openai/agents': ^0.1.3
+      zod: ^4.1.0
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -1092,6 +1124,29 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@openai/agents-core@0.4.10':
+    resolution: {integrity: sha512-U2uu22OZGFZ53Ogm5Qtzymg1Oc1FFNdkh+fg0QWDJ7mERQU5G4LzhbTiwS/jylVgKPj74e2uBb8oj/X5rHwxDQ==}
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@openai/agents-openai@0.4.10':
+    resolution: {integrity: sha512-z0HxNpchPRhAugDeO7mwzj7i8QcEEfWppXYTVbyYYbbN6zni5uIFm2N9t7fxbGXtaKCT7s7Io6aKrOsifRXncw==}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@openai/agents-realtime@0.4.10':
+    resolution: {integrity: sha512-cUU7tUgWJEZpewHfK+O4Gi36TMst7AStC1RKBm7uwm2t7WYQRIxY042Ykl6sou1wsLg/dXlY2UM07lZPN7TT5A==}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@openai/agents@0.4.10':
+    resolution: {integrity: sha512-Hw/1VK4FagUHG3OU3SwcPrHHplSyok/O2w/p8utwGmeOT/uy/21j/JLukCIXBe9WHZf1MtP6YSxJ35OrSebVng==}
+    peerDependencies:
+      zod: ^4.0.0
 
   '@opentelemetry/api-logs@0.207.0':
     resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
@@ -3675,6 +3730,10 @@ packages:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
 
+  dotenv@17.3.1:
+    resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
+    engines: {node: '>=12'}
+
   drange@1.1.1:
     resolution: {integrity: sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==}
     engines: {node: '>=4'}
@@ -5186,6 +5245,18 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
+  openai@6.22.0:
+    resolution: {integrity: sha512-7Yvy17F33Bi9RutWbsaYt5hJEEJ/krRPOrwan+f9aCPuMat1WVsb2VNSII5W1EksKT6fF69TG/xj4XzodK3JZw==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -5446,6 +5517,9 @@ packages:
   puppeteer-core@24.34.0:
     resolution: {integrity: sha512-24evawO+mUGW4mvS2a2ivwLdX3gk8zRLZr9HP+7+VT2vBQnm0oh9jJEZmUE3ePJhRkYlZ93i7OMpdcoi2qNCLg==}
     engines: {node: '>=18'}
+
+  pusher-js@8.4.0:
+    resolution: {integrity: sha512-wp3HqIIUc1GRyu1XrP6m2dgyE9MoCsXVsWNlohj0rjSkLf+a0jLvEyVubdg58oMk7bhjBWnFClgp8jfAa6Ak4Q==}
 
   qs@6.14.1:
     resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
@@ -6218,6 +6292,9 @@ packages:
     resolution: {integrity: sha512-bf6YKUv11l5Xfcmg76PyWoy/e2vbkkxFNBGJSnfdSXQC33ZiUfutYh6IXidc5MhsnrFkWfdNNLyaRk+kHMLlwA==}
     hasBin: true
 
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -6771,6 +6848,32 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@composio/client@0.1.0-alpha.56': {}
+
+  '@composio/core@0.6.3(ws@8.18.3)(zod@3.25.76)':
+    dependencies:
+      '@composio/client': 0.1.0-alpha.56
+      '@composio/json-schema-to-zod': 0.1.20(zod@3.25.76)
+      '@types/json-schema': 7.0.15
+      chalk: 4.1.2
+      openai: 6.22.0(ws@8.18.3)(zod@3.25.76)
+      pusher-js: 8.4.0
+      semver: 7.7.3
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - ws
+
+  '@composio/json-schema-to-zod@0.1.20(zod@3.25.76)':
+    dependencies:
+      zod: 3.25.76
+
+  '@composio/openai-agents@0.6.3(@composio/core@0.6.3(ws@8.18.3)(zod@3.25.76))(@openai/agents@0.4.10(ws@8.18.3)(zod@3.25.76))(zod@3.25.76)':
+    dependencies:
+      '@composio/core': 0.6.3(ws@8.18.3)(zod@3.25.76)
+      '@openai/agents': 0.4.10(ws@8.18.3)(zod@3.25.76)
+      zod: 3.25.76
 
   '@csstools/color-helpers@5.1.0': {}
 
@@ -7352,6 +7455,57 @@ snapshots:
       fastq: 1.19.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@openai/agents-core@0.4.10(ws@8.18.3)(zod@3.25.76)':
+    dependencies:
+      debug: 4.4.3
+      openai: 6.22.0(ws@8.18.3)(zod@3.25.76)
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.26.0(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+      - ws
+
+  '@openai/agents-openai@0.4.10(ws@8.18.3)(zod@3.25.76)':
+    dependencies:
+      '@openai/agents-core': 0.4.10(ws@8.18.3)(zod@3.25.76)
+      debug: 4.4.3
+      openai: 6.22.0(ws@8.18.3)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+      - ws
+
+  '@openai/agents-realtime@0.4.10(zod@3.25.76)':
+    dependencies:
+      '@openai/agents-core': 0.4.10(ws@8.18.3)(zod@3.25.76)
+      '@types/ws': 8.18.1
+      debug: 4.4.3
+      ws: 8.18.3
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@openai/agents@0.4.10(ws@8.18.3)(zod@3.25.76)':
+    dependencies:
+      '@openai/agents-core': 0.4.10(ws@8.18.3)(zod@3.25.76)
+      '@openai/agents-openai': 0.4.10(ws@8.18.3)(zod@3.25.76)
+      '@openai/agents-realtime': 0.4.10(zod@3.25.76)
+      debug: 4.4.3
+      openai: 6.22.0(ws@8.18.3)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
 
   '@opentelemetry/api-logs@0.207.0':
     dependencies:
@@ -10143,6 +10297,8 @@ snapshots:
 
   dotenv@16.6.1: {}
 
+  dotenv@17.3.1: {}
+
   drange@1.1.1: {}
 
   dunder-proto@1.0.1:
@@ -11907,6 +12063,11 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
+  openai@6.22.0(ws@8.18.3)(zod@3.25.76):
+    optionalDependencies:
+      ws: 8.18.3
+      zod: 3.25.76
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -12178,6 +12339,10 @@ snapshots:
       - react-native-b4a
       - supports-color
       - utf-8-validate
+
+  pusher-js@8.4.0:
+    dependencies:
+      tweetnacl: 1.0.3
 
   qs@6.14.1:
     dependencies:
@@ -13074,6 +13239,8 @@ snapshots:
       turbo-linux-arm64: 2.6.3
       turbo-windows-64: 2.6.3
       turbo-windows-arm64: 2.6.3
+
+  tweetnacl@1.0.3: {}
 
   type-check@0.4.0:
     dependencies:

--- a/scripts/composio-agent.ts
+++ b/scripts/composio-agent.ts
@@ -1,17 +1,37 @@
+import "dotenv/config";
 import { Composio } from "@composio/core";
 import { Agent, run } from "@openai/agents";
 import { OpenAIAgentsProvider } from "@composio/openai-agents";
 
+// Validate required environment variables
+const COMPOSIO_API_KEY = process.env.COMPOSIO_API_KEY;
+const COMPOSIO_EXTERNAL_USER_ID = process.env.COMPOSIO_EXTERNAL_USER_ID;
+
+if (!COMPOSIO_API_KEY) {
+  console.error("Missing COMPOSIO_API_KEY in environment variables.");
+  console.error("Set it in your .env file or export it: export COMPOSIO_API_KEY=ak_...");
+  process.exit(1);
+}
+
+if (!COMPOSIO_EXTERNAL_USER_ID) {
+  console.error("Missing COMPOSIO_EXTERNAL_USER_ID in environment variables.");
+  process.exit(1);
+}
+
+if (!process.env.OPENAI_API_KEY) {
+  console.error("Missing OPENAI_API_KEY in environment variables.");
+  console.error("Set it in your .env file or export it: export OPENAI_API_KEY=sk-...");
+  process.exit(1);
+}
+
 // Initialize Composio with OpenAI Agents provider
 const composio = new Composio({
-  apiKey: "ak_Bgzgar_dPkuw7qmFWl_p",
+  apiKey: COMPOSIO_API_KEY,
   provider: new OpenAIAgentsProvider(),
 });
 
-const externalUserId = "pg-test-d0909a46-5eb8-4218-b41c-f1718e588b1f";
-
 // Create a tool router session
-const session = await composio.create(externalUserId);
+const session = await composio.create(COMPOSIO_EXTERNAL_USER_ID);
 
 // Get tools from the session (native)
 const tools = await session.tools();
@@ -26,13 +46,13 @@ const agent = new Agent({
 });
 
 // Run the agent
-console.log(`🔄 Running agent...`);
-const result = await run(
-  agent,
-  "Send an email to unitegroup.in@gmail.com with the subject 'Hello from Composio' and the body 'This is a test email!'"
-);
+const prompt = process.argv[2] ||
+  "Send an email to unitegroup.in@gmail.com with the subject 'Hello from Composio' and the body 'This is a test email!'";
 
-console.log(`✅ Received response from agent`);
+console.log(`Running agent with prompt: ${prompt}`);
+const result = await run(agent, prompt);
+
+console.log("Received response from agent");
 if (result.finalOutput) {
   console.log(result.finalOutput);
 }

--- a/scripts/composio-agent.ts
+++ b/scripts/composio-agent.ts
@@ -1,0 +1,38 @@
+import { Composio } from "@composio/core";
+import { Agent, run } from "@openai/agents";
+import { OpenAIAgentsProvider } from "@composio/openai-agents";
+
+// Initialize Composio with OpenAI Agents provider
+const composio = new Composio({
+  apiKey: "ak_Bgzgar_dPkuw7qmFWl_p",
+  provider: new OpenAIAgentsProvider(),
+});
+
+const externalUserId = "pg-test-d0909a46-5eb8-4218-b41c-f1718e588b1f";
+
+// Create a tool router session
+const session = await composio.create(externalUserId);
+
+// Get tools from the session (native)
+const tools = await session.tools();
+
+// Create agent with tools
+const agent = new Agent({
+  name: "Email Manager",
+  model: "gpt-4o",
+  instructions:
+    "You are a helpful assistant. Use Composio tools to execute tasks.",
+  tools: tools,
+});
+
+// Run the agent
+console.log(`🔄 Running agent...`);
+const result = await run(
+  agent,
+  "Send an email to unitegroup.in@gmail.com with the subject 'Hello from Composio' and the body 'This is a test email!'"
+);
+
+console.log(`✅ Received response from agent`);
+if (result.finalOutput) {
+  console.log(result.finalOutput);
+}


### PR DESCRIPTION
## Summary
- **Live demo landing page** with server-side fetched stats from new `/api/public/stats` endpoint — animated counters, live pulse indicator, graceful fallback when backend is down
- **Composio AI agent integration** — tool router connecting Gmail, Slack, GitHub, Supabase, Vercel & OpenAI via `@composio/core` + `@openai/agents`
- **API client hardening** — request tracing middleware, resilient retry logic, lazy Supabase initialization
- **Security** — moved hardcoded API keys to environment variables with `dotenv`

## Changes (7 commits, 25 files)

### Backend
- `public_stats.py` — New public endpoint returning aggregate platform metrics (no PII)
- `auth.py` — Added `/api/public/stats` to public paths allowlist
- `request_id.py` — Request tracing middleware with correlation IDs
- `database.py` / `settings.py` — Config fixes (DB port, env loading)

### Frontend
- `page.tsx` — Enhanced landing page with live stats bar and dynamic feature cards
- `LiveStatsBar.tsx` / `AnimatedCounter.tsx` — Animated metric components (framer-motion)
- `AgentMetricsWidget.tsx` — Dashboard widget for agent orchestration metrics
- `client.ts` — Resilient API client with retry, timeout, request IDs
- `auth.ts` / `supabase/client.ts` — SSR-safe lazy initialization

### Infrastructure
- `composio-agent.ts` — AI agent script using env vars (dotenv)
- `.env.example` — Documented Composio/OpenAI env vars
- `package.json` — Added composio, openai-agents, dotenv deps
- `.husky/pre-commit` — lint-staged hook

## Test plan
- [ ] `curl http://localhost:8000/api/public/stats` returns live JSON metrics
- [ ] Landing page (`/`) shows animated stats when backend is running
- [ ] Landing page renders gracefully without stats when backend is down
- [ ] Sign-in flow still works and redirects to dashboard
- [ ] `npx tsx scripts/composio-agent.ts` validates env vars before running

🤖 Generated with [Claude Code](https://claude.com/claude-code)