### PR TITLE
fix(security): enforce STRIPE_WEBHOOK_SECRET — reject unverified webhook payloads (UNI-1819)

### DIFF
--- a/apps/backend/src/api/routes/stripe_webhooks.py
+++ b/apps/backend/src/api/routes/stripe_webhooks.py
@@ -14,7 +14,6 @@ processing occurs. Unsigned or tampered requests are rejected with 400.
 """
 from __future__ import annotations
 
-import json as _json
 import os
 from decimal import Decimal
 from typing import Annotated, Any
@@ -33,6 +32,13 @@ router = APIRouter(prefix="/api/webhooks", tags=["Stripe Webhooks"])
 
 STRIPE_WEBHOOK_SECRET = os.getenv("STRIPE_WEBHOOK_SECRET", "")
 
+if not STRIPE_WEBHOOK_SECRET:
+    logger.critical(
+        "STRIPE_WEBHOOK_SECRET is not set. "
+        "All incoming Stripe webhook requests will be rejected with HTTP 503 "
+        "until this environment variable is configured."
+    )
+
 
 @router.post("/stripe")
 async def stripe_webhook(
@@ -46,6 +52,12 @@ async def stripe_webhook(
     events that were successfully received but had non-critical processing
     errors.
     """
+    if not STRIPE_WEBHOOK_SECRET:
+        raise HTTPException(
+            status_code=503,
+            detail="Webhook secret not configured",
+        )
+
     payload = await request.body()
     signature = request.headers.get("stripe-signature", "")
 
@@ -93,23 +105,16 @@ def _verify_signature(payload: bytes, signature: str) -> dict[Any, Any] | None:
     Returns None if verification fails (missing secret, bad signature, etc.).
     """
     if not STRIPE_WEBHOOK_SECRET:
-        logger.warning(
-            "STRIPE_WEBHOOK_SECRET not set — accepting webhook without verification. "
-            "Set the env var in production."
-        )
-        # In development without a secret, attempt to parse payload anyway
-        try:
-            result: dict[Any, Any] = _json.loads(payload)
-            return result
-        except Exception:
-            return None
+        # Secret is not configured; reject unconditionally.
+        # The startup critical log already flagged this condition.
+        return None
 
     try:
         import stripe
 
         event = stripe.Webhook.construct_event(payload, signature, STRIPE_WEBHOOK_SECRET)
         return dict(event)
-    except stripe.SignatureVerificationError as exc:
+    except stripe.error.SignatureVerificationError as exc:
         logger.warning("Stripe signature verification failed", error=str(exc))
         return None
     except Exception as exc:


### PR DESCRIPTION
## Summary

Critical payment fraud fix. Stripe webhook handler previously accepted payloads without signature verification when STRIPE_WEBHOOK_SECRET was unset, allowing fake invoice.paid events.

- Removed unsafe fallback that skipped verification
- HTTP 503 when secret is absent
- CRITICAL log at startup if secret missing
- Fixed exception class to `stripe.error.SignatureVerificationError`
- Signature mismatch → 400

## Test plan
- [ ] Webhook returns 503 if STRIPE_WEBHOOK_SECRET not configured
- [ ] Invalid signature returns 400
- [ ] Valid Stripe signature processes normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)