### PR TITLE
fix(security): apply RBAC to settings routes, add API rate limiting (UNI-1839/1861)

### DIFF
--- a/apps/backend/src/api/main.py
+++ b/apps/backend/src/api/main.py
@@ -7,7 +7,6 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
-from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from sqlalchemy.exc import DatabaseError, IntegrityError, OperationalError
 from starlette.exceptions import HTTPException as StarletteHTTPException
@@ -25,7 +24,7 @@ from .exceptions import (
     validation_exception_handler,
 )
 from .middleware.auth import AuthMiddleware
-from .middleware.rate_limit import limiter
+from .middleware.rate_limit import limiter, rate_limit_exceeded_handler
 from .middleware.request_id import RequestIdMiddleware
 from .middleware.security_headers import SecurityHeadersMiddleware
 from .routes import (
@@ -399,7 +398,7 @@ All errors return JSON with this format:
 
 # Rate limiter state (for SlowAPI)
 app.state.limiter = limiter
-app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)  # type: ignore[arg-type]
 
 # Global exception handlers (order matters - most specific first, generic last)
 # These ensure ALL errors return JSON, preventing HTML error pages that cause JSONDecodeError

--- a/apps/backend/src/api/middleware/rate_limit.py
+++ b/apps/backend/src/api/middleware/rate_limit.py
@@ -4,7 +4,10 @@ Rate limiting middleware for API endpoints.
 Prevents brute force attacks and abuse by limiting request rates.
 """
 
+from fastapi import Request
+from fastapi.responses import JSONResponse
 from slowapi import Limiter
+from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
 
 from src.config.settings import get_settings
@@ -38,6 +41,22 @@ def get_rate_limit_key(request) -> str:
     return f"ip:{get_remote_address(request)}"
 
 
+async def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
+    """
+    Custom 429 handler that returns a structured JSON error with retry information.
+
+    Returns:
+        429 JSON response with error message and reset time in seconds.
+    """
+    # Extract reset time from the rate limit error (slowapi stores it in the detail)
+    reset_time = getattr(exc, "retry_after", 60)
+    return JSONResponse(
+        status_code=429,
+        content={"error": f"Rate limit exceeded. Retry after {reset_time}s"},
+        headers={"Retry-After": str(reset_time)},
+    )
+
+
 # Create limiter instance with Redis storage for multi-instance support
 storage_uri = (
     f"redis://{settings.redis_host}:{settings.redis_port}/{settings.redis_db}"
@@ -47,7 +66,7 @@ storage_uri = (
 
 limiter = Limiter(
     key_func=get_rate_limit_key,
-    default_limits=["60/minute"] if settings.rate_limit_enabled else [],
+    default_limits=["100/minute"] if settings.rate_limit_enabled else [],
     storage_uri=storage_uri,
     enabled=settings.rate_limit_enabled,
 )
@@ -57,14 +76,16 @@ limiter = Limiter(
 class RateLimits:
     """Predefined rate limits for different endpoint types."""
 
-    # Authentication endpoints (more restrictive)
+    # Authentication endpoints (more restrictive — 10/minute per spec UNI-1861)
+    AUTH = "10/minute"           # 10 auth attempts per minute
     LOGIN = "5/minute"           # 5 login attempts per minute
     REGISTER = "3/hour"          # 3 registration attempts per hour
     PASSWORD_RESET = "3/hour"    # 3 password reset requests per hour
     CHANGE_PASSWORD = "5/hour"   # 5 password change attempts per hour
     REFRESH = "10/minute"        # 10 token refresh per minute
 
-    # API endpoints (standard)
+    # API endpoints (standard — 100/minute per spec UNI-1861)
+    API = "100/minute"           # 100 requests per minute (standard)
     READ = "100/minute"          # 100 read operations per minute
     WRITE = "30/minute"          # 30 write operations per minute
     DELETE = "10/minute"         # 10 delete operations per minute

--- a/apps/backend/src/api/routes/settings.py
+++ b/apps/backend/src/api/routes/settings.py
@@ -4,11 +4,13 @@ from typing import Annotated
 from uuid import UUID
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.api.middleware.rate_limit import RateLimits, limiter
+from src.api.middleware.rbac import require_permission
 from src.api.middleware.tenant_isolation import CurrentOrganization
 from src.config.database import get_async_db
 from src.db.demo_models import Organization
@@ -37,11 +39,14 @@ class UpdateCompanyRequest(BaseModel):
 
 
 @router.get("/company")
+@limiter.limit(RateLimits.API)
+@require_permission("settings:company")
 async def get_company_settings(
+    request: Request,
     org_id: CurrentOrganization,
     db: Annotated[AsyncSession, Depends(get_async_db)],
 ) -> CompanySettingsResponse:
-    """Get current organization settings."""
+    """Get current organization settings. Requires admin or owner role."""
     result = await db.execute(select(Organization).where(Organization.id == org_id))
     org = result.scalar_one_or_none()
 
@@ -60,12 +65,15 @@ async def get_company_settings(
 
 
 @router.put("/company")
+@limiter.limit(RateLimits.API)
+@require_permission("settings:company")
 async def update_company_settings(
+    request: Request,
     data: UpdateCompanyRequest,
     org_id: CurrentOrganization,
     db: Annotated[AsyncSession, Depends(get_async_db)],
 ) -> CompanySettingsResponse:
-    """Update organization name."""
+    """Update organization name. Requires admin or owner role."""
     result = await db.execute(select(Organization).where(Organization.id == org_id))
     org = result.scalar_one_or_none()
 


### PR DESCRIPTION
## Summary

- **UNI-1839**: Added `@require_permission("settings:company")` to both `GET /api/settings/company` and `PUT /api/settings/company`. Only users with `admin` or `owner` role have `settings:company` permission per the RBAC matrix. Added `request: Request` as first parameter (required by the decorator) and imported `require_permission` from the existing middleware.
- **UNI-1861**: Replaced the slowapi default `_rate_limit_exceeded_handler` with a custom `rate_limit_exceeded_handler` that returns `{"error": "Rate limit exceeded. Retry after {N}s"}` with a `Retry-After` header. Raised the global default from 60/min to 100/min. Added `RateLimits.API = "100/minute"` and `RateLimits.AUTH = "10/minute"` named constants. Applied `@limiter.limit(RateLimits.API)` to both settings endpoints.

## Files changed

- `apps/backend/src/api/routes/settings.py` — RBAC + rate limiting on settings routes
- `apps/backend/src/api/middleware/rate_limit.py` — custom 429 handler, corrected default limit, new constants
- `apps/backend/src/api/main.py` — wire custom 429 handler, remove slowapi default import

## Test plan

- [ ] `GET /api/settings/company` with `member` role token → 403 Forbidden
- [ ] `GET /api/settings/company` with `admin` role token → 200 OK
- [ ] `PUT /api/settings/company` with `owner` role token → 200 OK
- [ ] `GET /api/settings/company` called >100 times/minute → 429 `{"error": "Rate limit exceeded. Retry after Xs"}`
- [ ] Auth endpoints (`/api/auth/login`) remain at their existing stricter limits (5/min)
- [ ] `pnpm turbo run type-check` — pre-existing frontend `@supabase/ssr` errors only (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)