### PR TITLE
feat(ai): add AgentCard metadata to all 20 AI agents + discovery endpoints (UNI-1871)

### DIFF
--- a/apps/backend/src/ai/agents/specialized/anomaly_detection_agent.py
+++ b/apps/backend/src/ai/agents/specialized/anomaly_detection_agent.py
@@ -5,6 +5,38 @@ Detects unusual patterns and outliers in business data using statistical
 analysis to alert before issues escalate.
 """
 
+AGENT_CARD = {
+    "name": "anomaly_detection_agent",
+    "display_name": "Anomaly Detection Agent",
+    "description": "Detects unusual patterns and outliers in business data using statistical z-score analysis to alert before issues escalate",
+    "version": "1.0.0",
+    "capabilities": ["anomaly_detection", "statistical_analysis", "outlier_detection", "fraud_detection"],
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "detection_type": {
+                "type": "string",
+                "enum": ["order_amount", "inventory", "pricing", "pos_failures"],
+                "description": "Type of anomaly to detect",
+            },
+            "entity_id": {"type": "string", "description": "UUID of the entity to check"},
+            "order_id": {"type": "string", "description": "Order UUID for order_amount checks"},
+            "product_id": {"type": "string", "description": "Product UUID for inventory/pricing checks"},
+            "location": {"type": "string", "description": "Location filter for POS/inventory checks"},
+            "terminal_id": {"type": "string", "description": "POS terminal UUID filter"},
+            "time_window_minutes": {"type": "integer", "description": "Time window for POS failure detection"},
+        },
+        "required": ["detection_type"],
+    },
+    "output_schema": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string"},
+            "metadata": {"type": "object"},
+        },
+    },
+}
+
 import statistics
 from datetime import UTC, datetime, timedelta
 from typing import Any

--- a/apps/backend/src/ai/agents/specialized/autonomous_ops_agent.py
+++ b/apps/backend/src/ai/agents/specialized/autonomous_ops_agent.py
@@ -9,6 +9,33 @@ Runs in demo mode (structured mock data) when ANTHROPIC_API_KEY is absent.
 
 from __future__ import annotations
 
+AGENT_CARD = {
+    "name": "autonomous_ops_agent",
+    "display_name": "Autonomous Operations Agent",
+    "description": "ERP decision engine that autonomously handles purchase order creation, dunning, bank reconciliation, and SLA monitoring using Claude Sonnet 4.6",
+    "version": "1.0.0",
+    "capabilities": ["autonomous_ops", "purchase_order_creation", "dunning", "bank_reconciliation", "sla_monitoring"],
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["check_low_stock", "run_dunning", "reconcile_bank", "monitor_sla", "full_cycle"],
+                "description": "Autonomous operation to execute",
+            },
+            "dry_run": {"type": "boolean", "description": "If true, recommend actions without executing them"},
+        },
+        "required": ["action"],
+    },
+    "output_schema": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string"},
+            "metadata": {"type": "object"},
+        },
+    },
+}
+
 import os
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime, timedelta

--- a/apps/backend/src/ai/agents/specialized/cin7_anomaly_agent.py
+++ b/apps/backend/src/ai/agents/specialized/cin7_anomaly_agent.py
@@ -4,6 +4,34 @@ Detects anomalies in Cin7 sync data — sync frequency spikes, price drift
 between ERP and Cin7, stock mismatches, and mapping coverage gaps.
 """
 
+AGENT_CARD = {
+    "name": "cin7_anomaly_agent",
+    "display_name": "Cin7 Anomaly Detection Agent",
+    "description": "Detects anomalies in Cin7 sync data including sync frequency spikes, price drift between ERP and Cin7, stock mismatches, and mapping coverage gaps",
+    "version": "1.0.0",
+    "capabilities": ["cin7_anomaly_detection", "sync_failure_detection", "cin7_data_quality"],
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "detection_type": {
+                "type": "string",
+                "enum": ["sync_frequency", "price_drift", "stock_mismatch", "mapping_coverage"],
+                "description": "Type of Cin7 anomaly to detect",
+            },
+            "product_id": {"type": "string", "description": "Product UUID for product-level checks"},
+            "time_window_hours": {"type": "integer", "description": "Time window for sync frequency analysis"},
+        },
+        "required": ["detection_type"],
+    },
+    "output_schema": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string"},
+            "metadata": {"type": "object"},
+        },
+    },
+}
+
 import statistics
 from datetime import datetime
 from typing import Any

--- a/apps/backend/src/ai/agents/specialized/cin7_forecasting_agent.py
+++ b/apps/backend/src/ai/agents/specialized/cin7_forecasting_agent.py
@@ -4,6 +4,30 @@ AI-powered demand prediction for Cin7-synced products using
 sync history, velocity analysis, and seasonal pattern detection.
 """
 
+AGENT_CARD = {
+    "name": "cin7_forecasting_agent",
+    "display_name": "Cin7 Forecasting Agent",
+    "description": "AI-powered demand prediction for Cin7-synced products using sync history, velocity analysis, and seasonal pattern detection",
+    "version": "1.0.0",
+    "capabilities": ["cin7_forecasting", "sync_demand_prediction", "cin7_reorder_recommendations"],
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "product_id": {"type": "string", "description": "Product UUID to forecast"},
+            "horizon_days": {"type": "integer", "description": "Forecast horizon in days"},
+            "include_seasonality": {"type": "boolean", "description": "Whether to factor in seasonal patterns"},
+        },
+        "required": ["product_id"],
+    },
+    "output_schema": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string"},
+            "metadata": {"type": "object"},
+        },
+    },
+}
+
 import math
 import statistics
 from datetime import UTC, datetime, timedelta

--- a/apps/backend/src/ai/agents/specialized/cin7_shadow_agent.py
+++ b/apps/backend/src/ai/agents/specialized/cin7_shadow_agent.py
@@ -8,6 +8,34 @@ UNI-1262: Shadow Transition System Phase C
 
 from __future__ import annotations
 
+AGENT_CARD = {
+    "name": "cin7_shadow_agent",
+    "display_name": "Cin7 Shadow Gap Analysis Agent",
+    "description": "Analyzes Cin7->ERP sync gaps, classifies severity, generates prioritized recommendations, and auto-resolves stale conflicts",
+    "version": "1.0.0",
+    "capabilities": ["cin7_shadow_gap_analysis", "cin7_auto_resolve", "cin7_sync_recommendations"],
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["analyze_gaps", "auto_resolve", "get_recommendations"],
+                "description": "Shadow analysis action to perform",
+            },
+            "max_age_hours": {"type": "integer", "description": "Maximum age of gaps to consider for auto-resolve"},
+            "severity_filter": {"type": "string", "enum": ["low", "medium", "high", "critical"], "description": "Filter gaps by severity"},
+        },
+        "required": ["action"],
+    },
+    "output_schema": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string"},
+            "metadata": {"type": "object"},
+        },
+    },
+}
+
 from collections import defaultdict
 from datetime import UTC, datetime, timedelta
 from typing import Any

--- a/apps/backend/src/ai/agents/specialized/development_agent.py
+++ b/apps/backend/src/ai/agents/specialized/development_agent.py
@@ -4,6 +4,34 @@ Development Agent for autonomous code generation.
 Generates production-quality code following project patterns and conventions.
 """
 
+AGENT_CARD = {
+    "name": "development_agent",
+    "display_name": "Development Agent",
+    "description": "Generates production-quality code following project patterns and conventions — API endpoints, database models, services, and frontend components",
+    "version": "1.0.0",
+    "capabilities": ["code_generation", "api_endpoints", "database_models", "services", "components", "pattern_following"],
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "task": {"type": "string", "description": "Code generation task description"},
+            "target_type": {
+                "type": "string",
+                "enum": ["api_endpoint", "model", "service", "component", "test"],
+                "description": "Type of code artifact to generate",
+            },
+            "context": {"type": "object", "description": "Additional context such as existing models or schemas"},
+        },
+        "required": ["task"],
+    },
+    "output_schema": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string"},
+            "metadata": {"type": "object"},
+        },
+    },
+}
+
 import json
 from collections.abc import AsyncGenerator
 from pathlib import Path

--- a/apps/backend/src/ai/agents/specialized/document_parser_agent.py
+++ b/apps/backend/src/ai/agents/specialized/document_parser_agent.py
@@ -5,6 +5,38 @@ Parses emails and documents to extract structured order data using NLP
 and pattern matching.
 """
 
+AGENT_CARD = {
+    "name": "document_parser_agent",
+    "display_name": "Document Parser Agent",
+    "description": "Parses emails and documents to extract structured order data using NLP and pattern matching — supports email, PDF, and plain text input",
+    "version": "1.0.0",
+    "capabilities": ["document_parsing", "email_parsing", "pdf_parsing", "nlp_extraction", "product_matching"],
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "document_type": {
+                "type": "string",
+                "enum": ["email", "pdf", "text"],
+                "description": "Type of document to parse",
+            },
+            "content": {"type": "string", "description": "Raw document text or base64-encoded PDF content"},
+            "extract_fields": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Specific fields to extract (e.g. customer_name, products, quantities)",
+            },
+        },
+        "required": ["document_type", "content"],
+    },
+    "output_schema": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string"},
+            "metadata": {"type": "object"},
+        },
+    },
+}
+
 import re
 from typing import Any
 

--- a/apps/backend/src/ai/agents/specialized/form_autofill_agent.py
+++ b/apps/backend/src/ai/agents/specialized/form_autofill_agent.py
@@ -5,6 +5,34 @@ Provides context-aware form auto-fill suggestions based on customer history,
 order patterns, and common workflows to reduce manual data entry.
 """
 
+AGENT_CARD = {
+    "name": "form_autofill_agent",
+    "display_name": "Form Auto-Fill Agent",
+    "description": "Provides context-aware form auto-fill suggestions based on customer history, order patterns, and common workflows to reduce manual data entry",
+    "version": "1.0.0",
+    "capabilities": ["form_autofill", "customer_history", "pattern_detection", "duplicate_detection"],
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "form_type": {
+                "type": "string",
+                "enum": ["order", "quote", "customer", "contact"],
+                "description": "Type of form to auto-fill",
+            },
+            "customer_id": {"type": "string", "description": "Customer UUID for history-based suggestions"},
+            "partial_data": {"type": "object", "description": "Partial form data already entered by the user"},
+        },
+        "required": ["form_type"],
+    },
+    "output_schema": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string"},
+            "metadata": {"type": "object"},
+        },
+    },
+}
+
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import UUID

--- a/apps/backend/src/ai/agents/specialized/inventory_forecasting_agent.py
+++ b/apps/backend/src/ai/agents/specialized/inventory_forecasting_agent.py
@@ -4,6 +4,31 @@ Inventory Forecasting Agent.
 AI-powered demand prediction and stock replenishment recommendations.
 """
 
+AGENT_CARD = {
+    "name": "inventory_forecasting_agent",
+    "display_name": "Inventory Forecasting Agent",
+    "description": "AI-powered inventory demand prediction and stock replenishment recommendations using seasonal pattern detection and safety stock calculation",
+    "version": "1.0.0",
+    "capabilities": ["inventory_forecasting", "demand_prediction", "reorder_recommendations", "seasonal_pattern_detection", "safety_stock_calculation"],
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "product_id": {"type": "string", "description": "Product UUID to forecast"},
+            "horizon_days": {"type": "integer", "description": "Forecast horizon in days (default: 30)"},
+            "include_safety_stock": {"type": "boolean", "description": "Whether to include safety stock calculation"},
+            "location": {"type": "string", "description": "Warehouse location filter"},
+        },
+        "required": ["product_id"],
+    },
+    "output_schema": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string"},
+            "metadata": {"type": "object"},
+        },
+    },
+}
+
 from datetime import datetime, timedelta
 from typing import Any
 

--- a/apps/backend/src/ai/agents/specialized/marketing_agent.py
+++ b/apps/backend/src/ai/agents/specialized/marketing_agent.py
@@ -1,5 +1,33 @@
 """Marketing Agent for AI-powered campaign generation and audience analysis."""
 
+AGENT_CARD = {
+    "name": "marketing_agent",
+    "display_name": "Marketing Agent",
+    "description": "Generates campaign copy, social posts, email sequences, and audience segment analysis for CCW products",
+    "version": "1.0.0",
+    "capabilities": ["generate_campaign", "analyze_audience", "get_stats", "marketing_copy", "audience_segmentation", "campaign_management"],
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "action": {"type": "string", "enum": ["generate_campaign", "analyze_audience", "get_stats"]},
+            "product_name": {"type": "string", "description": "Name of the product to market"},
+            "target_audience": {"type": "string", "description": "Description of the target audience"},
+            "campaign_type": {"type": "string", "enum": ["email", "social", "sms"]},
+            "tone": {"type": "string", "enum": ["professional", "friendly", "urgent", "casual"]},
+            "product_category": {"type": "string", "description": "Category for audience segmentation"},
+            "location": {"type": "string", "description": "Geographic location for audience targeting"},
+        },
+        "required": ["action"],
+    },
+    "output_schema": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string"},
+            "metadata": {"type": "object"},
+        },
+    },
+}
+
 import os
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime

--- a/apps/backend/src/ai/agents/specialized/pricing_agent.py
+++ b/apps/backend/src/ai/agents/specialized/pricing_agent.py
@@ -1,5 +1,33 @@
 """Pricing agent for cost analysis and price optimization."""
 
+AGENT_CARD = {
+    "name": "pricing_agent",
+    "display_name": "Pricing Agent",
+    "description": "Analyzes product costs and recommends optimal pricing strategies using margin calculation, competitive analysis, and cost-plus modeling",
+    "version": "1.0.0",
+    "capabilities": ["pricing", "cost_analysis", "price_optimization", "margin_calculation"],
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "product_id": {"type": "string", "description": "Product UUID to analyze"},
+            "action": {
+                "type": "string",
+                "enum": ["analyze_margin", "recommend_price", "bulk_audit"],
+                "description": "Pricing action to perform",
+            },
+            "target_margin_percent": {"type": "number", "description": "Target profit margin percentage"},
+        },
+        "required": ["product_id", "action"],
+    },
+    "output_schema": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string"},
+            "metadata": {"type": "object"},
+        },
+    },
+}
+
 from collections.abc import AsyncGenerator
 from decimal import Decimal
 from typing import Any

--- a/apps/backend/src/ai/agents/specialized/procurement_agent.py
+++ b/apps/backend/src/ai/agents/specialized/procurement_agent.py
@@ -1,5 +1,37 @@
 """Procurement agent for inventory management and supplier recommendations."""
 
+AGENT_CARD = {
+    "name": "procurement_agent",
+    "display_name": "Procurement Agent",
+    "description": "Manages inventory levels and generates procurement recommendations including supplier selection, reorder calculations, and inventory replenishment planning",
+    "version": "1.0.0",
+    "capabilities": ["procurement", "inventory_management", "supplier_recommendation", "inventory_replenishment", "reorder_calculation"],
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["check_reorder_points", "recommend_supplier", "create_draft_po", "audit_inventory"],
+                "description": "Procurement action to perform",
+            },
+            "product_ids": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "List of product UUIDs to process",
+            },
+            "supplier_id": {"type": "string", "description": "Preferred supplier UUID"},
+        },
+        "required": ["action"],
+    },
+    "output_schema": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string"},
+            "metadata": {"type": "object"},
+        },
+    },
+}
+
 from collections.abc import AsyncGenerator
 from typing import Any
 from uuid import UUID

--- a/apps/backend/src/ai/agents/specialized/project_intelligence_agent.py
+++ b/apps/backend/src/ai/agents/specialized/project_intelligence_agent.py
@@ -1,7 +1,38 @@
 """
 Project Intelligence Agent — Meta-agent for codebase auditing, gap analysis, and PRD generation.
 Reads from catalog files (docs/catalogs/) rather than scanning raw code.
+"""
 
+from __future__ import annotations
+
+AGENT_CARD = {
+    "name": "project_intelligence_agent",
+    "display_name": "Project Intelligence Agent",
+    "description": "Meta-agent for codebase auditing, gap analysis, and PRD generation — reads catalog files and syncs findings to Linear",
+    "version": "1.0.0",
+    "capabilities": ["codebase_audit", "gap_analysis", "prd_generation", "issue_sync", "dep_graph"],
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "skill": {
+                "type": "string",
+                "enum": ["scan_routes", "scan_pages", "scan_agents", "scan_packages", "cross_ref", "generate_prd", "sync_linear", "dep_graph", "score_coverage", "full_audit"],
+                "description": "Audit skill to execute",
+            },
+            "target": {"type": "string", "description": "Specific target file or module for scoped audits"},
+        },
+        "required": ["skill"],
+    },
+    "output_schema": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string"},
+            "metadata": {"type": "object"},
+        },
+    },
+}
+
+"""
 Skills (1:10 Law — exactly 10):
 1. scan_routes     - Scan routes directory, update ROUTES catalog
 2. scan_pages      - Scan frontend pages, update PAGES catalog
@@ -14,7 +45,6 @@ Skills (1:10 Law — exactly 10):
 9. issue_sync      - Prepare issues for Linear
 10. health         - Agent health check
 """
-from __future__ import annotations
 
 import json
 import re

--- a/apps/backend/src/ai/agents/specialized/query_agent.py
+++ b/apps/backend/src/ai/agents/specialized/query_agent.py
@@ -9,6 +9,29 @@ Runs in demo mode (no ANTHROPIC_API_KEY) returning canned realistic answers.
 
 from __future__ import annotations
 
+AGENT_CARD = {
+    "name": "query_agent",
+    "display_name": "NL ERP Query Agent",
+    "description": "Converts plain English questions into safe read-only SQL queries against the ERP database, executes them, and returns natural-language explanations",
+    "version": "1.0.0",
+    "capabilities": ["natural_language_query", "erp_search", "analytics"],
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Natural language question about ERP data"},
+            "db": {"type": "object", "description": "Optional async database session for live query execution"},
+        },
+        "required": ["query"],
+    },
+    "output_schema": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string"},
+            "metadata": {"type": "object"},
+        },
+    },
+}
+
 import os
 from collections.abc import AsyncGenerator
 from typing import Any

--- a/apps/backend/src/ai/agents/specialized/recommendation_agent.py
+++ b/apps/backend/src/ai/agents/specialized/recommendation_agent.py
@@ -4,6 +4,35 @@ Recommendation Agent for intelligent product recommendations.
 Provides personalized product recommendations using multiple algorithms.
 """
 
+AGENT_CARD = {
+    "name": "recommendation_agent",
+    "display_name": "Recommendation Agent",
+    "description": "Provides intelligent product recommendations using collaborative filtering and content-based algorithms — similar products, frequently bought together, and personalised recommendations",
+    "version": "1.0.0",
+    "capabilities": ["product_recommendations", "similar_products", "frequently_bought_together", "personalized_recommendations", "interaction_tracking", "recommendation_precomputation"],
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["get_recommendations", "get_similar", "get_frequently_bought_together", "track_interaction", "precompute"],
+                "description": "Recommendation action to perform",
+            },
+            "product_id": {"type": "string", "description": "Product UUID for similarity/FBT recommendations"},
+            "customer_id": {"type": "string", "description": "Customer UUID for personalised recommendations"},
+            "limit": {"type": "integer", "description": "Maximum number of recommendations to return"},
+        },
+        "required": ["action"],
+    },
+    "output_schema": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string"},
+            "metadata": {"type": "object"},
+        },
+    },
+}
+
 import json
 from collections.abc import AsyncGenerator
 from typing import Any

--- a/apps/backend/src/ai/agents/specialized/reconciliation_agent.py
+++ b/apps/backend/src/ai/agents/specialized/reconciliation_agent.py
@@ -5,6 +5,29 @@ Uses fuzzy matching and pattern learning to suggest POS transaction matches
 for bank feed entries with improved accuracy.
 """
 
+AGENT_CARD = {
+    "name": "reconciliation_agent",
+    "display_name": "Reconciliation Agent",
+    "description": "AI-powered bank feed reconciliation using fuzzy matching and pattern learning to suggest POS transaction matches with confidence scoring",
+    "version": "1.0.0",
+    "capabilities": ["bank_reconciliation", "fuzzy_matching", "confidence_scoring", "pattern_learning", "pos_matching"],
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "feed_id": {"type": "string", "description": "Bank feed UUID to generate match suggestions for"},
+            "max_suggestions": {"type": "integer", "description": "Maximum number of match suggestions to return (default: 3)"},
+        },
+        "required": ["feed_id"],
+    },
+    "output_schema": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string"},
+            "metadata": {"type": "object"},
+        },
+    },
+}
+
 from datetime import timedelta
 from decimal import Decimal
 from uuid import UUID

--- a/apps/backend/src/ai/agents/specialized/search_agent.py
+++ b/apps/backend/src/ai/agents/specialized/search_agent.py
@@ -4,6 +4,32 @@ Search Agent for intelligent product search.
 Orchestrates semantic search using embeddings and multi-language support.
 """
 
+AGENT_CARD = {
+    "name": "search_agent",
+    "display_name": "Search Agent",
+    "description": "Orchestrates intelligent product search using semantic embeddings and multi-language support with hybrid keyword and vector search",
+    "version": "1.0.0",
+    "capabilities": ["semantic_search", "product_search", "keyword_search", "hybrid_search", "multi_language_search", "search_analytics"],
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Search query string"},
+            "language": {"type": "string", "description": "Query language (default: en)"},
+            "limit": {"type": "integer", "description": "Maximum number of results to return"},
+            "search_mode": {"type": "string", "enum": ["semantic", "keyword", "hybrid"], "description": "Search algorithm to use"},
+            "filters": {"type": "object", "description": "Optional filters (category, price range, stock status)"},
+        },
+        "required": ["query"],
+    },
+    "output_schema": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string"},
+            "metadata": {"type": "object"},
+        },
+    },
+}
+
 import json
 from collections.abc import AsyncGenerator
 from typing import Any

--- a/apps/backend/src/ai/agents/specialized/staff_copilot_agent.py
+++ b/apps/backend/src/ai/agents/specialized/staff_copilot_agent.py
@@ -1,5 +1,34 @@
 """Staff Copilot Agent — answers operational ERP/CRM queries for staff."""
 
+AGENT_CARD = {
+    "name": "staff_copilot_agent",
+    "display_name": "Staff Copilot Agent",
+    "description": "Answers staff queries about orders, inventory, customers, and operations — provides order summaries, customer profiles, and next-action suggestions",
+    "version": "1.0.0",
+    "capabilities": ["staff_query", "order_summary", "customer_summary", "next_action_suggestion", "erp_assistant"],
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["general_query", "summarise_order", "summarise_customer", "suggest_next_action"],
+                "description": "Type of staff assistance to provide",
+            },
+            "query": {"type": "string", "description": "Natural language question or request"},
+            "order_id": {"type": "string", "description": "Order UUID for order summary requests"},
+            "customer_id": {"type": "string", "description": "Customer UUID for customer summary requests"},
+        },
+        "required": ["action"],
+    },
+    "output_schema": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string"},
+            "metadata": {"type": "object"},
+        },
+    },
+}
+
 import os
 from collections.abc import AsyncGenerator
 from typing import Any

--- a/apps/backend/src/ai/agents/specialized/task_executor_agent.py
+++ b/apps/backend/src/ai/agents/specialized/task_executor_agent.py
@@ -1,5 +1,33 @@
 """Task executor agent with user confirmation flow for write operations."""
 
+AGENT_CARD = {
+    "name": "task_executor_agent",
+    "display_name": "Task Executor Agent",
+    "description": "Executes ERP write operations with mandatory user confirmation flow — creates orders, updates records, and processes bulk actions safely",
+    "version": "1.0.0",
+    "capabilities": ["task_execution", "action_execution", "user_confirmation", "write_operations"],
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "action_type": {
+                "type": "string",
+                "enum": ["create_order", "update_customer", "bulk_update", "send_email", "create_purchase_order"],
+                "description": "Type of write operation to execute",
+            },
+            "payload": {"type": "object", "description": "Action-specific data payload"},
+            "confirmation_token": {"type": "string", "description": "User confirmation token (required for write operations)"},
+        },
+        "required": ["action_type", "payload"],
+    },
+    "output_schema": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string"},
+            "metadata": {"type": "object"},
+        },
+    },
+}
+
 import secrets
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime, timedelta

--- a/apps/backend/src/ai/agents/specialized/testing_agent.py
+++ b/apps/backend/src/ai/agents/specialized/testing_agent.py
@@ -4,6 +4,35 @@ Testing Agent for autonomous test generation and execution.
 Generates and runs tests for code validation.
 """
 
+AGENT_CARD = {
+    "name": "testing_agent",
+    "display_name": "Testing Agent",
+    "description": "Generates and executes unit and integration tests for code validation — includes coverage analysis and failure root-cause analysis",
+    "version": "1.0.0",
+    "capabilities": ["test_generation", "unit_tests", "integration_tests", "test_execution", "coverage_analysis", "failure_analysis"],
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["generate_tests", "run_tests", "analyze_coverage", "analyze_failure"],
+                "description": "Testing action to perform",
+            },
+            "target_file": {"type": "string", "description": "Path to the file to generate tests for"},
+            "test_type": {"type": "string", "enum": ["unit", "integration", "e2e"], "description": "Type of tests to generate"},
+            "failure_output": {"type": "string", "description": "Test failure output to analyze"},
+        },
+        "required": ["action"],
+    },
+    "output_schema": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string"},
+            "metadata": {"type": "object"},
+        },
+    },
+}
+
 import json
 import subprocess
 from collections.abc import AsyncGenerator

--- a/apps/backend/src/api/routes/agents_monitor.py
+++ b/apps/backend/src/api/routes/agents_monitor.py
@@ -2,16 +2,59 @@
 
 Provides read-only visibility into agent execution stats, task history,
 performance trends, and learning insights for the Agents Dashboard.
+
+Also exposes AgentCard discovery endpoints for orchestration layer routing.
 """
 
 from datetime import UTC, datetime, timedelta
+from importlib import import_module
 
 import structlog
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, HTTPException, Query
 
 logger = structlog.get_logger(__name__)
 
 router = APIRouter(prefix="/api/agents", tags=["Agent Monitoring"])
+
+# ---------------------------------------------------------------------------
+# AgentCard registry — maps agent name -> module path
+# ---------------------------------------------------------------------------
+
+_AGENT_MODULES: dict[str, str] = {
+    "anomaly_detection_agent": "src.ai.agents.specialized.anomaly_detection_agent",
+    "autonomous_ops_agent": "src.ai.agents.specialized.autonomous_ops_agent",
+    "cin7_anomaly_agent": "src.ai.agents.specialized.cin7_anomaly_agent",
+    "cin7_forecasting_agent": "src.ai.agents.specialized.cin7_forecasting_agent",
+    "cin7_shadow_agent": "src.ai.agents.specialized.cin7_shadow_agent",
+    "development_agent": "src.ai.agents.specialized.development_agent",
+    "document_parser_agent": "src.ai.agents.specialized.document_parser_agent",
+    "form_autofill_agent": "src.ai.agents.specialized.form_autofill_agent",
+    "inventory_forecasting_agent": "src.ai.agents.specialized.inventory_forecasting_agent",
+    "marketing_agent": "src.ai.agents.specialized.marketing_agent",
+    "pricing_agent": "src.ai.agents.specialized.pricing_agent",
+    "procurement_agent": "src.ai.agents.specialized.procurement_agent",
+    "project_intelligence_agent": "src.ai.agents.specialized.project_intelligence_agent",
+    "query_agent": "src.ai.agents.specialized.query_agent",
+    "recommendation_agent": "src.ai.agents.specialized.recommendation_agent",
+    "reconciliation_agent": "src.ai.agents.specialized.reconciliation_agent",
+    "search_agent": "src.ai.agents.specialized.search_agent",
+    "staff_copilot_agent": "src.ai.agents.specialized.staff_copilot_agent",
+    "task_executor_agent": "src.ai.agents.specialized.task_executor_agent",
+    "testing_agent": "src.ai.agents.specialized.testing_agent",
+}
+
+
+def _load_agent_card(agent_name: str) -> dict | None:
+    """Dynamically load AGENT_CARD from an agent module."""
+    module_path = _AGENT_MODULES.get(agent_name)
+    if not module_path:
+        return None
+    try:
+        mod = import_module(module_path)
+        return getattr(mod, "AGENT_CARD", None)
+    except Exception as exc:
+        logger.warning("agent_card_load_failed", agent=agent_name, error=str(exc))
+        return None
 
 
 def _get_collector():
@@ -216,3 +259,39 @@ async def get_agent_insights() -> dict:
             })
 
     return {"insights": insights}
+
+
+# ─── AgentCard discovery ──────────────────────────────────────────────────────
+
+@router.get("/cards")
+async def list_agent_cards() -> list[dict]:
+    """Return AgentCard metadata for all registered AI agents.
+
+    Enables orchestration-layer agent discovery, capability-based routing,
+    and composition planning.
+    """
+    cards = []
+    for agent_name in _AGENT_MODULES:
+        card = _load_agent_card(agent_name)
+        if card is not None:
+            cards.append(card)
+    return sorted(cards, key=lambda c: c.get("name", ""))
+
+
+@router.get("/cards/{agent_name}")
+async def get_agent_card(agent_name: str) -> dict:
+    """Return the AgentCard metadata for a specific agent by name.
+
+    Args:
+        agent_name: Snake-case agent name (e.g. ``marketing_agent``).
+
+    Raises:
+        404 if the agent does not exist or has no AGENT_CARD.
+    """
+    card = _load_agent_card(agent_name)
+    if card is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Agent '{agent_name}' not found or has no AGENT_CARD",
+        )
+    return card


### PR DESCRIPTION
## Summary

- Added `AGENT_CARD` dict to all 20 specialized AI agents in `apps/backend/src/ai/agents/specialized/` with accurate `name`, `display_name`, `description`, `version`, `capabilities`, `input_schema`, and `output_schema` fields derived from each agent's actual implementation
- Added `GET /api/agents/cards` endpoint returning all AgentCard dicts for orchestration-layer agent discovery and capability-based routing
- Added `GET /api/agents/cards/{agent_name}` endpoint for single-agent card lookup (404 on unknown agents)
- Both endpoints added to the existing `agents_monitor` router (prefix `/api/agents`, already registered in `main.py`)

## Agents covered (20 total)

`anomaly_detection_agent`, `autonomous_ops_agent`, `cin7_anomaly_agent`, `cin7_forecasting_agent`, `cin7_shadow_agent`, `development_agent`, `document_parser_agent`, `form_autofill_agent`, `inventory_forecasting_agent`, `marketing_agent`, `pricing_agent`, `procurement_agent`, `project_intelligence_agent`, `query_agent`, `recommendation_agent`, `reconciliation_agent`, `search_agent`, `staff_copilot_agent`, `task_executor_agent`, `testing_agent`

## Test plan

- [ ] `GET /api/agents/cards` returns a list of 20 dicts, each with `name`, `display_name`, `description`, `version`, `capabilities`, `input_schema`, `output_schema`
- [ ] `GET /api/agents/cards/marketing_agent` returns the marketing agent card
- [ ] `GET /api/agents/cards/nonexistent` returns HTTP 404
- [ ] All 20 agent files parse without `SyntaxError` (verified via AST check — 20/20 OK)
- [ ] Existing `/api/agents/stats`, `/api/agents/list`, `/api/agents/tasks/recent` endpoints unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)