### PR TITLE
feat: register, forgot-password, Shopify & Xero live integration routes

### DIFF
--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,22 @@
+import { ForgotPasswordForm } from '@/components/auth/forgot-password-form';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+export const metadata = { title: 'Reset password — CCW Online' };
+
+export default function ForgotPasswordPage() {
+  return (
+    <Card className="w-full">
+      <CardHeader className="space-y-1">
+        <CardTitle className="text-center text-2xl font-bold" as="h1">
+          Reset your password
+        </CardTitle>
+        <CardDescription className="text-center">
+          Enter your email and we&apos;ll send a reset link
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ForgotPasswordForm />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -1,0 +1,20 @@
+import { SignupForm } from '@/components/auth/signup-form';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+export const metadata = { title: 'Create account — CCW Online' };
+
+export default function RegisterPage() {
+  return (
+    <Card className="w-full">
+      <CardHeader className="space-y-1">
+        <CardTitle className="text-center text-2xl font-bold" as="h1">
+          Create your account
+        </CardTitle>
+        <CardDescription className="text-center">Get started with CCW Online ERP</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <SignupForm />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/api/integrations/shopify/configure/route.ts
+++ b/src/app/api/integrations/shopify/configure/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createServerClient } from '@/lib/supabase/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as { shop_domain?: string; access_token?: string };
+    const { shop_domain, access_token } = body;
+
+    if (!shop_domain || !access_token) {
+      return NextResponse.json(
+        { detail: 'shop_domain and access_token are required' },
+        { status: 400 }
+      );
+    }
+
+    // Normalise domain — strip protocol and trailing slash
+    const normalisedDomain = shop_domain
+      .replace(/^https?:\/\//, '')
+      .replace(/\/$/, '')
+      .toLowerCase();
+
+    if (!normalisedDomain.includes('.myshopify.com')) {
+      return NextResponse.json(
+        { detail: 'shop_domain must be a valid myshopify.com domain' },
+        { status: 400 }
+      );
+    }
+
+    const supabase = createServerClient();
+
+    const { error } = await supabase.from('shopify_connections').upsert(
+      {
+        shop_domain: normalisedDomain,
+        access_token,
+        is_active: false,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'shop_domain' }
+    );
+
+    if (error) throw new Error(error.message);
+
+    return NextResponse.json({
+      success: true,
+      shop_domain: normalisedDomain,
+      message: 'Shopify credentials saved. Run /api/integrations/shopify/connect to verify.',
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ detail: message }, { status: 500 });
+  }
+}

--- a/src/app/api/integrations/shopify/connect/route.ts
+++ b/src/app/api/integrations/shopify/connect/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@/lib/supabase/server';
+
+interface ShopifyShop {
+  id: number;
+  name: string;
+  email: string;
+  currency: string;
+  myshopify_domain: string;
+}
+
+export async function POST() {
+  try {
+    const supabase = createServerClient();
+
+    // Get the most recently updated inactive (or any) connection to test
+    const { data: connection, error: fetchError } = await supabase
+      .from('shopify_connections')
+      .select('*')
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .single();
+
+    if (fetchError || !connection) {
+      return NextResponse.json(
+        { detail: 'No Shopify credentials found. Call /configure first.' },
+        { status: 404 }
+      );
+    }
+
+    // Verify credentials against Shopify Admin API
+    const shopResponse = await fetch(
+      `https://${connection.shop_domain}/admin/api/2026-01/shop.json`,
+      {
+        headers: {
+          'X-Shopify-Access-Token': connection.access_token as string,
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+
+    if (!shopResponse.ok) {
+      const text = await shopResponse.text();
+      return NextResponse.json(
+        { detail: `Shopify rejected credentials: ${shopResponse.status} — ${text}` },
+        { status: 422 }
+      );
+    }
+
+    const { shop } = (await shopResponse.json()) as { shop: ShopifyShop };
+
+    // Mark connection as active and store shop metadata
+    const { error: updateError } = await supabase
+      .from('shopify_connections')
+      .update({
+        is_active: true,
+        shop_name: shop.name,
+        shop_email: shop.email,
+        currency: shop.currency,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', connection.id);
+
+    if (updateError) throw new Error(updateError.message);
+
+    return NextResponse.json({
+      connected: true,
+      shop_domain: connection.shop_domain,
+      shop_name: shop.name,
+      shop_email: shop.email,
+      currency: shop.currency,
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ detail: message }, { status: 500 });
+  }
+}

--- a/src/app/api/integrations/shopify/disconnect/route.ts
+++ b/src/app/api/integrations/shopify/disconnect/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@/lib/supabase/server';
+
+export async function POST() {
+  try {
+    const supabase = createServerClient();
+
+    const { error } = await supabase
+      .from('shopify_connections')
+      .update({ is_active: false, updated_at: new Date().toISOString() })
+      .eq('is_active', true);
+
+    if (error) throw new Error(error.message);
+
+    return NextResponse.json({ success: true, message: 'Shopify disconnected.' });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ detail: message }, { status: 500 });
+  }
+}

--- a/src/app/api/integrations/shopify/status/route.ts
+++ b/src/app/api/integrations/shopify/status/route.ts
@@ -1,8 +1,34 @@
 import { NextResponse } from 'next/server';
+import { createServerClient } from '@/lib/supabase/server';
 
 export async function GET() {
-  return NextResponse.json({
-    connected: false,
-    mode: 'demo',
-  });
+  try {
+    const supabase = createServerClient();
+
+    const { data: connection } = await supabase
+      .from('shopify_connections')
+      .select(
+        'shop_domain, shop_name, shop_email, currency, is_active, last_order_sync, last_inventory_sync'
+      )
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .single();
+
+    if (!connection) {
+      return NextResponse.json({ connected: false, mode: 'live' });
+    }
+
+    return NextResponse.json({
+      connected: connection.is_active,
+      mode: 'live',
+      shop_domain: connection.shop_domain,
+      shop_name: connection.shop_name,
+      shop_email: connection.shop_email,
+      currency: connection.currency,
+      last_order_sync: connection.last_order_sync,
+      last_inventory_sync: connection.last_inventory_sync,
+    });
+  } catch {
+    return NextResponse.json({ connected: false, mode: 'live' });
+  }
 }

--- a/src/app/api/integrations/xero/authorize/route.ts
+++ b/src/app/api/integrations/xero/authorize/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import crypto from 'crypto';
+
+const XERO_SCOPES = [
+  'openid',
+  'profile',
+  'email',
+  'offline_access',
+  'accounting.contacts',
+  'accounting.settings',
+  'accounting.invoices',
+  'accounting.payments',
+  'accounting.banktransactions',
+  'accounting.manualjournals',
+].join(' ');
+
+export async function GET() {
+  const clientId = process.env.XERO_CLIENT_ID;
+  const redirectUri = process.env.XERO_REDIRECT_URI;
+
+  if (!clientId || !redirectUri) {
+    return NextResponse.json(
+      { detail: 'XERO_CLIENT_ID and XERO_REDIRECT_URI must be set in environment variables.' },
+      { status: 500 }
+    );
+  }
+
+  const state = crypto.randomBytes(32).toString('hex');
+
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    scope: XERO_SCOPES,
+    state,
+  });
+
+  const authorizationUrl = `https://login.xero.com/identity/connect/authorize?${params.toString()}`;
+
+  // Store state in httpOnly cookie for CSRF validation in callback
+  const cookieStore = await cookies();
+  cookieStore.set('xero_oauth_state', state, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 600, // 10 minutes
+    path: '/',
+  });
+
+  return NextResponse.json({
+    mode: 'live',
+    authorization_url: authorizationUrl,
+    state,
+  });
+}

--- a/src/app/api/integrations/xero/callback/route.ts
+++ b/src/app/api/integrations/xero/callback/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { createServerClient } from '@/lib/supabase/server';
+
+interface XeroTokenResponse {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  token_type: string;
+}
+
+interface XeroTenant {
+  tenantId: string;
+  tenantName: string;
+  tenantType: string;
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const code = searchParams.get('code');
+  const returnedState = searchParams.get('state');
+  const error = searchParams.get('error');
+
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://ccw-crm-web.vercel.app';
+
+  if (error) {
+    return NextResponse.redirect(
+      `${baseUrl}/settings/integrations?xero_error=${encodeURIComponent(error)}`
+    );
+  }
+
+  if (!code || !returnedState) {
+    return NextResponse.redirect(`${baseUrl}/settings/integrations?xero_error=missing_params`);
+  }
+
+  // CSRF: validate state cookie
+  const cookieStore = await cookies();
+  const savedState = cookieStore.get('xero_oauth_state')?.value;
+
+  if (!savedState || savedState !== returnedState) {
+    return NextResponse.redirect(`${baseUrl}/settings/integrations?xero_error=invalid_state`);
+  }
+
+  // Clear the state cookie
+  cookieStore.delete('xero_oauth_state');
+
+  const clientId = process.env.XERO_CLIENT_ID!;
+  const clientSecret = process.env.XERO_CLIENT_SECRET!;
+  const redirectUri = process.env.XERO_REDIRECT_URI!;
+
+  try {
+    // Exchange code for tokens
+    const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+
+    const tokenResponse = await fetch('https://identity.xero.com/connect/token', {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${credentials}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: redirectUri,
+      }).toString(),
+    });
+
+    if (!tokenResponse.ok) {
+      const text = await tokenResponse.text();
+      throw new Error(`Token exchange failed: ${tokenResponse.status} — ${text}`);
+    }
+
+    const tokens = (await tokenResponse.json()) as XeroTokenResponse;
+    const tokenExpiresAt = new Date(Date.now() + tokens.expires_in * 1000).toISOString();
+
+    // Get connected tenants (organisations)
+    const tenantsResponse = await fetch('https://api.xero.com/connections', {
+      headers: { Authorization: `Bearer ${tokens.access_token}` },
+    });
+
+    if (!tenantsResponse.ok) {
+      throw new Error(`Failed to fetch Xero tenants: ${tenantsResponse.status}`);
+    }
+
+    const tenants = (await tenantsResponse.json()) as XeroTenant[];
+
+    if (!tenants.length) {
+      return NextResponse.redirect(`${baseUrl}/settings/integrations?xero_error=no_tenants`);
+    }
+
+    const primaryTenant = tenants[0];
+
+    // Persist tokens in Supabase
+    const supabase = createServerClient();
+
+    const { error: upsertError } = await supabase.from('xero_connections').upsert(
+      {
+        tenant_id: primaryTenant.tenantId,
+        tenant_name: primaryTenant.tenantName,
+        access_token: tokens.access_token,
+        refresh_token: tokens.refresh_token,
+        token_expires_at: tokenExpiresAt,
+        is_active: true,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'tenant_id' }
+    );
+
+    if (upsertError) throw new Error(upsertError.message);
+
+    const redirectUrl = `${baseUrl}/settings/integrations?xero_success=true&tenant=${encodeURIComponent(primaryTenant.tenantName)}`;
+    return NextResponse.redirect(redirectUrl);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.redirect(
+      `${baseUrl}/settings/integrations?xero_error=${encodeURIComponent(message)}`
+    );
+  }
+}

--- a/src/app/api/integrations/xero/disconnect/route.ts
+++ b/src/app/api/integrations/xero/disconnect/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@/lib/supabase/server';
+
+export async function POST() {
+  try {
+    const supabase = createServerClient();
+
+    const { error } = await supabase
+      .from('xero_connections')
+      .update({ is_active: false, updated_at: new Date().toISOString() })
+      .eq('is_active', true);
+
+    if (error) throw new Error(error.message);
+
+    return NextResponse.json({ success: true, message: 'Xero disconnected.' });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ detail: message }, { status: 500 });
+  }
+}

--- a/src/app/api/integrations/xero/refresh/route.ts
+++ b/src/app/api/integrations/xero/refresh/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from 'next/server';
+import { createServerClient } from '@/lib/supabase/server';
+
+interface XeroTokenResponse {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+}
+
+export async function POST() {
+  try {
+    const supabase = createServerClient();
+
+    const { data: connection, error: fetchError } = await supabase
+      .from('xero_connections')
+      .select('*')
+      .eq('is_active', true)
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .single();
+
+    if (fetchError || !connection) {
+      return NextResponse.json({ detail: 'No active Xero connection found.' }, { status: 404 });
+    }
+
+    const clientId = process.env.XERO_CLIENT_ID!;
+    const clientSecret = process.env.XERO_CLIENT_SECRET!;
+    const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+
+    const tokenResponse = await fetch('https://identity.xero.com/connect/token', {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${credentials}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: connection.refresh_token as string,
+      }).toString(),
+    });
+
+    if (!tokenResponse.ok) {
+      // Refresh failed — mark connection inactive so user re-authenticates
+      await supabase
+        .from('xero_connections')
+        .update({ is_active: false, updated_at: new Date().toISOString() })
+        .eq('id', connection.id);
+
+      return NextResponse.json(
+        { detail: 'Xero refresh token expired. Please re-connect Xero.' },
+        { status: 401 }
+      );
+    }
+
+    const tokens = (await tokenResponse.json()) as XeroTokenResponse;
+    const tokenExpiresAt = new Date(Date.now() + tokens.expires_in * 1000).toISOString();
+
+    await supabase
+      .from('xero_connections')
+      .update({
+        access_token: tokens.access_token,
+        refresh_token: tokens.refresh_token,
+        token_expires_at: tokenExpiresAt,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', connection.id);
+
+    return NextResponse.json({
+      success: true,
+      expires_at: tokenExpiresAt,
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Internal server error';
+    return NextResponse.json({ detail: message }, { status: 500 });
+  }
+}

--- a/src/app/api/integrations/xero/status/route.ts
+++ b/src/app/api/integrations/xero/status/route.ts
@@ -1,8 +1,33 @@
 import { NextResponse } from 'next/server';
+import { createServerClient } from '@/lib/supabase/server';
 
 export async function GET() {
-  return NextResponse.json({
-    connected: false,
-    mode: 'demo',
-  });
+  try {
+    const supabase = createServerClient();
+
+    const { data: connection } = await supabase
+      .from('xero_connections')
+      .select('tenant_id, tenant_name, is_active, token_expires_at, updated_at')
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .single();
+
+    if (!connection) {
+      return NextResponse.json({ connected: false, mode: 'live' });
+    }
+
+    const tokenExpiresAt = connection.token_expires_at as string | null;
+    const tokenExpired = tokenExpiresAt ? new Date(tokenExpiresAt) < new Date() : true;
+
+    return NextResponse.json({
+      connected: connection.is_active && !tokenExpired,
+      mode: 'live',
+      tenant_id: connection.tenant_id,
+      tenant_name: connection.tenant_name,
+      token_expires_at: tokenExpiresAt,
+      token_expired: tokenExpired,
+    });
+  } catch {
+    return NextResponse.json({ connected: false, mode: 'live' });
+  }
 }

--- a/src/components/auth/forgot-password-form.tsx
+++ b/src/components/auth/forgot-password-form.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useState } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import * as z from 'zod';
+import { Button } from '@/components/ui/button';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { useToast } from '@/hooks/use-toast';
+import { getSupabase } from '@/lib/supabase/client';
+
+const formSchema = z.object({
+  email: z.string().email('Invalid email address'),
+});
+
+type FormData = z.infer<typeof formSchema>;
+
+export function ForgotPasswordForm() {
+  const { toast } = useToast();
+  const [isLoading, setIsLoading] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { email: '' },
+  });
+
+  async function onSubmit(values: FormData) {
+    setIsLoading(true);
+    try {
+      const redirectTo = `${window.location.origin}/auth/reset-password`;
+      const { error } = await getSupabase().auth.resetPasswordForEmail(values.email, {
+        redirectTo,
+      });
+      if (error) throw new Error(error.message);
+      setSent(true);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Failed to send reset email';
+      toast({ variant: 'destructive', title: 'Error', description: message });
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  if (sent) {
+    return (
+      <div className="space-y-4 text-center">
+        <p className="text-sm text-slate-600">
+          Reset link sent — check your inbox. Once reset,{' '}
+          <a href="/login" className="text-primary font-medium hover:underline">
+            sign in here
+          </a>
+          .
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email address</FormLabel>
+              <FormControl>
+                <Input type="email" placeholder="you@company.com" autoComplete="email" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <Button type="submit" className="w-full" disabled={isLoading}>
+          {isLoading ? 'Sending...' : 'Send reset link'}
+        </Button>
+
+        <p className="text-center text-xs text-slate-600">
+          <a href="/login" className="font-medium hover:underline">
+            Back to sign in
+          </a>
+        </p>
+      </form>
+    </Form>
+  );
+}

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -89,7 +89,9 @@ export function LoginForm({ variant = 'default' }: LoginFormProps) {
           name="email"
           render={({ field }) => (
             <FormItem>
-              <FormLabel className={isMarketing ? 'text-sm font-semibold text-zinc-200' : undefined}>
+              <FormLabel
+                className={isMarketing ? 'text-sm font-semibold text-zinc-200' : undefined}
+              >
                 Email
               </FormLabel>
               <FormControl>
@@ -115,7 +117,9 @@ export function LoginForm({ variant = 'default' }: LoginFormProps) {
           name="password"
           render={({ field }) => (
             <FormItem>
-              <FormLabel className={isMarketing ? 'text-sm font-semibold text-zinc-200' : undefined}>
+              <FormLabel
+                className={isMarketing ? 'text-sm font-semibold text-zinc-200' : undefined}
+              >
                 Password
               </FormLabel>
               <FormControl>
@@ -153,7 +157,7 @@ export function LoginForm({ variant = 'default' }: LoginFormProps) {
                   onCheckedChange={field.onChange}
                   className={
                     isMarketing
-                      ? 'h-5 w-5 border-zinc-500 data-[state=checked]:border-transparent data-[state=checked]:bg-gradient-brand data-[state=checked]:text-white'
+                      ? 'data-[state=checked]:bg-gradient-brand h-5 w-5 border-zinc-500 data-[state=checked]:border-transparent data-[state=checked]:text-white'
                       : undefined
                   }
                 />
@@ -161,7 +165,7 @@ export function LoginForm({ variant = 'default' }: LoginFormProps) {
               <FormLabel
                 className={
                   isMarketing
-                    ? 'cursor-pointer text-sm font-medium leading-snug text-zinc-300'
+                    ? 'cursor-pointer text-sm leading-snug font-medium text-zinc-300'
                     : 'cursor-pointer text-sm font-normal'
                 }
               >
@@ -181,7 +185,9 @@ export function LoginForm({ variant = 'default' }: LoginFormProps) {
               : 'w-full'
           }
           disabled={isLoading}
-          rightIcon={isMarketing && !isLoading ? <ArrowRight className="h-4 w-4 opacity-90" /> : undefined}
+          rightIcon={
+            isMarketing && !isLoading ? <ArrowRight className="h-4 w-4 opacity-90" /> : undefined
+          }
         >
           {isLoading ? 'Signing in...' : 'Sign in'}
         </Button>
@@ -190,19 +196,29 @@ export function LoginForm({ variant = 'default' }: LoginFormProps) {
           className={
             isMarketing
               ? 'mt-5 text-center text-xs text-zinc-500'
-              : 'mt-4 text-center text-xs text-slate-400'
+              : 'mt-4 space-y-1 text-center text-xs text-slate-600'
           }
         >
-          <a
-            href="/forgot-password"
-            className={
-              isMarketing
-                ? 'font-medium text-zinc-400 underline-offset-4 transition-colors hover:text-sky-300 hover:underline'
-                : 'hover:text-slate-600 hover:underline'
-            }
-          >
-            Forgot your password?
-          </a>
+          <p>
+            <a
+              href="/forgot-password"
+              className={
+                isMarketing
+                  ? 'font-medium text-zinc-400 underline-offset-4 transition-colors hover:text-sky-300 hover:underline'
+                  : 'hover:underline'
+              }
+            >
+              Forgot your password?
+            </a>
+          </p>
+          {!isMarketing && (
+            <p>
+              No account?{' '}
+              <a href="/register" className="font-medium hover:underline">
+                Create one
+              </a>
+            </p>
+          )}
         </div>
       </form>
     </Form>

--- a/src/components/auth/signup-form.tsx
+++ b/src/components/auth/signup-form.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useState } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import * as z from 'zod';
+import { Button } from '@/components/ui/button';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { authApi } from '@/lib/api/auth';
+import { useToast } from '@/hooks/use-toast';
+
+const formSchema = z
+  .object({
+    full_name: z.string().min(2, 'Full name must be at least 2 characters'),
+    email: z.string().email('Invalid email address'),
+    password: z.string().min(8, 'Password must be at least 8 characters'),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],
+  });
+
+type FormData = z.infer<typeof formSchema>;
+
+export function SignupForm() {
+  const { toast } = useToast();
+  const [isLoading, setIsLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      full_name: '',
+      email: '',
+      password: '',
+      confirmPassword: '',
+    },
+  });
+
+  async function onSubmit(values: FormData) {
+    setIsLoading(true);
+    try {
+      await authApi.register({
+        email: values.email,
+        password: values.password,
+        full_name: values.full_name,
+      });
+      setSuccess(true);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Registration failed';
+      toast({ variant: 'destructive', title: 'Registration Failed', description: message });
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  if (success) {
+    return (
+      <div className="space-y-4 text-center">
+        <p className="text-sm text-slate-600">
+          Account created! Check your email to confirm your address, then{' '}
+          <a href="/login" className="text-primary font-medium hover:underline">
+            sign in
+          </a>
+          .
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="full_name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Full name</FormLabel>
+              <FormControl>
+                <Input placeholder="Toby Smith" autoComplete="name" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <Input type="email" placeholder="you@company.com" autoComplete="email" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="password"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Password</FormLabel>
+              <FormControl>
+                <Input
+                  type="password"
+                  placeholder="At least 8 characters"
+                  autoComplete="new-password"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="confirmPassword"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Confirm password</FormLabel>
+              <FormControl>
+                <Input
+                  type="password"
+                  placeholder="Repeat your password"
+                  autoComplete="new-password"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <Button type="submit" className="w-full" disabled={isLoading}>
+          {isLoading ? 'Creating account...' : 'Create account'}
+        </Button>
+
+        <p className="text-center text-xs text-slate-600">
+          Already have an account?{' '}
+          <a href="/login" className="font-medium hover:underline">
+            Sign in
+          </a>
+        </p>
+      </form>
+    </Form>
+  );
+}


### PR DESCRIPTION
## Summary

- **Register page** (`/register`) — full signup form with Supabase Auth, email confirmation flow
- **Forgot password** (`/forgot-password`) — email reset via Supabase, redirects to `/auth/reset-password`
- **Login form** — "Create account" link added; WCAG AA contrast fix (`text-slate-600`)
- **Shopify integration** — `/configure` (save creds), `/connect` (Admin API 2026-01 verify), `/disconnect`, `/status` — all live via Supabase direct
- **Xero integration** — `/authorize` (OAuth2, granular scopes), `/callback` (CSRF state cookie + token store), `/refresh` (token rotation), `/disconnect`, `/status` — all live via Supabase direct
- No Railway backend required — all routes run on Vercel + Supabase

## Test plan

- [ ] `/register` renders and creates a Supabase Auth user
- [ ] `/forgot-password` sends reset email via Supabase
- [ ] `/login` shows "Create account" link pointing to `/register`
- [ ] `POST /api/integrations/shopify/configure` saves credentials
- [ ] `POST /api/integrations/shopify/connect` verifies with Shopify Admin API
- [ ] `GET /api/integrations/xero/authorize` returns Xero OAuth URL with CSRF state
- [ ] Xero OAuth callback stores tokens in `xero_connections`

🤖 Generated with [Claude Code](https://claude.com/claude-code)