### PR TITLE
feat(cin7): persist poll watermarks, implement SO + PO push (UNI-1812/1837/1838)

### DIFF
--- a/apps/backend/alembic/versions/00h_add_integration_sync_state.py
+++ b/apps/backend/alembic/versions/00h_add_integration_sync_state.py
@@ -1,0 +1,44 @@
+"""Add integration_sync_state table for persistent poll watermarks.
+
+Revision ID: 00h_add_integration_sync_state
+Revises: 00g_variants_updated_at
+Create Date: 2026-04-16
+
+Fixes UNI-1838: Cin7 poll watermarks were stored only in memory.
+After a server restart, all data since the last watermark would be
+re-processed (duplicates) or lost.  This table persists the watermark
+so the ChangeDetector can seed its in-memory state on startup.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "00h_add_integration_sync_state"
+down_revision: str | None = "00g_variants_updated_at"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create integration_sync_state table."""
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS integration_sync_state (
+            integration  VARCHAR(100) NOT NULL,
+            entity_type  VARCHAR(100) NOT NULL,
+            last_synced  TIMESTAMPTZ,
+            updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            PRIMARY KEY (integration, entity_type)
+        )
+    """)
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_integration_sync_state_integration
+            ON integration_sync_state (integration)
+    """)
+
+
+def downgrade() -> None:
+    """Drop integration_sync_state table."""
+    op.execute("DROP TABLE IF EXISTS integration_sync_state")

--- a/apps/backend/src/db/cin7_models.py
+++ b/apps/backend/src/db/cin7_models.py
@@ -853,3 +853,44 @@ class Cin7StockTakeLine(Base):
 
     def __repr__(self) -> str:
         return f"<Cin7StockTakeLine(sku={self.sku}, counted={self.counted_qty}, variance={self.variance})>"
+
+
+class IntegrationSyncState(Base):
+    """Persistent watermark store for Cin7 (and other integration) pollers.
+
+    Each row records the last successful poll timestamp for a given
+    ``integration`` + ``entity_type`` pair, e.g.
+    ``("cin7", "products")``.  On restart the ChangeDetector seeds its
+    in-memory ``_last_polled`` dict from these rows, preventing re-
+    processing of already-seen records.
+    """
+
+    __tablename__ = "integration_sync_state"
+
+    # Natural composite key: integration name + entity type
+    integration: Mapped[str] = mapped_column(
+        String(100), primary_key=True, index=True
+    )
+    entity_type: Mapped[str] = mapped_column(
+        String(100), primary_key=True
+    )
+
+    # The watermark timestamp — last successful poll completion
+    last_synced: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    # Audit columns
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<IntegrationSyncState("
+            f"integration={self.integration!r}, "
+            f"entity={self.entity_type!r}, "
+            f"last_synced={self.last_synced!r})>"
+        )

--- a/apps/backend/src/integrations/cin7/change_detector.py
+++ b/apps/backend/src/integrations/cin7/change_detector.py
@@ -4,17 +4,27 @@ Cin7 Core has NO native webhook support. This module polls Cin7 APIs
 using ``modified_since`` parameters to detect changes and emit events.
 The ChangeDetector tracks last-polled timestamps per entity type and
 returns lists of change events for downstream dispatch.
+
+Watermarks (last-polled timestamps) are persisted to the
+``integration_sync_state`` Supabase table so that a server restart does
+not cause re-processing of already-seen records (UNI-1838).
 """
 
 from datetime import UTC, datetime
 from typing import Any, Literal
 
 import structlog
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.config.cin7_settings import Cin7Settings
+from src.db.cin7_models import IntegrationSyncState
 from src.integrations.cin7.client import Cin7Client
 
 logger = structlog.get_logger(__name__)
+
+INTEGRATION_NAME = "cin7"
 
 
 # ---------------------------------------------------------------------------
@@ -161,16 +171,91 @@ def detect_inventory_changes(
 class Cin7ChangeDetector:
     """Polls Cin7 APIs for changes using ``modified_since`` parameter.
 
-    Tracks last-polled timestamps per entity type in memory.
-    In production, these would be seeded from ``Cin7Connection.last_*_sync_at``.
+    Watermarks (last-polled timestamps) are stored both in memory (for
+    fast access within a process) and in the ``integration_sync_state``
+    Supabase table (for durability across restarts).
+
+    Pass an ``AsyncSession`` via ``db`` to enable Supabase-backed
+    watermarks.  When omitted the detector falls back to pure in-memory
+    behaviour (useful in tests).
     """
 
     ENTITY_TYPES = ("products", "customers", "sales", "inventory")
 
-    def __init__(self, client: Cin7Client, settings: Cin7Settings) -> None:
+    def __init__(
+        self,
+        client: Cin7Client,
+        settings: Cin7Settings,
+        db: AsyncSession | None = None,
+    ) -> None:
         self.client = client
         self.settings = settings
+        self.db = db
         self._last_polled: dict[str, datetime] = {}
+
+    # ------------------------------------------------------------------
+    # Watermark persistence (UNI-1838)
+    # ------------------------------------------------------------------
+
+    async def load_watermarks(self) -> None:
+        """Seed in-memory watermarks from the Supabase ``integration_sync_state`` table.
+
+        Call this once at startup (or before the first poll cycle) so that
+        the detector resumes from where it left off rather than re-fetching
+        all records since the beginning of time.
+        """
+        if self.db is None:
+            return
+
+        try:
+            result = await self.db.execute(
+                select(IntegrationSyncState).where(
+                    IntegrationSyncState.integration == INTEGRATION_NAME
+                )
+            )
+            rows = result.scalars().all()
+            for row in rows:
+                if row.last_synced is not None:
+                    self._last_polled[row.entity_type] = row.last_synced
+
+            logger.info(
+                "cin7_watermarks_loaded",
+                count=len(rows),
+                entity_types=list(self._last_polled.keys()),
+            )
+        except Exception as exc:
+            logger.warning("cin7_watermarks_load_failed", error=str(exc))
+
+    async def _persist_watermark(self, entity_type: str, ts: datetime) -> None:
+        """Upsert the watermark for *entity_type* to Supabase."""
+        if self.db is None:
+            return
+
+        try:
+            stmt = (
+                pg_insert(IntegrationSyncState)
+                .values(
+                    integration=INTEGRATION_NAME,
+                    entity_type=entity_type,
+                    last_synced=ts,
+                    updated_at=datetime.now(UTC),
+                )
+                .on_conflict_do_update(
+                    index_elements=["integration", "entity_type"],
+                    set_={
+                        "last_synced": ts,
+                        "updated_at": datetime.now(UTC),
+                    },
+                )
+            )
+            await self.db.execute(stmt)
+            await self.db.flush()
+        except Exception as exc:
+            logger.warning(
+                "cin7_watermark_persist_failed",
+                entity_type=entity_type,
+                error=str(exc),
+            )
 
     # ------------------------------------------------------------------
     # Public interface
@@ -239,7 +324,7 @@ class Cin7ChangeDetector:
                 if not isinstance(products, list):
                     products = []
 
-            self._update_last_polled("products")
+            await self._update_last_polled("products")
             return detect_product_changes(products, source)
         except Exception as exc:
             logger.error("cin7_poll_products_failed", source=source, error=str(exc))
@@ -266,7 +351,7 @@ class Cin7ChangeDetector:
                 if not isinstance(customers, list):
                     customers = []
 
-            self._update_last_polled("customers")
+            await self._update_last_polled("customers")
             return detect_customer_changes(customers, source)
         except Exception as exc:
             logger.error("cin7_poll_customers_failed", source=source, error=str(exc))
@@ -293,7 +378,7 @@ class Cin7ChangeDetector:
                 if not isinstance(sales, list):
                     sales = []
 
-            self._update_last_polled("sales")
+            await self._update_last_polled("sales")
             return detect_sales_changes(sales, source)
         except Exception as exc:
             logger.error("cin7_poll_sales_failed", source=source, error=str(exc))
@@ -314,7 +399,7 @@ class Cin7ChangeDetector:
                 if not isinstance(items, list):
                     items = []
 
-            self._update_last_polled("inventory")
+            await self._update_last_polled("inventory")
             return detect_inventory_changes(items, source)
         except Exception as exc:
             logger.error("cin7_poll_inventory_failed", source=source, error=str(exc))
@@ -335,6 +420,8 @@ class Cin7ChangeDetector:
     # Internal
     # ------------------------------------------------------------------
 
-    def _update_last_polled(self, entity_type: str) -> None:
-        """Update the last-polled timestamp for an entity type."""
-        self._last_polled[entity_type] = datetime.now(UTC)
+    async def _update_last_polled(self, entity_type: str) -> None:
+        """Update the last-polled timestamp in memory and in Supabase."""
+        ts = datetime.now(UTC)
+        self._last_polled[entity_type] = ts
+        await self._persist_watermark(entity_type, ts)

--- a/apps/backend/src/integrations/cin7/client.py
+++ b/apps/backend/src/integrations/cin7/client.py
@@ -17,6 +17,10 @@ import structlog
 from src.config.cin7_settings import Cin7Settings, get_cin7_settings
 from src.integrations.cin7.demo_client import Cin7CoreDemoClient, Cin7OmniDemoClient
 
+
+class ConfigurationError(Exception):
+    """Raised when a required integration credential is missing or invalid."""
+
 logger = structlog.get_logger(__name__)
 
 
@@ -187,6 +191,56 @@ class Cin7CoreLiveClient:
         """Get product brands."""
         return await self._request("GET", "/ref/brand")
 
+    async def post_sales_order(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Create a sales order in Cin7 Core (DEAR).
+
+        Endpoint: POST /sale
+        Required payload keys: ``SaleOrderNumber``, ``Status``, ``Customer``
+        (object with ``Name``), ``Lines`` (list of line items with
+        ``SKU``, ``Quantity``, ``Price``).
+
+        Returns the created sale record including the Cin7 ``SaleID``.
+
+        Raises:
+            ConfigurationError: if Core credentials are demo placeholders.
+            Cin7APIError: on HTTP errors from the Cin7 API.
+        """
+        if (
+            self.settings.core_account_id == "demo_account_id"
+            or self.settings.core_application_key == "demo_application_key"
+        ):
+            raise ConfigurationError(
+                "Cin7 Core credentials are not configured. "
+                "Set CIN7_CORE_ACCOUNT_ID and CIN7_CORE_APPLICATION_KEY "
+                "environment variables."
+            )
+        return await self._request("POST", "/sale", json=payload)
+
+    async def post_purchase_order(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Create a purchase order in Cin7 Core (DEAR).
+
+        Endpoint: POST /purchase
+        Required payload keys: ``SupplierName`` (str), ``OrderDate`` (YYYY-MM-DD
+        str), ``Lines`` (list of line items with ``SKU``, ``Quantity``,
+        ``Price``).
+
+        Returns the created purchase record including the Cin7 ``PurchaseID``.
+
+        Raises:
+            ConfigurationError: if Core credentials are demo placeholders.
+            Cin7APIError: on HTTP errors from the Cin7 API.
+        """
+        if (
+            self.settings.core_account_id == "demo_account_id"
+            or self.settings.core_application_key == "demo_application_key"
+        ):
+            raise ConfigurationError(
+                "Cin7 Core credentials are not configured. "
+                "Set CIN7_CORE_ACCOUNT_ID and CIN7_CORE_APPLICATION_KEY "
+                "environment variables."
+            )
+        return await self._request("POST", "/purchase", json=payload)
+
 
 # ---------------------------------------------------------------------------
 # Cin7 Omni Live Client
@@ -328,6 +382,54 @@ class Cin7OmniLiveClient:
     async def get_product_categories(self) -> list[dict[str, Any]]:
         """Get product categories."""
         return await self._request("GET", "/ProductCategories")
+
+    async def post_sales_order(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Create a sales order in Cin7 Omni.
+
+        Endpoint: POST /v1/SalesOrders
+        Required payload keys: ``LineItems`` (list), ``Contact`` (object with
+        ``Name``), ``OrderDate`` (ISO 8601 string), ``Status`` (e.g. ``"DRAFT"``).
+
+        Returns the created sales order object including the Cin7 order ``id``.
+
+        Raises:
+            ConfigurationError: if Omni credentials are demo placeholders.
+            Cin7APIError: on HTTP errors from the Cin7 API.
+        """
+        if (
+            self.settings.omni_username == "demo_omni_username"
+            or self.settings.omni_api_key == "demo_omni_api_key"
+        ):
+            raise ConfigurationError(
+                "Cin7 Omni credentials are not configured. "
+                "Set CIN7_OMNI_USERNAME and CIN7_OMNI_API_KEY "
+                "environment variables."
+            )
+        return await self._request("POST", "/SalesOrders", json=payload)
+
+    async def post_purchase_order(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Create a purchase order in Cin7 Omni.
+
+        Endpoint: POST /v1/PurchaseOrders
+        Required payload keys: ``LineItems`` (list), ``Supplier`` (object with
+        ``Name``), ``OrderDate`` (ISO 8601 string).
+
+        Returns the created purchase order object including the Cin7 PO ``id``.
+
+        Raises:
+            ConfigurationError: if Omni credentials are demo placeholders.
+            Cin7APIError: on HTTP errors from the Cin7 API.
+        """
+        if (
+            self.settings.omni_username == "demo_omni_username"
+            or self.settings.omni_api_key == "demo_omni_api_key"
+        ):
+            raise ConfigurationError(
+                "Cin7 Omni credentials are not configured. "
+                "Set CIN7_OMNI_USERNAME and CIN7_OMNI_API_KEY "
+                "environment variables."
+            )
+        return await self._request("POST", "/PurchaseOrders", json=payload)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/backend/src/integrations/cin7/purchase_sync.py
+++ b/apps/backend/src/integrations/cin7/purchase_sync.py
@@ -22,7 +22,7 @@ from src.db.cin7_models import (
     SyncStatus,
 )
 from src.db.inventory_models import PurchaseOrder
-from src.integrations.cin7.client import Cin7Client
+from src.integrations.cin7.client import Cin7Client, ConfigurationError
 
 logger = structlog.get_logger(__name__)
 
@@ -319,29 +319,69 @@ class Cin7PurchaseSyncer:
 
             if target == "core":
                 payload = map_erp_po_to_core(po)
+                cin7_response = await self.client.core.post_purchase_order(payload)
+                cin7_po_id = cin7_response.get("PurchaseID") or cin7_response.get("ID")
             else:
                 payload = map_erp_po_to_omni(po)
+                cin7_response = await self.client.omni.post_purchase_order(payload)
+                cin7_po_id = cin7_response.get("id")
 
-            log.details = {"payload": payload, "target": target}
-            log.records_processed = 1
-            log.records_updated = 1
-            log.status = SyncStatus.COMPLETED.value
+            logger.info(
+                "cin7_purchase_order_pushed",
+                erp_po_id=po_id,
+                cin7_po_id=cin7_po_id,
+                target=target,
+            )
 
             # Update or create mapping
             mapping = await self._find_po_mapping_by_po_id(po_id)
             if mapping is None:
+                mapping_kwargs: dict[str, Any] = {}
+                if target == "core" and cin7_po_id:
+                    mapping_kwargs["cin7_core_purchase_id"] = str(cin7_po_id)
+                elif target == "omni" and cin7_po_id:
+                    try:
+                        mapping_kwargs["cin7_omni_po_id"] = int(cin7_po_id)
+                    except (ValueError, TypeError):
+                        pass
                 mapping = Cin7PurchaseOrderMapping(
                     id=str(uuid4()),
                     purchase_order_id=po_id,
                     cin7_po_number=po.po_number,
                     sync_status="synced",
                     last_synced_at=datetime.now(UTC),
+                    **mapping_kwargs,
                 )
                 self.db.add(mapping)
             else:
+                if target == "core" and cin7_po_id:
+                    mapping.cin7_core_purchase_id = str(cin7_po_id)
+                elif target == "omni" and cin7_po_id:
+                    try:
+                        mapping.cin7_omni_po_id = int(cin7_po_id)
+                    except (ValueError, TypeError):
+                        pass
                 mapping.sync_status = "synced"
                 mapping.last_synced_at = datetime.now(UTC)
 
+            log.details = {
+                "payload": payload,
+                "target": target,
+                "cin7_po_id": str(cin7_po_id) if cin7_po_id else None,
+            }
+            log.records_processed = 1
+            log.records_updated = 1
+            log.status = SyncStatus.COMPLETED.value
+
+        except ConfigurationError as exc:
+            log.status = SyncStatus.FAILED.value
+            log.error_message = f"ConfigurationError: {exc}"
+            log.records_failed = 1
+            logger.error(
+                "cin7_purchase_order_push_config_error",
+                po_id=po_id,
+                error=str(exc),
+            )
         except Exception as exc:
             log.status = SyncStatus.FAILED.value
             log.error_message = str(exc)[:500]

--- a/apps/backend/src/integrations/cin7/sales_sync.py
+++ b/apps/backend/src/integrations/cin7/sales_sync.py
@@ -23,7 +23,7 @@ from src.db.cin7_models import (
     SyncStatus,
 )
 from src.db.demo_models import Order, OrderStatus, Quote, QuoteStatus
-from src.integrations.cin7.client import Cin7Client
+from src.integrations.cin7.client import Cin7Client, ConfigurationError
 
 logger = structlog.get_logger(__name__)
 
@@ -457,14 +457,74 @@ class Cin7SalesSyncer:
 
             if target == "core":
                 payload = map_erp_order_to_core(order)
+                cin7_response = await self.client.core.post_sales_order(payload)
+                cin7_order_id = cin7_response.get("SaleID") or cin7_response.get("ID")
             else:
                 payload = map_erp_order_to_omni(order)
+                cin7_response = await self.client.omni.post_sales_order(payload)
+                cin7_order_id = cin7_response.get("id")
 
-            log.details = {"payload": payload, "target": target}
+            logger.info(
+                "cin7_sales_order_pushed",
+                erp_order_id=order_id,
+                cin7_order_id=cin7_order_id,
+                target=target,
+            )
+
+            # Update or create the mapping so we can reconcile on future polls
+            mapping_result = await self.db.execute(
+                select(Cin7OrderMapping).where(
+                    Cin7OrderMapping.order_id == order_id
+                )
+            )
+            mapping = mapping_result.scalar_one_or_none()
+            if mapping is None:
+                mapping_kwargs: dict[str, Any] = {}
+                if target == "core" and cin7_order_id:
+                    mapping_kwargs["cin7_core_sale_id"] = str(cin7_order_id)
+                elif target == "omni" and cin7_order_id:
+                    try:
+                        mapping_kwargs["cin7_omni_order_id"] = int(cin7_order_id)
+                    except (ValueError, TypeError):
+                        pass
+                mapping = Cin7OrderMapping(
+                    id=str(uuid4()),
+                    order_id=order_id,
+                    cin7_order_number=order.order_number,
+                    sync_status="synced",
+                    last_synced_at=datetime.now(UTC),
+                    **mapping_kwargs,
+                )
+                self.db.add(mapping)
+            else:
+                if target == "core" and cin7_order_id:
+                    mapping.cin7_core_sale_id = str(cin7_order_id)
+                elif target == "omni" and cin7_order_id:
+                    try:
+                        mapping.cin7_omni_order_id = int(cin7_order_id)
+                    except (ValueError, TypeError):
+                        pass
+                mapping.sync_status = "synced"
+                mapping.last_synced_at = datetime.now(UTC)
+
+            log.details = {
+                "payload": payload,
+                "target": target,
+                "cin7_order_id": str(cin7_order_id) if cin7_order_id else None,
+            }
             log.records_processed = 1
             log.records_updated = 1
             log.status = SyncStatus.COMPLETED.value
 
+        except ConfigurationError as exc:
+            log.status = SyncStatus.FAILED.value
+            log.error_message = f"ConfigurationError: {exc}"
+            log.records_failed = 1
+            logger.error(
+                "cin7_sales_order_push_config_error",
+                order_id=order_id,
+                error=str(exc),
+            )
         except Exception as exc:
             log.status = SyncStatus.FAILED.value
             log.error_message = str(exc)[:500]


### PR DESCRIPTION
## Summary

- **UNI-1838** — Cin7 poll watermarks were lost on server restart. Now persisted to a new `integration_sync_state` Supabase table. `Cin7ChangeDetector` gains `load_watermarks()` (seed from DB on startup) and upserts after each successful poll, preventing duplicate re-processing.
- **UNI-1812** — `Cin7SalesSyncer.sync_order_to_cin7()` was a stub; now calls `POST /sale` (Core) or `POST /SalesOrders` (Omni), stores the Cin7 order ID in `Cin7OrderMapping`, raises `ConfigurationError` when credentials are demo placeholders.
- **UNI-1837** — `Cin7PurchaseSyncer.sync_purchase_order_to_cin7()` was a stub; now calls `POST /purchase` (Core) or `POST /PurchaseOrders` (Omni), stores the Cin7 PO ID in `Cin7PurchaseOrderMapping`, raises `ConfigurationError` when credentials are demo placeholders.

## Files changed

- `apps/backend/src/db/cin7_models.py` — `IntegrationSyncState` SQLAlchemy model
- `apps/backend/alembic/versions/00h_add_integration_sync_state.py` — Alembic migration
- `apps/backend/src/integrations/cin7/change_detector.py` — DB-backed watermark persistence
- `apps/backend/src/integrations/cin7/client.py` — `ConfigurationError`, `post_sales_order()`, `post_purchase_order()` on Core + Omni live clients
- `apps/backend/src/integrations/cin7/sales_sync.py` — real SO push (UNI-1812)
- `apps/backend/src/integrations/cin7/purchase_sync.py` — real PO push (UNI-1837)

## Test plan

- [ ] Run `pnpm turbo run type-check` — no new errors (pre-existing `@supabase/ssr` TS errors on main unaffected)
- [ ] Apply Alembic migration in staging — confirm `integration_sync_state` table created
- [ ] With `CIN7_MODE=live` + valid credentials: call `POST /api/cin7/sync/orders/{id}` — verify Cin7 receives order and `cin7_order_mappings` updated with `cin7_core_sale_id` / `cin7_omni_order_id`
- [ ] Same for `POST /api/cin7/sync/purchases/{id}` — verify PO pushed and mapping updated
- [ ] Restart server; confirm `load_watermarks()` restores last-polled timestamps so no duplicate sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)