### PR TITLE
chore: promote ai-updates → main (Sprint 1+2)

### DIFF
--- a/.claude/PROGRESS.md
+++ b/.claude/PROGRESS.md
@@ -1,65 +1,54 @@
 # Progress
 
-**Phase**: Production — Video Pipeline + Go-Live Sprint
-**Last Updated**: 2026-04-01T19:00:00
-**Branch**: `fix/railway-cache-auth-500`
+**Phase**: Go-Live — Sprint 2 Bug Fixes
+**Last Updated**: 2026-04-13
+**Branch**: `claude/festive-keller` → PR #69 into `ai-updates`
 
 ## Active Tasks
 
-| Task                                 | Status                            | Linear   |
-| ------------------------------------ | --------------------------------- | -------- |
-| Remotion scene redesign (emoji-free) | DONE                              | —        |
-| YouTube uploads (10/27 done)         | BLOCKED (channel limit)           | UNI-1751 |
-| ElevenLabs audio regeneration        | DONE                              | UNI-1752 |
-| YouTube OAuth → Unite-Group Nexus    | DONE                              | —        |
-| Supabase JWT hook activation         | DONE                              | UNI-1753 |
-| Leaked password protection           | N/A (custom auth, not applicable) | —        |
-| Vercel YOUTUBE_CHANNEL_ID env var    | DONE                              | —        |
+| Task                                | Status | Linear   |
+| ----------------------------------- | ------ | -------- |
+| XSS sanitisation on customer fields | DONE   | UNI-1783 |
+| Anthropic API key backend endpoint  | DONE   | UNI-1776 |
+| Anthropic API key Settings UI       | DONE   | UNI-1776 |
+| Anthropic step in onboarding wizard | DONE   | UNI-1776 |
+| Customer Discard button resets form | DONE   | UNI-1784 |
+| POS mobile tabbed layout            | DONE   | UNI-1787 |
+| Dashboard stale setState guard      | DONE   | —        |
 
-## Completed This Session (2026-04-01 continued)
+## Completed This Session (2026-04-13)
 
-- [x] FirstLookVideo: 6 scenes redesigned — emoji-free
-- [x] ConnectionsGuideVideo: rewritten for 2-connection flow (Shopify + Xero)
-- [x] Boardroom scenes (3): BuildStatusScene, CTAScene, MoonShotScene — emoji-free
-- [x] Onboarding scenes (3): GoLiveScene, ConnectionSetupScene, RequirementsScene — SVG icons
-- [x] YouTube channel ID fixed: `UChN8nQFig73BoefyMBIsN-w`
-- [x] Videos rendered: firstlook.mp4 + connections-guide.mp4
-- [x] TypeScript: 0 errors
-- [x] Production site verified: dashboard loads, all KPIs rendering
-- [x] Supabase advisors: 20 tables with USING(true) (acceptable MVP), leaked password WARN
-- [x] Git: 3 commits pushed (9c7a6d5, b3d4f20, 735573c)
-- [x] Linear: UNI-1747 Done, UNI-1751/1752/1753 created
-- [x] Chrome automation skills suite created (6 skills: linear/vercel/supabase/youtube/github/prod)
-- [x] ElevenLabs audio generated: firstlook-narration.mp3 (2096 KB) + connections-narration.mp3 (1602 KB)
-- [x] Videos re-rendered with audio: firstlook.mp4 (10.2 MB) + connections-guide.mp4 (12.1 MB)
-- [x] Videos copied to upload queue — CRON uploads daily at 9:07 AM (~6/day, quota-gated)
-- [x] YouTube OAuth migrated to Unite-Group Nexus (gen-lang-client-0999991687, client 251486789111)
-- [x] TypeScript: 0 errors (verified 2026-04-01)
-- [x] Supabase advisors: 20 tables USING(true) WARN (MVP acceptable), leaked password WARN (manual fix), 2 tables RLS-enabled no-policy INFO (alembic_version, carrier_configurations — non-PII)
+- [x] Dark smoke test run: injection, rapid nav, mobile, CSV, auth bypass
+- [x] Bugs logged to Linear: UNI-1783, UNI-1784, UNI-1787
+- [x] PR #67 merged to ai-updates (POS $NaN, logout redirect, connecting badge, settings redirect)
+- [x] fix(backend): html.escape() validator on CustomerBase + CustomerUpdate — UNI-1783
+- [x] feat(backend): GET/POST /api/integrations/anthropic/\* — UNI-1776
+- [x] feat(web): Anthropic API key input in Settings → Integrations — UNI-1776
+- [x] feat(onboarding): Claude AI step (step 4) in setup wizard — UNI-1776
+- [x] fix(web): Customer Discard button now calls form.reset() — UNI-1784
+- [x] fix(web): POS responsive tabbed layout for mobile (below lg) — UNI-1787
+- [x] fix(web): isMounted + cancelled flags on dashboard async fetches
+- [x] PR #69 raised: claude/festive-keller → ai-updates
 
 ## Decisions Log
 
-| Decision                                 | Rationale                                              | Date       |
-| ---------------------------------------- | ------------------------------------------------------ | ---------- |
-| Remove Supabase from ConnectionsGuide    | CCW manages infra; clients only connect Shopify + Xero | 2026-04-01 |
-| RLS USING(true) on 20 operational tables | Single-tenant MVP; org-scoped on 13 PII tables         | 2026-03-30 |
-| Custom JWT over Supabase Auth            | demo_auth.py locked; migration deferred                | 2026-03-30 |
-| YouTube private (not unlisted)           | Internal training videos for now                       | 2026-04-01 |
+| Decision                                            | Rationale                                                           | Date       |
+| --------------------------------------------------- | ------------------------------------------------------------------- | ---------- |
+| html.escape() not htmlspecialchars                  | stdlib, no deps, escapes all 5 HTML special chars                   | 2026-04-13 |
+| Anthropic key stored in IntegrationCredential table | Consistent with SendGrid pattern                                    | 2026-04-13 |
+| POS mobile = Tabs not scroll                        | Tabs give instant access without scroll; desktop grid unchanged     | 2026-04-13 |
+| isMounted plain object (not useRef)                 | useRef not imported; plain object works identically in this pattern | 2026-04-13 |
 
 ## Blockers (User Action Required)
 
-1. ~~**ELEVENLABS_API_KEY**~~ — DONE: audio generated via .env.local (pulled from Vercel)
-1. ~~**Supabase JWT hook**~~ — DONE: `public.custom_access_token_hook` enabled 2026-04-01
-1. ~~**Leaked password protection**~~ — N/A: project uses custom JWT auth, not Supabase native auth
-1. ~~**Vercel env**~~ — DONE: `YOUTUBE_CHANNEL_ID=UChN8nQFig73BoefyMBIsN-w` set via CLI 2026-04-01
-1. ~~**YouTube OAuth credentials**~~ — DONE: migrated to Unite-Group Nexus (`gen-lang-client-0999991687`)
-1. **YouTube uploads (17 pending)** — CRON retries daily at 9:07 AM. Channel daily limit resets midnight Pacific.
+1. **PR #69 review** — merge claude/festive-keller → ai-updates when CI passes
+2. **Anthropic API key** — CCW staff must enter their sk-ant- key via Settings → Integrations or onboarding wizard before AI features activate
 
 ## Notes for Next Context Window
 
-- All Remotion scenes are emoji-free. Do NOT re-introduce Unicode emoji in video scenes.
-- ConnectionsGuideVideo is 2-connection only (Shopify + Xero). Supabase is CCW infrastructure.
-- YouTube uploads are quota-gated (~6/day). Check `python scripts/youtube_upload.py --status`.
-- The `.claude/CLAUDE.md` file is the old detailed version (archived as `.claude/CLAUDE.md.pre-control-system`). The new control system uses CLAUDE.md (root) + companion files in `.claude/`.
+- All customer string fields are sanitised at Pydantic layer — SQL injection protection is via Supabase parameterised queries (not html.escape)
+- Anthropic key is checked: DB first → ANTHROPIC_API_KEY env var fallback
+- POS desktop layout is unchanged (h-[600px] still applies at lg+)
+- Dashboard first useEffect uses a plain `{ current: true }` object as isMounted flag (not useRef — was not imported)
 - Supabase project: `vwfgksqkajnpfjospbpe`
 - Linear team: Unite-Group, project: CCW-ERP/CRM

--- a/apps/backend/src/api/main.py
+++ b/apps/backend/src/api/main.py
@@ -95,6 +95,7 @@ except ImportError:
     autonomous_dev = recommendations = search = test_data_gen = ai_inventory_forecast = None  # type: ignore[assignment]
 
 from .routes.integrations import (
+    anthropic as anthropic_integration,
     ap2,
     cin7,
     cin7_crm,
@@ -574,6 +575,7 @@ app.include_router(xero.router, prefix="/api", tags=["Xero Integration"])
 app.include_router(shopify.router, tags=["Shopify Integration"])
 app.include_router(shopify_theme.router, tags=["Shopify Theme APIs"])
 app.include_router(sendgrid.router, tags=["SendGrid Integration"])
+app.include_router(anthropic_integration.router, tags=["Anthropic Integration"])
 app.include_router(elevenlabs.router, tags=["ElevenLabs Integration"])
 app.include_router(heygen.router, tags=["HeyGen Integration"])
 app.include_router(ap2.router, tags=["AP2 Integration"])

--- a/apps/backend/src/api/main.py
+++ b/apps/backend/src/api/main.py
@@ -96,6 +96,8 @@ except ImportError:
 
 from .routes.integrations import (
     anthropic as anthropic_integration,
+)
+from .routes.integrations import (
     ap2,
     cin7,
     cin7_crm,

--- a/apps/backend/src/api/routes/integrations/anthropic.py
+++ b/apps/backend/src/api/routes/integrations/anthropic.py
@@ -1,0 +1,119 @@
+"""Anthropic (Claude) integration — configure API key and check status.
+
+Follows the same pattern as the SendGrid integration.
+"""
+
+import os
+from typing import Annotated, Any
+
+import structlog
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.config.database import get_async_db
+from src.db.integration_credential_models import IntegrationCredential
+
+logger = structlog.get_logger()
+
+router = APIRouter(prefix="/api/integrations/anthropic")
+
+
+class AnthropicConfigureRequest(BaseModel):
+    """Request body for configuring the Anthropic API key."""
+
+    api_key: str = Field(
+        ...,
+        min_length=1,
+        description="Anthropic API key (starts with sk-ant-)",
+    )
+
+    @field_validator("api_key")
+    @classmethod
+    def validate_api_key_format(cls, v: str) -> str:
+        v = v.strip()
+        if not v.startswith("sk-ant-"):
+            raise ValueError("Anthropic API keys must start with sk-ant-")
+        return v
+
+
+@router.get("/status")
+async def anthropic_status(
+    db: Annotated[AsyncSession, Depends(get_async_db)],
+) -> dict[str, Any]:
+    """Check Anthropic integration status.
+
+    Checks the database for a stored key first, then falls back to the
+    ANTHROPIC_API_KEY environment variable.
+    """
+    try:
+        result = await db.execute(
+            select(IntegrationCredential).where(
+                IntegrationCredential.integration_name == "anthropic"
+            )
+        )
+        cred = result.scalar_one_or_none()
+        if cred and cred.is_active:
+            stored = cred.get_credentials()
+            if stored.get("api_key"):
+                return {
+                    "connected": True,
+                    "mode": "production",
+                    "model": "claude-sonnet-4-6",
+                    "source": "database",
+                }
+    except Exception:
+        # DB not available — fall through to env var check
+        pass
+
+    env_key = os.getenv("ANTHROPIC_API_KEY", "")
+    if env_key:
+        return {
+            "connected": True,
+            "mode": "production",
+            "model": "claude-sonnet-4-6",
+            "source": "environment",
+        }
+
+    return {
+        "connected": False,
+        "mode": "not_configured",
+        "message": "Enter your Anthropic API key to enable Claude AI features",
+    }
+
+
+@router.post("/configure")
+async def configure_anthropic(
+    request: AnthropicConfigureRequest,
+    db: Annotated[AsyncSession, Depends(get_async_db)],
+) -> dict[str, Any]:
+    """Save Anthropic API key to the database."""
+    logger.info("configuring_anthropic_credentials")
+
+    result = await db.execute(
+        select(IntegrationCredential).where(
+            IntegrationCredential.integration_name == "anthropic"
+        )
+    )
+    cred = result.scalar_one_or_none()
+
+    if cred:
+        cred.set_credentials({"api_key": request.api_key})
+        cred.is_active = True
+    else:
+        cred = IntegrationCredential(
+            integration_name="anthropic", is_active=True
+        )
+        cred.set_credentials({"api_key": request.api_key})
+        db.add(cred)
+
+    await db.commit()
+
+    logger.info("anthropic_credentials_saved")
+    return {
+        "connected": True,
+        "mode": "production",
+        "model": "claude-sonnet-4-6",
+        "message": "Anthropic API key saved successfully",
+    }

--- a/apps/backend/src/db/schemas.py
+++ b/apps/backend/src/db/schemas.py
@@ -1,4 +1,5 @@
 """Pydantic schemas for ERP API."""
+import html
 from datetime import UTC, date, datetime, time
 from decimal import Decimal
 from uuid import UUID
@@ -125,6 +126,24 @@ class CustomerBase(BaseModel):
     xero_synced_at: datetime | None = None
     is_active: bool = True
 
+    @field_validator(
+        "customer_number",
+        "company_name",
+        "contact_name",
+        "phone",
+        "address",
+        "city",
+        "state",
+        "postcode",
+        mode="before",
+    )
+    @classmethod
+    def sanitise_string_fields(cls, v: str | None) -> str | None:
+        """Escape HTML/XSS payloads and strip whitespace."""
+        if v is None or not isinstance(v, str):
+            return v
+        return html.escape(v.strip())
+
 
 class CustomerCreate(CustomerBase):
     pass
@@ -142,6 +161,23 @@ class CustomerUpdate(BaseModel):
     xero_contact_id: str | None = None
     xero_synced_at: datetime | None = None
     is_active: bool | None = None
+
+    @field_validator(
+        "company_name",
+        "contact_name",
+        "phone",
+        "address",
+        "city",
+        "state",
+        "postcode",
+        mode="before",
+    )
+    @classmethod
+    def sanitise_string_fields(cls, v: str | None) -> str | None:
+        """Escape HTML/XSS payloads and strip whitespace."""
+        if v is None or not isinstance(v, str):
+            return v
+        return html.escape(v.strip())
 
 
 class Customer(CustomerBase):

--- a/apps/backend/src/db/schemas.py
+++ b/apps/backend/src/db/schemas.py
@@ -126,6 +126,8 @@ class CustomerBase(BaseModel):
     xero_synced_at: datetime | None = None
     is_active: bool = True
 
+
+class CustomerCreate(CustomerBase):
     @field_validator(
         "customer_number",
         "company_name",
@@ -139,14 +141,10 @@ class CustomerBase(BaseModel):
     )
     @classmethod
     def sanitise_string_fields(cls, v: str | None) -> str | None:
-        """Escape HTML/XSS payloads and strip whitespace."""
+        """Escape HTML/XSS payloads and strip whitespace on input."""
         if v is None or not isinstance(v, str):
             return v
         return html.escape(v.strip())
-
-
-class CustomerCreate(CustomerBase):
-    pass
 
 
 class CustomerUpdate(BaseModel):

--- a/apps/backend/tests/api/test_anthropic_integration.py
+++ b/apps/backend/tests/api/test_anthropic_integration.py
@@ -1,0 +1,75 @@
+"""Tests for Anthropic integration endpoints — UNI-1776."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.routes.integrations.anthropic import router
+from src.config.database import get_async_db
+
+
+@pytest.fixture
+def app():
+    test_app = FastAPI()
+    test_app.include_router(router)
+
+    async def mock_db():
+        # Return a mock session that returns no credentials by default
+        session = AsyncMock()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=result)
+        session.commit = AsyncMock()
+        session.add = MagicMock()
+        yield session
+
+    test_app.dependency_overrides[get_async_db] = mock_db
+    return test_app
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+class TestAnthropicStatus:
+    def test_status_returns_200(self, client):
+        r = client.get("/api/integrations/anthropic/status")
+        assert r.status_code == 200
+        data = r.json()
+        assert "connected" in data
+        assert "mode" in data
+
+    def test_status_not_configured_without_key(self, client):
+        with patch.dict("os.environ", {}, clear=False):
+            # Ensure ANTHROPIC_API_KEY is absent
+            import os
+            os.environ.pop("ANTHROPIC_API_KEY", None)
+            r = client.get("/api/integrations/anthropic/status")
+        data = r.json()
+        assert data["mode"] in ("not_configured", "production")  # production if env var set
+
+
+class TestAnthropicConfigure:
+    def test_configure_requires_api_key(self, client):
+        r = client.post("/api/integrations/anthropic/configure", json={})
+        assert r.status_code == 422
+
+    def test_configure_rejects_invalid_prefix(self, client):
+        r = client.post(
+            "/api/integrations/anthropic/configure",
+            json={"api_key": "invalid_key_no_prefix"},
+        )
+        assert r.status_code == 422
+
+    def test_configure_accepts_valid_key(self, client):
+        r = client.post(
+            "/api/integrations/anthropic/configure",
+            json={"api_key": "sk-ant-api03-test-key-placeholder"},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["connected"] is True
+        assert data["mode"] == "production"

--- a/apps/backend/tests/api/test_customer_sanitisation.py
+++ b/apps/backend/tests/api/test_customer_sanitisation.py
@@ -1,0 +1,64 @@
+"""Tests for customer input sanitisation — UNI-1783."""
+
+from src.db.schemas import CustomerCreate, CustomerUpdate
+
+
+class TestCustomerSanitisation:
+    """Verify XSS payloads are escaped in customer schemas."""
+
+    def test_xss_in_company_name_is_escaped(self):
+        c = CustomerCreate(
+            customer_number="CUST-001",
+            company_name="<script>alert('xss')</script>",
+        )
+        assert "<script>" not in c.company_name
+        assert "&lt;script&gt;" in c.company_name
+
+    def test_sql_injection_in_customer_number_has_quotes_escaped(self):
+        c = CustomerCreate(
+            customer_number="'; DROP TABLE customers; --",
+            company_name="Test Corp",
+        )
+        # html.escape handles XSS; SQL injection is prevented by parameterised queries
+        assert "&#x27;" in c.customer_number  # apostrophe escaped
+        assert c.customer_number == "&#x27;; DROP TABLE customers; --"
+
+    def test_clean_input_unchanged(self):
+        c = CustomerCreate(
+            customer_number="CUST-002",
+            company_name="Davis Corp General Contracting",
+        )
+        assert c.company_name == "Davis Corp General Contracting"
+        assert c.customer_number == "CUST-002"
+
+    def test_whitespace_stripped(self):
+        c = CustomerCreate(
+            customer_number="  CUST-003  ",
+            company_name="  Acme  ",
+        )
+        assert c.customer_number == "CUST-003"
+        assert c.company_name == "Acme"
+
+    def test_optional_fields_sanitised(self):
+        c = CustomerCreate(
+            customer_number="CUST-004",
+            company_name="Test",
+            contact_name="<b>Bold</b>",
+            address="<img src=x onerror=alert(1)>",
+            city="<marquee>Sydney</marquee>",
+        )
+        assert "<b>" not in c.contact_name
+        assert "<img" not in c.address
+        assert "<marquee>" not in c.city
+
+    def test_none_values_pass_through(self):
+        c = CustomerCreate(
+            customer_number="CUST-005",
+            company_name="Test",
+            contact_name=None,
+        )
+        assert c.contact_name is None
+
+    def test_update_schema_sanitised(self):
+        u = CustomerUpdate(company_name="<script>alert(1)</script>")
+        assert "<script>" not in u.company_name

--- a/apps/web/app/(dashboard)/customers/components/CustomerForm.tsx
+++ b/apps/web/app/(dashboard)/customers/components/CustomerForm.tsx
@@ -191,7 +191,21 @@ export function CustomerForm({ customer, open, onOpenChange, onSuccess }: Custom
           <DraftRecoveryAlert
             savedAt={draftMetadata.savedAt}
             onRestore={loadDraft}
-            onDiscard={clearDraft}
+            onDiscard={() => {
+              clearDraft();
+              form.reset({
+                customer_number: '',
+                company_name: '',
+                contact_name: '',
+                email: '',
+                phone: '',
+                address: '',
+                city: '',
+                state: '',
+                postcode: '',
+                is_active: true,
+              });
+            }}
           />
         )}
 

--- a/apps/web/app/(dashboard)/dashboard/page.tsx
+++ b/apps/web/app/(dashboard)/dashboard/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -158,6 +158,8 @@ export default function DashboardPage() {
   const { data: metricsUpdate, status: metricsStreamStatus } = useDashboardMetricsStream(true);
 
   useEffect(() => {
+    const isMounted = { current: true };
+
     async function loadDashboardData() {
       try {
         // PHASE 4 OPTIMIZATION: Use aggregated endpoint (1 API call instead of 6)
@@ -176,6 +178,8 @@ export default function DashboardPage() {
               .get<CertStats>('/api/certifications/stats')
               .catch(() => ({ expiring_soon: 0, expiring_alerts: [] })),
           ]);
+
+        if (!isMounted.current) return;
 
         // Destructure aggregated data
         setMetrics(dashboardData.metrics);
@@ -216,6 +220,7 @@ export default function DashboardPage() {
         }
         setUrgentItems(urgent);
       } catch (error) {
+        if (!isMounted.current) return;
         console.error('Failed to load dashboard data:', error);
         setMetrics(null);
         setRevenueData([]);
@@ -224,11 +229,14 @@ export default function DashboardPage() {
         setActivity([]);
         setInsights([]);
       } finally {
-        setLoading(false);
+        if (isMounted.current) setLoading(false);
       }
     }
 
     loadDashboardData();
+    return () => {
+      isMounted.current = false;
+    };
   }, []);
 
   // PHASE 4: Handle real-time POS failure alerts
@@ -246,22 +254,27 @@ export default function DashboardPage() {
   // PHASE 4: Handle real-time dashboard metrics updates
   useEffect(() => {
     if (metricsUpdate) {
-      // Refresh specific metrics based on the update
-      async function refreshMetrics() {
+      let cancelled = false;
+
+      // Debounce refresh to avoid excessive API calls (wait 500ms before refreshing)
+      const timeout = setTimeout(async () => {
         try {
           const dashboardData = await apiClient.get<AggregatedDashboardData>(
             '/api/dashboard/aggregated'
           );
-          setMetrics(dashboardData.metrics);
-          setActivity(dashboardData.recent_activity);
+          if (!cancelled) {
+            setMetrics(dashboardData.metrics);
+            setActivity(dashboardData.recent_activity);
+          }
         } catch (error) {
-          console.error('Failed to refresh metrics:', error);
+          if (!cancelled) console.error('Failed to refresh metrics:', error);
         }
-      }
+      }, 500);
 
-      // Debounce refresh to avoid excessive API calls (wait 500ms before refreshing)
-      const timeout = setTimeout(refreshMetrics, 500);
-      return () => clearTimeout(timeout);
+      return () => {
+        cancelled = true;
+        clearTimeout(timeout);
+      };
     }
   }, [metricsUpdate]);
 

--- a/apps/web/app/(dashboard)/pos/components/POSTerminal.tsx
+++ b/apps/web/app/(dashboard)/pos/components/POSTerminal.tsx
@@ -11,6 +11,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Separator } from '@/components/ui/separator';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { MapPin, Monitor, CheckCircle2 } from 'lucide-react';
 import { apiClient } from '@/lib/api/client';
 import { useToast } from '@/hooks/use-toast';
@@ -210,7 +211,7 @@ export function POSTerminal() {
 
   if (loading) {
     return (
-      <div className="flex h-[600px] items-center justify-center">
+      <div className="flex h-64 items-center justify-center lg:h-[600px]">
         <div className="text-center">
           <div className="border-primary mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-b-2" />
           <p className="text-muted-foreground">Loading POS Terminal...</p>
@@ -276,8 +277,54 @@ export function POSTerminal() {
 
       <Separator />
 
-      {/* Main Terminal Layout */}
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-12">
+      {/* Mobile: tabbed layout */}
+      <div className="lg:hidden">
+        <Tabs defaultValue="products">
+          <TabsList className="grid w-full grid-cols-3">
+            <TabsTrigger value="products">Products</TabsTrigger>
+            <TabsTrigger value="cart">
+              Cart{cartItems.length > 0 ? ` (${cartItems.length})` : ''}
+            </TabsTrigger>
+            <TabsTrigger value="payment">Payment</TabsTrigger>
+          </TabsList>
+          <TabsContent value="products">
+            <Card>
+              <CardHeader className="pb-4">
+                <CardTitle className="text-lg">Products</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ProductSearch onAddProduct={handleAddProduct} />
+              </CardContent>
+            </Card>
+          </TabsContent>
+          <TabsContent value="cart">
+            <Card>
+              <CardContent className="p-4">
+                <Cart
+                  items={cartItems}
+                  onUpdateQuantity={handleUpdateQuantity}
+                  onRemoveItem={handleRemoveItem}
+                  onClearCart={handleClearCart}
+                />
+              </CardContent>
+            </Card>
+          </TabsContent>
+          <TabsContent value="payment">
+            <PaymentPanel
+              total={total}
+              items={cartItems}
+              salesStaff={locationStaff}
+              selectedStaffId={selectedStaffId}
+              onSelectStaff={setSelectedStaffId}
+              onProcessPayment={handleProcessPayment}
+              isProcessing={isProcessing}
+            />
+          </TabsContent>
+        </Tabs>
+      </div>
+
+      {/* Desktop: 3-panel grid */}
+      <div className="hidden gap-4 lg:grid lg:grid-cols-12">
         {/* Product Search - Left Panel */}
         <div className="lg:col-span-5">
           <Card className="h-[600px]">

--- a/apps/web/app/(dashboard)/pos/components/POSTerminal.tsx
+++ b/apps/web/app/(dashboard)/pos/components/POSTerminal.tsx
@@ -1,22 +1,22 @@
-"use client";
+'use client';
 
-import { useState, useEffect, useCallback } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
+import { useState, useEffect, useCallback } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/ui/select";
-import { Separator } from "@/components/ui/separator";
-import { MapPin, Monitor, CheckCircle2 } from "lucide-react";
-import { apiClient } from "@/lib/api/client";
-import { useToast } from "@/hooks/use-toast";
-import { ProductSearch } from "./ProductSearch";
-import { Cart } from "./Cart";
-import { PaymentPanel } from "./PaymentPanel";
+} from '@/components/ui/select';
+import { Separator } from '@/components/ui/separator';
+import { MapPin, Monitor, CheckCircle2 } from 'lucide-react';
+import { apiClient } from '@/lib/api/client';
+import { useToast } from '@/hooks/use-toast';
+import { ProductSearch } from './ProductSearch';
+import { Cart } from './Cart';
+import { PaymentPanel } from './PaymentPanel';
 import {
   Location,
   SalesStaff,
@@ -25,7 +25,7 @@ import {
   Product,
   PaymentMethod,
   CreateTransactionRequest,
-} from "../types";
+} from '../types';
 
 export function POSTerminal() {
   const { toast } = useToast();
@@ -34,8 +34,8 @@ export function POSTerminal() {
   const [locations, setLocations] = useState<Location[]>([]);
   const [salesStaff, setSalesStaff] = useState<SalesStaff[]>([]);
   const [terminals, setTerminals] = useState<POSTerminalType[]>([]);
-  const [selectedLocation, setSelectedLocation] = useState<string>("");
-  const [selectedTerminal, setSelectedTerminal] = useState<string>("");
+  const [selectedLocation, setSelectedLocation] = useState<string>('');
+  const [selectedTerminal, setSelectedTerminal] = useState<string>('');
   const [selectedStaffId, setSelectedStaffId] = useState<string | null>(null);
   const [cartItems, setCartItems] = useState<CartItem[]>([]);
   const [isProcessing, setIsProcessing] = useState(false);
@@ -47,26 +47,26 @@ export function POSTerminal() {
     setLoading(true);
     try {
       const [locationsRes, staffRes, terminalsRes] = await Promise.all([
-        apiClient.get<Location[]>("/api/pos/locations"),
-        apiClient.get<SalesStaff[]>("/api/pos/sales-staff"),
-        apiClient.get<POSTerminalType[]>("/api/pos/terminals"),
+        apiClient.get<Location[]>('/api/pos/locations'),
+        apiClient.get<SalesStaff[]>('/api/pos/sales-staff'),
+        apiClient.get<POSTerminalType[]>('/api/pos/terminals'),
       ]);
 
-      setLocations(locationsRes.filter((l) => l.location_type === "physical"));
+      setLocations(locationsRes.filter((l) => l.location_type === 'physical'));
       setSalesStaff(staffRes.filter((s) => s.is_active));
       setTerminals(terminalsRes.filter((t) => t.is_active));
 
       // Default to first physical location
-      const physicalLocations = locationsRes.filter((l) => l.location_type === "physical");
+      const physicalLocations = locationsRes.filter((l) => l.location_type === 'physical');
       if (physicalLocations.length > 0) {
         setSelectedLocation(physicalLocations[0].code);
       }
     } catch (error) {
-      console.error("Failed to load POS data:", error);
+      console.error('Failed to load POS data:', error);
       toast({
-        variant: "destructive",
-        title: "Error",
-        description: "Failed to load POS configuration. Please refresh the page.",
+        variant: 'destructive',
+        title: 'Error',
+        description: 'Failed to load POS configuration. Please refresh the page.',
       });
     } finally {
       setLoading(false);
@@ -110,6 +110,7 @@ export function POSTerminal() {
             : item
         );
       }
+      const unitPrice = Number(product.price);
       return [
         ...prev,
         {
@@ -117,14 +118,14 @@ export function POSTerminal() {
           sku: product.sku,
           name: product.name,
           quantity: 1,
-          unit_price: product.price,
-          subtotal: product.price,
+          unit_price: unitPrice,
+          subtotal: unitPrice,
         },
       ];
     });
 
     toast({
-      title: "Added to cart",
+      title: 'Added to cart',
       description: `${product.name} added`,
     });
   };
@@ -155,9 +156,9 @@ export function POSTerminal() {
   const handleProcessPayment = async (method: PaymentMethod) => {
     if (!selectedTerminal || cartItems.length === 0) {
       toast({
-        variant: "destructive",
-        title: "Error",
-        description: "Please select a terminal and add items to cart",
+        variant: 'destructive',
+        title: 'Error',
+        description: 'Please select a terminal and add items to cart',
       });
       return;
     }
@@ -177,30 +178,30 @@ export function POSTerminal() {
       };
 
       const response = await apiClient.post<{ transaction_number: string; payment_status: string }>(
-        "/api/pos/transactions",
+        '/api/pos/transactions',
         request
       );
 
-      if (response.payment_status === "captured") {
+      if (response.payment_status === 'captured') {
         setLastTransaction(response.transaction_number);
         setCartItems([]);
         toast({
-          title: "Payment Successful",
+          title: 'Payment Successful',
           description: `Transaction ${response.transaction_number} completed`,
         });
       } else {
         toast({
-          variant: "destructive",
-          title: "Payment Failed",
-          description: "The payment could not be processed. Please try again.",
+          variant: 'destructive',
+          title: 'Payment Failed',
+          description: 'The payment could not be processed. Please try again.',
         });
       }
     } catch (error) {
-      console.error("Payment failed:", error);
+      console.error('Payment failed:', error);
       toast({
-        variant: "destructive",
-        title: "Payment Error",
-        description: "An error occurred while processing the payment.",
+        variant: 'destructive',
+        title: 'Payment Error',
+        description: 'An error occurred while processing the payment.',
       });
     } finally {
       setIsProcessing(false);
@@ -209,9 +210,9 @@ export function POSTerminal() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-[600px]">
+      <div className="flex h-[600px] items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4" />
+          <div className="border-primary mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-b-2" />
           <p className="text-muted-foreground">Loading POS Terminal...</p>
         </div>
       </div>
@@ -221,11 +222,11 @@ export function POSTerminal() {
   return (
     <div className="space-y-4">
       {/* Terminal Header */}
-      <div className="flex items-center justify-between flex-wrap gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-4">
         <div className="flex items-center gap-4">
           {/* Location Selector */}
           <div className="flex items-center gap-2">
-            <MapPin className="h-5 w-5 text-muted-foreground" />
+            <MapPin className="text-muted-foreground h-5 w-5" />
             <Select value={selectedLocation} onValueChange={setSelectedLocation}>
               <SelectTrigger className="w-[180px]">
                 <SelectValue placeholder="Select location" />
@@ -242,7 +243,7 @@ export function POSTerminal() {
 
           {/* Terminal Selector */}
           <div className="flex items-center gap-2">
-            <Monitor className="h-5 w-5 text-muted-foreground" />
+            <Monitor className="text-muted-foreground h-5 w-5" />
             <Select value={selectedTerminal} onValueChange={setSelectedTerminal}>
               <SelectTrigger className="w-[180px]">
                 <SelectValue placeholder="Select terminal" />
@@ -261,7 +262,7 @@ export function POSTerminal() {
         {/* Status Badges */}
         <div className="flex items-center gap-2">
           <Badge variant="outline" className="gap-1">
-            <div className="w-2 h-2 rounded-full bg-green-500" />
+            <div className="h-2 w-2 rounded-full bg-green-500" />
             Terminal Online
           </Badge>
           {lastTransaction && (
@@ -276,7 +277,7 @@ export function POSTerminal() {
       <Separator />
 
       {/* Main Terminal Layout */}
-      <div className="grid grid-cols-1 lg:grid-cols-12 gap-4">
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-12">
         {/* Product Search - Left Panel */}
         <div className="lg:col-span-5">
           <Card className="h-[600px]">
@@ -292,7 +293,7 @@ export function POSTerminal() {
         {/* Cart - Middle Panel */}
         <div className="lg:col-span-4">
           <Card className="h-[600px]">
-            <CardContent className="p-4 h-full">
+            <CardContent className="h-full p-4">
               <Cart
                 items={cartItems}
                 onUpdateQuantity={handleUpdateQuantity}

--- a/apps/web/app/(dashboard)/settings/integrations/page.tsx
+++ b/apps/web/app/(dashboard)/settings/integrations/page.tsx
@@ -36,6 +36,8 @@ function IntegrationsContent() {
     default_model?: string;
   } | null>(null);
   const [claudeStatus, setClaudeStatus] = useState<{ mode: string; status: string } | null>(null);
+  const [anthropicKey, setAnthropicKey] = useState('');
+  const [anthropicSaving, setAnthropicSaving] = useState(false);
 
   const loadXeroStatus = async () => {
     try {
@@ -79,16 +81,42 @@ function IntegrationsContent() {
 
   const loadAiStatuses = async () => {
     try {
-      const [g, c] = await Promise.allSettled([
+      const [g, c, anthropic] = await Promise.allSettled([
         apiClient.get<{ configured: boolean; status: string; default_model?: string }>(
           '/api/google-ai/health'
         ),
         apiClient.get<{ mode: string; status: string }>('/api/ai/autonomous/health'),
+        apiClient.get<{ connected: boolean; mode: string }>('/api/integrations/anthropic/status'),
       ]);
       if (g.status === 'fulfilled') setGeminiStatus(g.value);
       if (c.status === 'fulfilled') setClaudeStatus(c.value);
+      if (anthropic.status === 'fulfilled' && anthropic.value.mode === 'production') {
+        setClaudeStatus({ mode: 'production', status: 'healthy' });
+      }
     } catch {
       // AI services are optional — don't error
+    }
+  };
+
+  const saveAnthropicKey = async () => {
+    if (!anthropicKey.trim()) return;
+    setAnthropicSaving(true);
+    try {
+      const result = await apiClient.post<{ connected: boolean; mode: string; message: string }>(
+        '/api/integrations/anthropic/configure',
+        { api_key: anthropicKey }
+      );
+      setClaudeStatus({ mode: result.mode, status: 'healthy' });
+      setAnthropicKey('');
+      toast({ title: 'Anthropic Connected', description: result.message });
+    } catch (error) {
+      toast({
+        variant: 'destructive',
+        title: 'Configuration Failed',
+        description: error instanceof Error ? error.message : 'Invalid API key',
+      });
+    } finally {
+      setAnthropicSaving(false);
     }
   };
 
@@ -368,8 +396,8 @@ function IntegrationsContent() {
                       <CheckCircle2 className="h-3.5 w-3.5" /> Production
                     </span>
                   ) : (
-                    <span className="flex items-center gap-1 text-xs text-blue-600">
-                      <Bot className="h-3.5 w-3.5" /> Demo mode
+                    <span className="flex items-center gap-1 text-xs text-orange-600">
+                      <XCircle className="h-3.5 w-3.5" /> Not configured
                     </span>
                   )}
                 </div>
@@ -378,10 +406,39 @@ function IntegrationsContent() {
                 </p>
                 <p className="mt-1 font-mono text-xs text-purple-600">claude-sonnet-4-6</p>
                 {claudeStatus?.mode !== 'production' && (
-                  <p className="mt-2 text-xs text-blue-700">
-                    Set <code className="bg-muted rounded px-1">ANTHROPIC_API_KEY</code> for live AI
-                    decisions.
-                  </p>
+                  <div className="mt-3 space-y-2">
+                    <label className="text-xs font-medium">API Key</label>
+                    <div className="flex gap-2">
+                      <input
+                        type="password"
+                        value={anthropicKey}
+                        onChange={(e) => setAnthropicKey(e.target.value)}
+                        placeholder="sk-ant-..."
+                        className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-8 w-full rounded-md border px-3 text-xs focus-visible:ring-2 focus-visible:outline-none"
+                      />
+                      <button
+                        onClick={saveAnthropicKey}
+                        disabled={anthropicSaving || !anthropicKey.startsWith('sk-ant-')}
+                        className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-8 items-center rounded-md px-3 text-xs font-medium disabled:opacity-50"
+                      >
+                        {anthropicSaving ? 'Saving...' : 'Connect'}
+                      </button>
+                    </div>
+                    <p className="text-muted-foreground text-xs">
+                      Get your key from{' '}
+                      <a
+                        href="https://console.anthropic.com/settings/keys"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary underline"
+                      >
+                        console.anthropic.com
+                      </a>
+                    </p>
+                  </div>
+                )}
+                {claudeStatus?.mode === 'production' && (
+                  <p className="mt-2 text-xs text-green-700">Claude AI features are active.</p>
                 )}
               </div>
             </div>

--- a/apps/web/app/(dashboard)/settings/page.tsx
+++ b/apps/web/app/(dashboard)/settings/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function SettingsPage() {
+  redirect('/settings/integrations');
+}

--- a/apps/web/components/layout/mobile-nav.tsx
+++ b/apps/web/components/layout/mobile-nav.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   Menu,
@@ -28,9 +28,20 @@ const navItems = [
   { href: '/dashboard/settings', icon: Settings, label: 'Settings' },
 ];
 
+async function logout(router: ReturnType<typeof useRouter>) {
+  try {
+    await fetch('/api/auth/logout', { method: 'POST' });
+  } catch {
+    // ignore — clear client state regardless
+  }
+  localStorage.removeItem('onboarding_completed');
+  router.push('/login');
+}
+
 export function MobileNav() {
   const [open, setOpen] = useState(false);
   const pathname = usePathname();
+  const router = useRouter();
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
@@ -130,7 +141,7 @@ export function MobileNav() {
               className="hover:bg-destructive/10 text-destructive group relative flex w-full items-center gap-3 overflow-hidden rounded-lg px-4 py-3 text-left transition-all duration-200"
               onClick={() => {
                 setOpen(false);
-                // Handle logout
+                void logout(router);
               }}
               whileHover={{ scale: 1.02 }}
               whileTap={{ scale: 0.98 }}

--- a/apps/web/components/layout/sidebar.tsx
+++ b/apps/web/components/layout/sidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { cn } from '@/lib/utils';
 import { NotificationBell } from '@/components/layout/NotificationBell';
@@ -55,6 +55,7 @@ import {
   Cpu,
   MessageCircle,
   Store,
+  LogOut,
 } from 'lucide-react';
 import { useState, useEffect } from 'react';
 
@@ -208,8 +209,19 @@ function NavLink({ item, isActive }: { item: NavItem; isActive: boolean }) {
   );
 }
 
+async function logout(router: ReturnType<typeof useRouter>) {
+  try {
+    await fetch('/api/auth/logout', { method: 'POST' });
+  } catch {
+    // ignore — clear client state regardless
+  }
+  localStorage.removeItem('onboarding_completed');
+  router.push('/login');
+}
+
 export function Sidebar() {
   const pathname = usePathname();
+  const router = useRouter();
   const [openGroups, setOpenGroups] = useState<Set<string>>(() => new Set(DEFAULT_OPEN));
 
   // Persist collapsed state in localStorage
@@ -274,7 +286,7 @@ export function Sidebar() {
         <NotificationBell />
       </div>
 
-      <nav className="flex-1 space-y-1 overflow-y-auto p-3">
+      <nav className="flex-1 space-y-1 overflow-y-auto p-3" id="sidebar-nav">
         {/* Dashboard — always visible, no group */}
         <NavLink
           item={{ name: 'Dashboard', href: '/dashboard', icon: LayoutDashboard }}
@@ -319,6 +331,24 @@ export function Sidebar() {
           );
         })}
       </nav>
+
+      {/* Logout */}
+      <div className="border-t p-3">
+        <motion.button
+          onClick={() => void logout(router)}
+          className="hover:bg-destructive/10 text-muted-foreground hover:text-destructive group flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm transition-all"
+          whileHover={{ scale: 1.02 }}
+          whileTap={{ scale: 0.98 }}
+        >
+          <motion.div
+            whileHover={{ scale: 1.2, rotate: -15 }}
+            transition={{ type: 'spring', stiffness: 400, damping: 10 }}
+          >
+            <LogOut className="h-4 w-4" />
+          </motion.div>
+          <span>Log out</span>
+        </motion.button>
+      </div>
     </aside>
   );
 }

--- a/apps/web/components/onboarding/AnthropicConnectStep.tsx
+++ b/apps/web/components/onboarding/AnthropicConnectStep.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Loader2, CheckCircle2, BookOpen, ExternalLink } from 'lucide-react';
+import { apiClient } from '@/lib/api/client';
+
+interface AnthropicConnectStepProps {
+  onComplete: (data?: Record<string, unknown>) => void;
+  onSkip: () => void;
+  onBack: () => void;
+  canGoBack: boolean;
+  isOptional: boolean;
+}
+
+const SETUP_STEPS = [
+  'Go to console.anthropic.com and sign in (or create a free account)',
+  'Click "API Keys" in the left sidebar',
+  'Click "Create Key" — give it a name like "CCW ERP"',
+  'Copy the key immediately (it starts with sk-ant- and is only shown once)',
+  'Paste it into the field below and click Connect',
+];
+
+export function AnthropicConnectStep({
+  onComplete,
+  onSkip,
+  onBack,
+  canGoBack,
+  isOptional,
+}: AnthropicConnectStepProps) {
+  const [apiKey, setApiKey] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [isConnected, setIsConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showInstructions, setShowInstructions] = useState(false);
+
+  const isValidKey = apiKey.startsWith('sk-ant-');
+
+  async function handleConnect() {
+    if (!isValidKey) return;
+    setIsSaving(true);
+    setError(null);
+    try {
+      await apiClient.post('/api/integrations/anthropic/configure', { api_key: apiKey });
+      setIsConnected(true);
+    } catch {
+      setError(
+        'Could not save the API key. Make sure the backend is reachable and the key starts with sk-ant-.'
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  if (isConnected) {
+    return (
+      <div className="space-y-6">
+        <div className="flex flex-col items-center justify-center space-y-4 py-8">
+          <CheckCircle2 className="h-16 w-16 text-green-500" />
+          <div className="text-center">
+            <h3 className="text-lg font-semibold">Claude AI Connected!</h3>
+            <p className="text-muted-foreground text-sm">
+              Autonomous ops, document extraction, NL queries, and the staff copilot are now active.
+            </p>
+            <p className="mt-1 font-mono text-xs text-purple-600">claude-sonnet-4-6</p>
+          </div>
+        </div>
+        <div className="flex justify-between">
+          <Button variant="outline" onClick={onBack}>
+            Back
+          </Button>
+          <Button onClick={() => onComplete({ connected: true })}>Continue</Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <Alert>
+        <AlertDescription>
+          CCW uses Claude (claude-sonnet-4-6) for autonomous operations, document extraction,
+          natural-language queries, and the staff copilot. Paste your Anthropic API key below to
+          activate these features.
+        </AlertDescription>
+      </Alert>
+
+      <div className="space-y-3 rounded-lg border p-4">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <BookOpen className="h-4 w-4" />
+          What Claude powers in CCW
+        </div>
+        <ul className="text-muted-foreground list-inside list-disc space-y-1 text-sm">
+          <li>Autonomous order and quote processing</li>
+          <li>PDF / document data extraction</li>
+          <li>Natural-language search across customers, orders, and products</li>
+          <li>Staff copilot — ask questions, get instant ERP insights</li>
+        </ul>
+      </div>
+
+      <div className="space-y-3">
+        <label className="text-sm font-medium">Anthropic API Key</label>
+        <Input
+          type="password"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          placeholder="sk-ant-..."
+          className="font-mono text-sm"
+        />
+        {apiKey.length > 0 && !isValidKey && (
+          <p className="text-xs text-red-600">Key must start with sk-ant-</p>
+        )}
+      </div>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="space-y-3 rounded-lg border p-4">
+        <button
+          type="button"
+          className="flex w-full items-center justify-between text-sm font-medium"
+          onClick={() => setShowInstructions(!showInstructions)}
+        >
+          <span>Where do I get an API key? (2 min)</span>
+          <Badge variant="outline">{showInstructions ? 'Hide' : 'Show steps'}</Badge>
+        </button>
+        {showInstructions && (
+          <ol className="text-muted-foreground list-inside list-decimal space-y-2 text-sm">
+            {SETUP_STEPS.map((step, i) => (
+              <li key={i}>{step}</li>
+            ))}
+          </ol>
+        )}
+        <a
+          href="https://console.anthropic.com/settings/keys"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary flex items-center gap-1 text-sm hover:underline"
+        >
+          Open Anthropic Console <ExternalLink className="h-3 w-3" />
+        </a>
+      </div>
+
+      <div className="flex justify-between">
+        <Button variant="outline" onClick={onBack} disabled={!canGoBack || isSaving}>
+          Back
+        </Button>
+        <div className="flex gap-2">
+          {isOptional && (
+            <Button variant="ghost" onClick={onSkip} disabled={isSaving}>
+              Skip for Now
+            </Button>
+          )}
+          <Button onClick={handleConnect} disabled={isSaving || !isValidKey}>
+            {isSaving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Connect Claude
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/onboarding/OnboardingWizard.tsx
+++ b/apps/web/components/onboarding/OnboardingWizard.tsx
@@ -8,8 +8,9 @@ import { CheckCircle2 } from 'lucide-react';
 import { WelcomeStep } from './WelcomeStep';
 import { XeroConnectStep } from './XeroConnectStep';
 import { ShopifyConnectStep } from './ShopifyConnectStep';
+import { AnthropicConnectStep } from './AnthropicConnectStep';
 
-export type OnboardingStep = 'welcome' | 'xero' | 'shopify';
+export type OnboardingStep = 'welcome' | 'xero' | 'shopify' | 'anthropic';
 
 interface StepConfig {
   id: OnboardingStep;
@@ -34,6 +35,12 @@ const STEPS: StepConfig[] = [
     id: 'shopify',
     title: 'Connect Shopify',
     description: 'Sync products & stock',
+    optional: true,
+  },
+  {
+    id: 'anthropic',
+    title: 'Claude AI',
+    description: 'Activate AI features',
     optional: true,
   },
 ];
@@ -90,6 +97,8 @@ export function OnboardingWizard() {
         return <XeroConnectStep {...commonProps} />;
       case 'shopify':
         return <ShopifyConnectStep {...commonProps} />;
+      case 'anthropic':
+        return <AnthropicConnectStep {...commonProps} />;
     }
   };
 

--- a/apps/web/components/ui/real-time-indicator.tsx
+++ b/apps/web/components/ui/real-time-indicator.tsx
@@ -5,50 +5,50 @@
  * Green dot = connected, Gray = disconnected, Red = error
  */
 
-import { Wifi, WifiOff, AlertCircle } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Wifi, WifiOff, AlertCircle } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 interface RealTimeIndicatorProps {
-  status: "connecting" | "connected" | "disconnected" | "error";
+  status: 'connecting' | 'connected' | 'disconnected' | 'error';
   messagesReceived?: number;
 }
 
 export function RealTimeIndicator({ status, messagesReceived = 0 }: RealTimeIndicatorProps) {
   const getStatusConfig = () => {
     switch (status) {
-      case "connected":
+      case 'connected':
         return {
           icon: Wifi,
-          label: "Live",
-          color: "bg-green-500",
-          textColor: "text-green-700",
+          label: 'Live',
+          color: 'bg-green-500',
+          textColor: 'text-green-700',
           tooltip: `Connected - ${messagesReceived} updates received`,
         };
-      case "connecting":
+      case 'connecting':
         return {
           icon: Wifi,
-          label: "Connecting...",
-          color: "bg-yellow-500 animate-pulse",
-          textColor: "text-yellow-700",
-          tooltip: "Connecting to real-time updates...",
+          label: 'Connecting...',
+          color: 'bg-yellow-500 animate-pulse',
+          textColor: 'text-yellow-700',
+          tooltip: 'Connecting to real-time updates...',
         };
-      case "error":
+      case 'error':
         return {
           icon: AlertCircle,
-          label: "Error",
-          color: "bg-red-500",
-          textColor: "text-red-700",
-          tooltip: "Connection error - will retry automatically",
+          label: 'Error',
+          color: 'bg-red-500',
+          textColor: 'text-red-700',
+          tooltip: 'Connection error - will retry automatically',
         };
-      case "disconnected":
+      case 'disconnected':
       default:
         return {
           icon: WifiOff,
-          label: "Offline",
-          color: "bg-gray-400",
-          textColor: "text-gray-700",
-          tooltip: "Not connected to real-time updates",
+          label: 'Offline',
+          color: 'bg-gray-400',
+          textColor: 'text-gray-700',
+          tooltip: 'Not connected to real-time updates',
         };
     }
   };
@@ -56,16 +56,19 @@ export function RealTimeIndicator({ status, messagesReceived = 0 }: RealTimeIndi
   const config = getStatusConfig();
   const Icon = config.icon;
 
+  // Don't render during initial connection attempt — avoids persistent "Connecting..." badge
+  if (status === 'connecting') return null;
+
   return (
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>
           <Badge
             variant="outline"
-            className={`flex items-center gap-1.5 ${config.textColor} border-${status === "connected" ? "green" : status === "error" ? "red" : "gray"}-300`}
+            className={`flex items-center gap-1.5 ${config.textColor} border-${status === 'connected' ? 'green' : status === 'error' ? 'red' : 'gray'}-300`}
           >
-            <div className={`w-2 h-2 rounded-full ${config.color}`} />
-            <Icon className="w-3 h-3" />
+            <div className={`h-2 w-2 rounded-full ${config.color}`} />
+            <Icon className="h-3 w-3" />
             <span className="text-xs font-medium">{config.label}</span>
           </Badge>
         </TooltipTrigger>


### PR DESCRIPTION
Promotes all Sprint 1 + Sprint 2 work to main for production deployment.

## Includes
- fix(backend): XSS sanitisation on CustomerCreate + CustomerUpdate — UNI-1783
- feat(backend): Anthropic API key configure/status endpoints — UNI-1776
- feat(web): Anthropic API key input in Settings + onboarding wizard — UNI-1776
- fix(web): Customer Discard button resets form state — UNI-1784
- fix(web): POS responsive tabbed layout for mobile — UNI-1787
- fix(web): Dashboard stale setState guards (isMounted + cancelled flags)
- fix(pos): coerce product.price to Number
- fix(ui): logout redirect, settings redirect, products connecting badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)