### PR TITLE
feat: BAS report + POS refund workflow with Xero credit note (UNI-1816, UNI-1854)

### DIFF
--- a/apps/backend/src/api/main.py
+++ b/apps/backend/src/api/main.py
@@ -56,6 +56,7 @@ from .routes import (
     google_ai,
     health,
     inventory,
+    bas_report,  # BAS report generation (UNI-1816)
     invoice_payments,  # Invoice payments for UNI-173
     invoices,  # Invoices for UNI-173
     jobs,
@@ -449,6 +450,8 @@ app.include_router(activities.router, tags=["Activities"])  # CRM Activities
 app.include_router(customer_orders.router, tags=["Customer Orders"])
 app.include_router(orders.router, tags=["Orders"])
 app.include_router(quotes.router, tags=["Quotes"])
+# BAS Report (UNI-1816)
+app.include_router(bas_report.router, tags=["BAS Report"])
 # Invoicing & Payments (UNI-173)
 app.include_router(invoices.router, tags=["Invoices"])
 app.include_router(invoice_payments.router, tags=["Invoice Payments"])

--- a/apps/backend/src/api/main.py
+++ b/apps/backend/src/api/main.py
@@ -35,6 +35,7 @@ from .routes import (
     audit_trail,  # Entity-level audit trail
     backorders,
     bank_feeds,
+    bas_report,  # BAS report generation (UNI-1816)
     billing,  # Billing and payment endpoints (Phase 2 Batch 2A)
     boardroom,  # Boardroom AI session endpoint (4x daily CRON)
     certifications,  # IICRC/ISSA/ARCR certification tracking (Sprint 2)
@@ -56,7 +57,6 @@ from .routes import (
     google_ai,
     health,
     inventory,
-    bas_report,  # BAS report generation (UNI-1816)
     invoice_payments,  # Invoice payments for UNI-173
     invoices,  # Invoices for UNI-173
     jobs,

--- a/apps/backend/src/api/routes/bas_report.py
+++ b/apps/backend/src/api/routes/bas_report.py
@@ -1,0 +1,125 @@
+"""BAS (Business Activity Statement) report endpoint."""
+from datetime import UTC, date, datetime
+from decimal import Decimal
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.api.deps import get_current_user
+from src.config.database import get_async_db
+from src.db.models import User
+from src.db.models.invoicing import Invoice
+from src.db.pos_models import POSTransaction
+
+router = APIRouter(prefix="/api/bas-report", tags=["BAS Report"])
+
+# Australian quarter date ranges (month boundaries, inclusive)
+QUARTER_RANGES: dict[int, tuple[tuple[int, int], tuple[int, int]]] = {
+    1: ((1, 1), (3, 31)),
+    2: ((4, 1), (6, 30)),
+    3: ((7, 1), (9, 30)),
+    4: ((10, 1), (12, 31)),
+}
+
+
+class BASReport(BaseModel):
+    quarter: int
+    year: int
+    period_start: date
+    period_end: date
+    g1_total_sales: Decimal
+    g3_gst_free_sales: Decimal
+    field_1a_gst_on_sales: Decimal
+    g10_capital_purchases: Decimal
+    field_1b_gst_on_purchases: Decimal
+    net_gst_payable: Decimal
+    pos_refund_adjustments: Decimal
+    pos_refund_gst: Decimal
+    adjusted_gst_payable: Decimal
+    invoice_count: int
+    pos_refund_count: int
+    generated_at: datetime
+
+
+@router.get("", response_model=BASReport)
+async def get_bas_report(
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_async_db)],
+    quarter: int = Query(..., ge=1, le=4, description="Quarter (1–4)"),
+    year: int = Query(..., ge=2000, le=2100, description="Calendar year"),
+) -> BASReport:
+    """Compute Australian BAS figures for the given quarter and year."""
+    if quarter not in QUARTER_RANGES:
+        raise HTTPException(status_code=400, detail="Quarter must be between 1 and 4.")
+
+    (start_month, start_day), (end_month, end_day) = QUARTER_RANGES[quarter]
+    period_start = date(year, start_month, start_day)
+    period_end = date(year, end_month, end_day)
+
+    # --- Invoice aggregates ---
+    invoice_result = await db.execute(
+        select(
+            func.coalesce(func.sum(Invoice.total_amount), 0).label("g1"),
+            func.coalesce(func.sum(Invoice.tax_amount), 0).label("field_1a"),
+            func.count(Invoice.id).label("invoice_count"),
+        ).where(
+            Invoice.status.in_(["sent", "partial", "paid"]),
+            Invoice.invoice_date >= period_start,
+            Invoice.invoice_date <= period_end,
+        )
+    )
+    inv_row = invoice_result.one()
+    g1_total_sales = Decimal(str(inv_row.g1))
+    field_1a_gst_on_sales = Decimal(str(inv_row.field_1a))
+    invoice_count: int = inv_row.invoice_count
+
+    # --- POS refund aggregates ---
+    pos_result = await db.execute(
+        select(
+            func.coalesce(func.sum(POSTransaction.amount), 0).label("refund_total"),
+            func.count(POSTransaction.id).label("refund_count"),
+        ).where(
+            POSTransaction.transaction_type == "refund",
+            POSTransaction.payment_status == "refunded",
+            func.date(POSTransaction.created_at) >= period_start,
+            func.date(POSTransaction.created_at) <= period_end,
+        )
+    )
+    pos_row = pos_result.one()
+    pos_refund_adjustments = Decimal(str(pos_row.refund_total))
+    pos_refund_count: int = pos_row.refund_count
+
+    # GST included in refund amount (tax fraction = 10/110)
+    pos_refund_gst = (pos_refund_adjustments * Decimal("10") / Decimal("110")).quantize(
+        Decimal("0.01")
+    )
+
+    # Placeholder fields
+    g3_gst_free_sales = Decimal("0.00")
+    g10_capital_purchases = Decimal("0.00")
+    field_1b_gst_on_purchases = Decimal("0.00")
+
+    net_gst_payable = field_1a_gst_on_sales - field_1b_gst_on_purchases
+    adjusted_gst_payable = net_gst_payable - pos_refund_gst
+
+    return BASReport(
+        quarter=quarter,
+        year=year,
+        period_start=period_start,
+        period_end=period_end,
+        g1_total_sales=g1_total_sales,
+        g3_gst_free_sales=g3_gst_free_sales,
+        field_1a_gst_on_sales=field_1a_gst_on_sales,
+        g10_capital_purchases=g10_capital_purchases,
+        field_1b_gst_on_purchases=field_1b_gst_on_purchases,
+        net_gst_payable=net_gst_payable,
+        pos_refund_adjustments=pos_refund_adjustments,
+        pos_refund_gst=pos_refund_gst,
+        adjusted_gst_payable=adjusted_gst_payable,
+        invoice_count=invoice_count,
+        pos_refund_count=pos_refund_count,
+        generated_at=datetime.now(UTC),
+    )

--- a/apps/backend/src/api/routes/pos_transactions.py
+++ b/apps/backend/src/api/routes/pos_transactions.py
@@ -13,6 +13,7 @@ from decimal import Decimal
 from typing import Annotated
 from uuid import UUID
 
+import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 from sqlalchemy import func, or_, select
@@ -29,6 +30,7 @@ from src.db.pos_models import (
 )
 from src.services.sse_service import sse_service
 
+logger = structlog.get_logger(__name__)
 router = APIRouter(prefix="/api/pos", tags=["POS"])
 
 
@@ -875,3 +877,129 @@ async def bulk_create_xero_invoices(
             failed=0,
             errors=[{"error": f"Failed to create Xero invoices: {str(e)}"}],
         )
+
+
+# ============================================================
+# REFUND ENDPOINT
+# ============================================================
+
+
+class POSRefundRequest(BaseModel):
+    """Request body for issuing a POS refund."""
+
+    amount: Decimal = Field(..., gt=0)
+    reason: str = Field(..., min_length=3, max_length=500)
+    push_to_xero: bool = True
+
+
+@router.post(
+    "/transactions/{transaction_id}/refund",
+    response_model=POSTransactionResponse,
+    status_code=201,
+)
+async def refund_pos_transaction(
+    transaction_id: UUID,
+    data: POSRefundRequest,
+    db: Annotated[AsyncSession, Depends(get_async_db)],
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> POSTransactionResponse:
+    """Issue a refund for a captured POS sale and optionally push a Xero credit note."""
+    # 1. Fetch original transaction
+    result = await db.execute(select(POSTransaction).where(POSTransaction.id == transaction_id))
+    original = result.scalar_one_or_none()
+    if not original:
+        raise HTTPException(status_code=404, detail="Transaction not found")
+
+    # 2. Validate transaction type and status
+    if original.transaction_type != "sale":
+        raise HTTPException(status_code=422, detail="Only 'sale' transactions can be refunded")
+    if original.payment_status not in ("captured", "completed"):
+        raise HTTPException(
+            status_code=422,
+            detail=f"Transaction payment_status must be 'captured' or 'completed', got '{original.payment_status}'",
+        )
+
+    # 3. Validate refund amount
+    if data.amount > original.amount:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Refund amount {data.amount} exceeds original transaction amount {original.amount}",
+        )
+
+    # 4. Create refund transaction
+    refund_txn = POSTransaction(
+        transaction_number=f"REF-{original.transaction_number}",
+        transaction_type="refund",
+        amount=data.amount,
+        payment_method=original.payment_method,
+        payment_status="refunded",
+        location_code=original.location_code,
+        terminal_id=original.terminal_id,
+        order_id=original.order_id,
+        currency=original.currency,
+        reconciliation_status="pending",
+    )
+    db.add(refund_txn)
+
+    # 5. Update original transaction status
+    original.payment_status = "refunded"
+
+    # 6. Commit
+    await db.commit()
+    await db.refresh(refund_txn)
+
+    # 7. Optionally push Xero credit note (non-blocking)
+    if data.push_to_xero and original.xero_invoice_id is not None:
+        try:
+            from src.integrations.xero.auth import XeroAuth
+            from src.integrations.xero.client import XeroClient
+            from src.integrations.xero.credit_notes import push_credit_note
+
+            organization_id = getattr(current_user, "organization_id", None)
+            if organization_id:
+                xero_auth = XeroAuth()
+                connection = await xero_auth.get_active_connection(db, organization_id)
+                if connection:
+                    xero_client = XeroClient(
+                        access_token=connection.access_token,
+                        tenant_id=connection.tenant_id,
+                    )
+                    try:
+                        await push_credit_note(
+                            xero_client=xero_client,
+                            contact_id=original.xero_invoice_id,
+                            amount=data.amount,
+                            description=data.reason,
+                            reference=refund_txn.transaction_number,
+                        )
+                    finally:
+                        await xero_client.close()
+        except Exception as exc:
+            logger.warning(
+                "Failed to push credit note to Xero (refund still created)",
+                transaction_id=str(original.id),
+                refund_transaction_number=refund_txn.transaction_number,
+                error=str(exc),
+            )
+
+    # 8. Return refund transaction
+    return POSTransactionResponse(
+        id=refund_txn.id,
+        transaction_number=refund_txn.transaction_number,
+        order_id=refund_txn.order_id,
+        terminal_id=refund_txn.terminal_id,
+        sales_staff_id=refund_txn.sales_staff_id,
+        location_code=refund_txn.location_code,
+        resolved_location_code=refund_txn.resolved_location_code,
+        transaction_type=refund_txn.transaction_type,
+        payment_method=refund_txn.payment_method,
+        amount=refund_txn.amount,
+        currency=refund_txn.currency,
+        payment_status=refund_txn.payment_status,
+        payment_gateway_ref=refund_txn.payment_gateway_ref,
+        reconciliation_status=refund_txn.reconciliation_status,
+        bank_statement_ref=refund_txn.bank_statement_ref,
+        xero_invoice_id=refund_txn.xero_invoice_id,
+        created_at=refund_txn.created_at,
+        updated_at=refund_txn.updated_at,
+    )

--- a/apps/backend/src/integrations/xero/credit_notes.py
+++ b/apps/backend/src/integrations/xero/credit_notes.py
@@ -1,0 +1,67 @@
+"""Xero credit note integration for POS refunds."""
+
+from datetime import UTC, datetime
+
+import structlog
+
+from src.integrations.xero.client import XeroClient
+
+logger = structlog.get_logger(__name__)
+
+
+async def push_credit_note(
+    xero_client: XeroClient,
+    contact_id: str,
+    amount: float | str,
+    description: str,
+    reference: str,
+) -> str:
+    """Create an ACCREC credit note in Xero and return its CreditNoteID.
+
+    Args:
+        xero_client: Authenticated XeroClient instance.
+        contact_id: Xero ContactID to apply the credit note to.
+        amount: Refund amount (positive value).
+        description: Line-item description.
+        reference: Internal reference (e.g. refund transaction number).
+
+    Returns:
+        The CreditNoteID string from Xero.
+
+    Raises:
+        XeroAPIError: If the API request fails.
+        ValueError: If Xero returns an empty response.
+    """
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    payload = {
+        "CreditNotes": [
+            {
+                "Type": "ACCREC",
+                "Contact": {"ContactID": contact_id},
+                "Date": today,
+                "DueDate": today,
+                "Status": "AUTHORISED",
+                "Reference": reference,
+                "LineItems": [
+                    {
+                        "Description": description,
+                        "Quantity": "1.00",
+                        "UnitAmount": str(amount),
+                        "AccountCode": "200",
+                        "TaxType": "OUTPUT2",
+                    }
+                ],
+            }
+        ]
+    }
+
+    logger.info("Pushing credit note to Xero", reference=reference, amount=amount)
+    result = await xero_client._make_request("POST", "/CreditNotes", data=payload)
+
+    credit_notes = result.get("CreditNotes", [])
+    if not credit_notes:
+        raise ValueError("No CreditNote returned from Xero")
+
+    credit_note_id = credit_notes[0].get("CreditNoteID")
+    logger.info("Credit note created in Xero", credit_note_id=credit_note_id)
+    return credit_note_id


### PR DESCRIPTION
## Summary

- **UNI-1816** — `GET /api/bas-report?quarter=N&year=YYYY` aggregates GST figures for the Australian quarter: G1 total sales, 1A GST collected, POS refund adjustments, and adjusted net payable. Placeholders for G3/G10/1B until purchase GST is tracked.
- **UNI-1854** — `POST /api/pos/transactions/{id}/refund` creates a typed refund row, updates original payment status to `refunded`, and optionally pushes an ACCREC credit note to Xero (non-blocking on Xero failure).
- New `integrations/xero/credit_notes.py` — `push_credit_note()` builds the Xero payload with `TaxType: OUTPUT2` and returns the CreditNote ID.

## Test plan

- [ ] `GET /api/bas-report?quarter=1&year=2026` returns valid BASReport JSON with correct quarter date range Jan 1 – Mar 31
- [ ] Invoices with status `draft` are excluded from G1/1A totals
- [ ] POS refunds with `payment_status != refunded` are excluded from adjustments
- [ ] `POST /api/pos/transactions/{id}/refund` with amount > original returns 422
- [ ] Refunding a non-sale or non-captured transaction returns 422
- [ ] Successful refund creates new row with `transaction_type=refund`, updates original to `refunded`
- [ ] `push_to_xero=false` skips Xero credit note push
- [ ] Xero push failure does not block refund response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New BAS Report endpoint generates quarterly Australian Business Activity Statement reports with computed sales totals, GST figures, invoice counts, and refund transaction summaries.
  * New POS refund endpoint enables refunding completed point-of-sale transactions with optional automatic Xero credit note creation and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->