### PR TITLE
feat(invoices,xero): credit note workflow + Xero credit note sync (UNI-1810/1814)

### DIFF
--- a/apps/backend/alembic/versions/c1d2e3f4a5b6_add_credit_notes_table.py
+++ b/apps/backend/alembic/versions/c1d2e3f4a5b6_add_credit_notes_table.py
@@ -1,0 +1,45 @@
+"""add_credit_notes_table
+
+Revision ID: c1d2e3f4a5b6
+Revises: b8c4e2f9a1d3
+Create Date: 2026-04-16 00:00:00.000000
+
+UNI-1810: Credit note workflow
+UNI-1814: Xero credit note sync (xero_credit_note_id column)
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c1d2e3f4a5b6"
+down_revision: Union[str, Sequence[str], None] = "b8c4e2f9a1d3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create credit_notes table (UNI-1810, UNI-1814)."""
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS credit_notes (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            invoice_id UUID NOT NULL REFERENCES invoices(id) ON DELETE RESTRICT,
+            credit_note_number VARCHAR(100) UNIQUE NOT NULL,
+            reason TEXT NOT NULL,
+            amount DECIMAL(10,2) NOT NULL CHECK (amount > 0),
+            status VARCHAR(20) NOT NULL DEFAULT 'draft'
+                CHECK (status IN ('draft', 'issued', 'applied')),
+            xero_credit_note_id VARCHAR(255),
+            created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+            issued_at TIMESTAMP WITH TIME ZONE
+        )
+    """)
+
+    op.execute("CREATE INDEX IF NOT EXISTS ix_credit_notes_invoice_id ON credit_notes (invoice_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_credit_notes_status ON credit_notes (status)")
+
+
+def downgrade() -> None:
+    """Drop credit_notes table."""
+    op.execute("DROP TABLE IF EXISTS credit_notes")

--- a/apps/backend/src/api/main.py
+++ b/apps/backend/src/api/main.py
@@ -56,6 +56,7 @@ from .routes import (
     google_ai,
     health,
     inventory,
+    credit_notes,  # Credit notes for UNI-1810/1814
     invoice_payments,  # Invoice payments for UNI-173
     invoices,  # Invoices for UNI-173
     jobs,
@@ -452,6 +453,8 @@ app.include_router(quotes.router, tags=["Quotes"])
 # Invoicing & Payments (UNI-173)
 app.include_router(invoices.router, tags=["Invoices"])
 app.include_router(invoice_payments.router, tags=["Invoice Payments"])
+# Credit notes (UNI-1810/1814)
+app.include_router(credit_notes.router, tags=["Credit Notes"])
 # Billing & Payment Methods (Phase 2 Batch 2A)
 app.include_router(billing.router, tags=["Billing"])
 # Background jobs router

--- a/apps/backend/src/api/routes/credit_notes.py
+++ b/apps/backend/src/api/routes/credit_notes.py
@@ -1,0 +1,211 @@
+"""Credit note API endpoints (UNI-1810, UNI-1814).
+
+Endpoints:
+  POST /api/invoices/{invoice_id}/credit-notes  — create a credit note
+  POST /api/credit-notes/{id}/issue             — issue a credit note + sync to Xero
+  GET  /api/credit-notes/{id}                   — retrieve a credit note
+"""
+from datetime import UTC, datetime
+from typing import Annotated
+from uuid import UUID
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from src.api.middleware.tenant_isolation import CurrentOrganization
+from src.api.schemas.invoicing import CreditNoteCreate, CreditNoteResponse
+from src.config.database import get_async_db
+from src.config.xero_settings import XeroSettings, get_xero_settings
+from src.db.models.invoicing import CreditNote, Invoice
+from src.integrations.xero.auth import XeroAuth
+from src.integrations.xero.credit_notes import push_credit_note
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(tags=["Credit Notes"])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_xero_auth(settings: Annotated[XeroSettings, Depends(get_xero_settings)]) -> XeroAuth:
+    """Dependency: build a XeroAuth instance from settings."""
+    return XeroAuth(
+        client_id=settings.client_id,
+        client_secret=settings.client_secret,
+        redirect_uri=settings.redirect_uri,
+        scopes=settings.scopes_list,
+    )
+
+
+async def _generate_credit_note_number(db: AsyncSession, invoice_number: str) -> str:
+    """Generate a sequential credit note number: CN-{invoice_number}-{seq}.
+
+    Example: CN-INV-2026-0001-1
+    """
+    prefix = f"CN-{invoice_number}-"
+    result = await db.execute(
+        select(func.count(CreditNote.id)).where(
+            CreditNote.credit_note_number.like(f"{prefix}%")
+        )
+    )
+    existing_count: int = result.scalar() or 0
+    return f"{prefix}{existing_count + 1}"
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/api/invoices/{invoice_id}/credit-notes",
+    response_model=CreditNoteResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_credit_note(
+    invoice_id: UUID,
+    body: CreditNoteCreate,
+    db: Annotated[AsyncSession, Depends(get_async_db)],
+) -> CreditNoteResponse:
+    """Create a draft credit note against an invoice.
+
+    - amount must be > 0 and <= invoice total
+    - Credit note is created in 'draft' status; call /issue to finalise.
+    """
+    # Load invoice
+    stmt = select(Invoice).where(Invoice.id == invoice_id)
+    result = await db.execute(stmt)
+    invoice = result.scalar_one_or_none()
+
+    if not invoice:
+        raise HTTPException(status_code=404, detail="Invoice not found")
+
+    if body.amount > invoice.total:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Credit note amount ({body.amount}) exceeds invoice total ({invoice.total})",
+        )
+
+    credit_note_number = await _generate_credit_note_number(db, invoice.invoice_number)
+
+    cn = CreditNote(
+        invoice_id=invoice_id,
+        credit_note_number=credit_note_number,
+        reason=body.reason,
+        amount=body.amount,
+        status="draft",
+    )
+    db.add(cn)
+    await db.commit()
+    await db.refresh(cn)
+
+    logger.info(
+        "Credit note created",
+        credit_note_id=str(cn.id),
+        credit_note_number=credit_note_number,
+        invoice_id=str(invoice_id),
+        amount=str(body.amount),
+    )
+
+    return CreditNoteResponse.model_validate(cn)
+
+
+@router.post(
+    "/api/credit-notes/{credit_note_id}/issue",
+    response_model=CreditNoteResponse,
+)
+async def issue_credit_note(
+    credit_note_id: UUID,
+    org_id: CurrentOrganization,
+    db: Annotated[AsyncSession, Depends(get_async_db)],
+    xero_auth: Annotated[XeroAuth, Depends(_get_xero_auth)],
+) -> CreditNoteResponse:
+    """Issue a draft credit note.
+
+    - Sets status to 'issued' and records issued_at timestamp.
+    - Reduces the originating invoice's amount_due by the credit note amount.
+    - Pushes the credit note to Xero (non-blocking if Xero is not connected).
+    """
+    stmt = (
+        select(CreditNote)
+        .where(CreditNote.id == credit_note_id)
+        .options(selectinload(CreditNote.invoice))
+    )
+    result = await db.execute(stmt)
+    cn = result.scalar_one_or_none()
+
+    if not cn:
+        raise HTTPException(status_code=404, detail="Credit note not found")
+
+    if cn.status != "draft":
+        raise HTTPException(
+            status_code=400,
+            detail=f"Credit note is already '{cn.status}' — only draft credit notes can be issued",
+        )
+
+    # Update status
+    cn.status = "issued"
+    cn.issued_at = datetime.now(UTC)
+
+    # Reduce invoice outstanding amount
+    invoice: Invoice = cn.invoice
+    new_amount_due = max(invoice.amount_due - cn.amount, 0)
+    invoice.amount_due = new_amount_due
+
+    await db.flush()
+
+    # Push to Xero (non-blocking)
+    try:
+        xero_cn_id = await push_credit_note(
+            db=db,
+            organization_id=org_id,
+            credit_note_id=cn.id,
+            xero_auth=xero_auth,
+        )
+        if xero_cn_id:
+            cn.xero_credit_note_id = xero_cn_id
+    except Exception as exc:
+        # Xero sync failure is non-blocking — log and continue
+        logger.warning(
+            "Xero credit note sync failed — continuing without Xero ID",
+            credit_note_id=str(credit_note_id),
+            error=str(exc),
+        )
+
+    await db.commit()
+    await db.refresh(cn)
+
+    logger.info(
+        "Credit note issued",
+        credit_note_id=str(cn.id),
+        credit_note_number=cn.credit_note_number,
+        invoice_id=str(invoice.id),
+        xero_credit_note_id=cn.xero_credit_note_id,
+    )
+
+    return CreditNoteResponse.model_validate(cn)
+
+
+@router.get(
+    "/api/credit-notes/{credit_note_id}",
+    response_model=CreditNoteResponse,
+)
+async def get_credit_note(
+    credit_note_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_async_db)],
+) -> CreditNoteResponse:
+    """Retrieve a credit note by ID."""
+    stmt = select(CreditNote).where(CreditNote.id == credit_note_id)
+    result = await db.execute(stmt)
+    cn = result.scalar_one_or_none()
+
+    if not cn:
+        raise HTTPException(status_code=404, detail="Credit note not found")
+
+    return CreditNoteResponse.model_validate(cn)

--- a/apps/backend/src/api/schemas/invoicing.py
+++ b/apps/backend/src/api/schemas/invoicing.py
@@ -304,3 +304,31 @@ class PaymentListResponse(BaseModel):
     page: int
     page_size: int
     total_pages: int
+
+
+# ---------------------------------------------------------------------------
+# Credit Note schemas (UNI-1810)
+# ---------------------------------------------------------------------------
+
+
+class CreditNoteCreate(BaseModel):
+    """Request body for creating a credit note."""
+
+    reason: str = Field(..., min_length=1, max_length=1000, description="Reason for the credit note")
+    amount: Decimal = Field(..., gt=0, description="Credit note amount (must be <= invoice total)")
+
+
+class CreditNoteResponse(BaseModel):
+    """Credit note detail response."""
+
+    id: UUID
+    invoice_id: UUID
+    credit_note_number: str
+    reason: str
+    amount: Decimal
+    status: str  # draft | issued | applied
+    xero_credit_note_id: str | None = None
+    created_at: datetime
+    issued_at: datetime | None = None
+
+    model_config = {"from_attributes": True}

--- a/apps/backend/src/db/models/invoicing.py
+++ b/apps/backend/src/db/models/invoicing.py
@@ -1,4 +1,4 @@
-"""Invoicing and payment models for UNI-173."""
+"""Invoicing and payment models for UNI-173, UNI-1810."""
 from datetime import UTC, date, datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING
@@ -9,6 +9,7 @@ from sqlalchemy import (
     Boolean,
     CheckConstraint,
     Date,
+    DateTime,
     ForeignKey,
     Integer,
     String,
@@ -86,6 +87,9 @@ class Invoice(Base):
     )
     payments: Mapped[list["InvoicePayment"]] = relationship(
         "InvoicePayment", back_populates="invoice", cascade="all, delete-orphan"
+    )
+    credit_notes: Mapped[list["CreditNote"]] = relationship(
+        "CreditNote", back_populates="invoice", cascade="all, delete-orphan"
     )
     customer: Mapped["Customer"] = relationship("Customer", foreign_keys=[customer_id])
     order: Mapped["Order | None"] = relationship("Order", foreign_keys=[order_id])
@@ -180,3 +184,53 @@ class InvoicePayment(Base):
     __table_args__ = (
         CheckConstraint("amount > 0", name="invoice_payments_amount_positive"),
     )
+
+
+class CreditNote(Base):
+    """Credit note (adjustment note) for ATO-compliant invoice reversals (UNI-1810).
+
+    A credit note is issued when an invoice needs to be fully or partially reversed
+    due to a return, pricing error, or dispute. Issuing a credit note reduces the
+    originating invoice's amount_due.
+    """
+
+    __tablename__ = "credit_notes"
+
+    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
+    invoice_id: Mapped[UUID] = mapped_column(
+        ForeignKey("invoices.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    credit_note_number: Mapped[str] = mapped_column(
+        String(100), unique=True, nullable=False, index=True
+    )
+    reason: Mapped[str] = mapped_column(Text, nullable=False)
+    amount: Mapped[Decimal] = mapped_column(DECIMAL(10, 2), nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(20), default="draft", nullable=False, index=True
+    )  # draft | issued | applied
+
+    # Xero sync (UNI-1814)
+    xero_credit_note_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    # Timestamps
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
+    issued_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    # Relationships
+    invoice: Mapped["Invoice"] = relationship("Invoice", back_populates="credit_notes")
+
+    __table_args__ = (
+        CheckConstraint("amount > 0", name="credit_notes_amount_positive"),
+        CheckConstraint(
+            "status IN ('draft', 'issued', 'applied')",
+            name="credit_notes_status_valid",
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<CreditNote(number={self.credit_note_number},"
+            f" amount={self.amount}, status={self.status})>"
+        )

--- a/apps/backend/src/integrations/xero/client.py
+++ b/apps/backend/src/integrations/xero/client.py
@@ -388,6 +388,61 @@ class XeroClient:
 
         return result.get("BankTransactions", [])
 
+    async def create_credit_note(
+        self,
+        contact_id: str,
+        description: str,
+        amount: float,
+        reference: str | None = None,
+    ) -> dict:
+        """Create a credit note in Xero (UNI-1814).
+
+        Args:
+            contact_id: Xero contact ID
+            description: Credit note line item description
+            amount: Credit note amount (positive, Xero handles sign)
+            reference: Internal reference (e.g. credit note number)
+
+        Returns:
+            Created credit note data including CreditNoteID
+
+        Raises:
+            XeroAPIError: If creation fails
+        """
+        payload = {
+            "CreditNotes": [
+                {
+                    "Type": "ACCREC",
+                    "Contact": {"ContactID": contact_id},
+                    "LineItems": [
+                        {
+                            "Description": description,
+                            "Quantity": 1,
+                            "UnitAmount": amount,
+                            "TaxType": "OUTPUT2",  # GST on Income (Australia)
+                        }
+                    ],
+                    "Status": "SUBMITTED",
+                    **({"Reference": reference} if reference else {}),
+                }
+            ]
+        }
+
+        logger.info("Creating Xero credit note", contact_id=contact_id, amount=amount)
+
+        result = await self._make_request("POST", "/CreditNotes", data=payload)
+
+        credit_notes = result.get("CreditNotes", [])
+        if credit_notes:
+            cn = credit_notes[0]
+            logger.info(
+                "Successfully created credit note",
+                credit_note_id=cn.get("CreditNoteID"),
+            )
+            return cn
+
+        raise XeroAPIError("No credit note returned from Xero")
+
     async def close(self) -> None:
         """Close HTTP client."""
         await self._http_client.aclose()

--- a/apps/backend/src/integrations/xero/credit_notes.py
+++ b/apps/backend/src/integrations/xero/credit_notes.py
@@ -1,0 +1,122 @@
+"""Xero credit note synchronization logic (UNI-1814).
+
+Pushes credit notes issued in the ERP to Xero as ACCREC credit notes,
+reducing accounts receivable to match the adjustment note.
+"""
+
+from uuid import UUID
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.integrations.xero import get_xero_client
+from src.integrations.xero.auth import XeroAuth
+from src.integrations.xero.client import XeroAPIError
+
+logger = structlog.get_logger(__name__)
+
+
+async def push_credit_note(
+    db: AsyncSession,
+    organization_id: UUID,
+    credit_note_id: UUID,
+    xero_auth: XeroAuth,
+) -> str | None:
+    """Push a credit note to Xero and return the Xero CreditNoteID.
+
+    Called automatically when a credit note is issued via
+    POST /api/credit-notes/{id}/issue.
+
+    If no active Xero connection exists for the organization, logs a warning
+    and returns None (non-blocking — the credit note is still issued locally).
+
+    Args:
+        db: Async database session
+        organization_id: Organization UUID
+        credit_note_id: CreditNote UUID
+        xero_auth: XeroAuth instance for token management
+
+    Returns:
+        Xero CreditNoteID string, or None if Xero is not connected.
+
+    Raises:
+        XeroAPIError: If the Xero API call fails (bubbles up to caller).
+    """
+    from sqlalchemy import select
+    from sqlalchemy.orm import selectinload
+
+    from src.db.models.invoicing import CreditNote, Invoice
+    from src.db.demo_models import Customer
+
+    # Resolve Xero connection (non-blocking if absent)
+    connection = await xero_auth.get_active_connection(db, organization_id)
+    if not connection:
+        logger.warning(
+            "No active Xero connection — skipping credit note sync",
+            organization_id=str(organization_id),
+            credit_note_id=str(credit_note_id),
+        )
+        return None
+
+    # Load credit note + invoice + customer
+    stmt = (
+        select(CreditNote)
+        .where(CreditNote.id == credit_note_id)
+        .options(
+            selectinload(CreditNote.invoice).selectinload(Invoice.customer)
+        )
+    )
+    result = await db.execute(stmt)
+    cn = result.scalar_one_or_none()
+
+    if not cn:
+        raise ValueError(f"CreditNote {credit_note_id} not found")
+
+    customer: Customer = cn.invoice.customer
+
+    demo_mode = connection.access_token.startswith("demo_")
+    xero_client = get_xero_client(
+        access_token=connection.access_token,
+        tenant_id=connection.tenant_id,
+        demo_mode=demo_mode,
+    )
+
+    try:
+        # Resolve or create Xero contact
+        contact = await xero_client.get_contact_by_email(customer.email)
+        if not contact:
+            contact = await xero_client.create_contact(
+                name=customer.company_name,
+                email=customer.email,
+                phone=getattr(customer, "phone", None),
+            )
+
+        xero_cn = await xero_client.create_credit_note(
+            contact_id=contact["ContactID"],
+            description=(
+                f"Credit note for invoice {cn.invoice.invoice_number}: {cn.reason}"
+            ),
+            amount=float(cn.amount),
+            reference=cn.credit_note_number,
+        )
+
+        xero_cn_id: str = xero_cn["CreditNoteID"]
+
+        logger.info(
+            "Credit note pushed to Xero",
+            credit_note_id=str(credit_note_id),
+            credit_note_number=cn.credit_note_number,
+            xero_credit_note_id=xero_cn_id,
+        )
+
+        return xero_cn_id
+
+    except XeroAPIError:
+        logger.error(
+            "Failed to push credit note to Xero",
+            credit_note_id=str(credit_note_id),
+        )
+        raise
+
+    finally:
+        await xero_client.close()

--- a/apps/backend/src/integrations/xero/demo_client.py
+++ b/apps/backend/src/integrations/xero/demo_client.py
@@ -207,6 +207,45 @@ class DemoXeroClient:
             "Edition": "BUSINESS",
         }
 
+    async def create_credit_note(
+        self,
+        contact_id: str,
+        description: str,
+        amount: float,
+        reference: str | None = None,
+    ) -> dict:
+        """Return mock credit note data (UNI-1814)."""
+        credit_note_id = str(uuid.uuid4())
+
+        logger.info(
+            "Demo: Created credit note",
+            contact_id=contact_id,
+            amount=amount,
+            credit_note_id=credit_note_id,
+        )
+
+        return {
+            "CreditNoteID": credit_note_id,
+            "Type": "ACCREC",
+            "Status": "SUBMITTED",
+            "CreditNoteNumber": f"CN-DEMO-{credit_note_id[:8].upper()}",
+            "Contact": {"ContactID": contact_id},
+            "LineItems": [
+                {
+                    "Description": description,
+                    "Quantity": 1.0,
+                    "UnitAmount": amount,
+                    "TaxType": "OUTPUT2",
+                }
+            ],
+            "SubTotal": amount,
+            "TotalTax": round(amount * 0.1, 2),
+            "Total": round(amount * 1.1, 2),
+            "AmountDue": round(amount * 1.1, 2),
+            "AmountCredited": 0.0,
+            "DateString": datetime.now().strftime("%Y-%m-%d"),
+        }
+
     async def close(self) -> None:
         """No-op for demo client."""
         logger.info("Demo: Client closed")


### PR DESCRIPTION
## Summary

- **UNI-1810**: Implements the full credit note workflow — ATO-compliant adjustment notes for invoice reversals (returns, pricing errors, disputes)
- **UNI-1814**: Syncs issued credit notes to Xero as ACCREC credit notes, reducing accounts receivable; non-blocking if Xero not connected

## Changes

### Model (`src/db/models/invoicing.py`)
- New `CreditNote` SQLAlchemy model: `id`, `invoice_id` (FK → invoices, RESTRICT), `credit_note_number`, `reason`, `amount`, `status` (draft|issued|applied), `xero_credit_note_id`, `created_at`, `issued_at`
- `Invoice` model gains `credit_notes` relationship

### Migration (`alembic/versions/c1d2e3f4a5b6_add_credit_notes_table.py`)
- Creates `credit_notes` table with CHECK constraints on `amount > 0` and `status IN (draft, issued, applied)`

### API endpoints (`src/api/routes/credit_notes.py`)
- `POST /api/invoices/{invoice_id}/credit-notes` — creates a draft credit note (validates amount ≤ invoice total; numbering: CN-{invoice_number}-{seq})
- `POST /api/credit-notes/{id}/issue` — sets status=issued, records issued_at, reduces `invoice.amount_due`, pushes to Xero
- `GET /api/credit-notes/{id}` — retrieves credit note detail

### Xero integration
- `XeroClient.create_credit_note()` and `DemoXeroClient.create_credit_note()` — POST to `/CreditNotes` with `Type: ACCREC, TaxType: OUTPUT2, Status: SUBMITTED`
- `src/integrations/xero/credit_notes.py` — `push_credit_note()` helper; logs a warning and returns `None` if no active Xero connection (non-blocking)

### Schemas (`src/api/schemas/invoicing.py`)
- `CreditNoteCreate` (reason + amount validation)
- `CreditNoteResponse` (full credit note detail including Xero ID)

## Test plan

- [ ] `POST /api/invoices/{id}/credit-notes` with valid amount returns 201 with status=draft, CN-INV-...-1 number
- [ ] `POST /api/invoices/{id}/credit-notes` with amount > invoice total returns 400
- [ ] `POST /api/credit-notes/{id}/issue` sets status=issued, updates invoice amount_due
- [ ] `POST /api/credit-notes/{id}/issue` on already-issued CN returns 400
- [ ] `GET /api/credit-notes/{id}` returns 200 with all fields
- [ ] Xero push: with demo connection, `xero_credit_note_id` is populated
- [ ] Xero push: without any connection, issue still succeeds (xero_credit_note_id null, warning logged)
- [ ] Alembic migration upgrades and downgrades cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)