### PR TITLE
feat: volume pricing, Xero PO bills, shipping webhook sig, quote expiry+search, audit retention, EOD cash (UNI-1815/1843/1849/1852/1853/1864/1870/1875)

### DIFF
--- a/apps/backend/src/api/main.py
+++ b/apps/backend/src/api/main.py
@@ -60,6 +60,7 @@ from .routes import (
     invoices,  # Invoices for UNI-173
     jobs,
     orders,
+    eod_reconciliation,  # EOD cash reconciliation (UNI-1849)
     pos_transactions,
     prd,
     pricing,  # Customer trade pricing tiers (Sprint 2)
@@ -69,6 +70,7 @@ from .routes import (
     public_stats,  # Public landing page stats (no auth required)
     purchase_orders,
     quotes,
+    xero_tracking,
     reconciliation,
     reconciliation_dashboard,
     service_requests,
@@ -493,6 +495,7 @@ app.include_router(purchase_orders.router, tags=["Purchase Orders"])
 app.include_router(procurement.router, tags=["Procurement"])
 # Shipment tracking router
 app.include_router(shipments.router, tags=["Shipment Tracking"])
+app.include_router(shipments.webhook_router, tags=["Shipping Webhooks"])
 # Container tracking and backorder management
 app.include_router(containers.router, tags=["Container Tracking"])
 app.include_router(backorders.router, tags=["Backorder Management"])
@@ -574,6 +577,7 @@ app.include_router(translations.router, tags=["Translation Management"])
 
 # Integration routers (✅ ALL IMPLEMENTED)
 app.include_router(xero.router, prefix="/api", tags=["Xero Integration"])
+app.include_router(xero_tracking.router, tags=["Xero Tracking"])
 app.include_router(shopify.router, tags=["Shopify Integration"])
 app.include_router(shopify_theme.router, tags=["Shopify Theme APIs"])
 app.include_router(sendgrid.router, tags=["SendGrid Integration"])
@@ -765,6 +769,7 @@ app.include_router(pos_transactions.router, tags=["POS System"])
 app.include_router(bank_feeds.router, tags=["Bank Feeds"])
 app.include_router(reconciliation.router, tags=["Reconciliation"])
 app.include_router(reconciliation_dashboard.router, tags=["Reconciliation Dashboard"])
+app.include_router(eod_reconciliation.router, tags=["POS EOD Reconciliation"])  # UNI-1849
 
 # Monitoring routers (system alerts, business metrics, performance)
 try:

--- a/apps/backend/src/api/main.py
+++ b/apps/backend/src/api/main.py
@@ -52,6 +52,7 @@ from .routes import (
     demo_dashboard,
     demo_lists,
     email_audit,  # Email audit trail for GDPR compliance (ISS-037)
+    eod_reconciliation,  # EOD cash reconciliation (UNI-1849)
     equipment_lifecycle,  # Equipment serial numbers + warranty tracking (Sprint 2)
     google_ai,
     health,
@@ -60,7 +61,6 @@ from .routes import (
     invoices,  # Invoices for UNI-173
     jobs,
     orders,
-    eod_reconciliation,  # EOD cash reconciliation (UNI-1849)
     pos_transactions,
     prd,
     pricing,  # Customer trade pricing tiers (Sprint 2)
@@ -70,7 +70,6 @@ from .routes import (
     public_stats,  # Public landing page stats (no auth required)
     purchase_orders,
     quotes,
-    xero_tracking,
     reconciliation,
     reconciliation_dashboard,
     service_requests,
@@ -81,6 +80,7 @@ from .routes import (
     translations,
     warehouse,  # Warehouse operations feed (UNI-1251)
     webhooks,
+    xero_tracking,
 )
 from .routes import (
     settings as settings_routes,  # Account and company settings

--- a/apps/backend/src/api/routes/audit_trail.py
+++ b/apps/backend/src/api/routes/audit_trail.py
@@ -1,12 +1,13 @@
 """Audit trail API — entity-level change history."""
-from datetime import datetime
+import os
+from datetime import UTC, datetime, timedelta
 from typing import Annotated
 from uuid import UUID
 
 import structlog
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.routes.demo_auth import get_current_user
@@ -102,6 +103,35 @@ async def list_audit_logs(
         page_size=page_size,
         total_pages=(total + page_size - 1) // page_size,
     )
+
+
+@router.get("/retention-policy")
+async def get_retention_policy() -> dict:
+    """Return the current audit log retention and archive policy from env vars."""
+    return {
+        "retention_days": int(os.getenv("AUDIT_RETENTION_DAYS", "2555")),
+        "archive_after_days": int(os.getenv("AUDIT_ARCHIVE_AFTER_DAYS", "365")),
+    }
+
+
+@router.delete("/purge-expired")
+async def purge_expired_audit_logs(
+    db: Annotated[AsyncSession, Depends(get_async_db)],
+    current_user: Annotated[dict, Depends(get_current_user)],
+) -> dict:
+    """Delete AuditLog entries older than AUDIT_RETENTION_DAYS. Requires admin role."""
+    if current_user.get("role") != "admin":
+        raise HTTPException(status_code=403, detail="Admin role required")
+
+    retention_days = int(os.getenv("AUDIT_RETENTION_DAYS", "2555"))
+    cutoff = datetime.now(UTC) - timedelta(days=retention_days)
+
+    result = await db.execute(delete(AuditLog).where(AuditLog.created_at < cutoff))
+    await db.commit()
+
+    purged_count = result.rowcount
+    logger.info("Audit logs purged", purged_count=purged_count, retention_days=retention_days, cutoff=cutoff.isoformat())
+    return {"purged_count": purged_count}
 
 
 @router.get("/{entity_type}/{entity_id}", response_model=list[AuditLogResponse])

--- a/apps/backend/src/api/routes/eod_reconciliation.py
+++ b/apps/backend/src/api/routes/eod_reconciliation.py
@@ -1,0 +1,109 @@
+"""End-of-day cash reconciliation endpoints (UNI-1849)."""
+from datetime import date
+from decimal import Decimal
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.api.deps import get_current_user
+from src.config.database import get_async_db
+from src.db.models import User
+from src.db.pos_models import POSTransaction
+
+router = APIRouter(prefix="/api/pos", tags=["POS EOD Reconciliation"])
+
+_CASH_STATUSES = ("captured", "completed")
+
+
+class EODReconciliationRequest(BaseModel):
+    location_code: str
+    date: date
+    counted_cash: Decimal
+
+
+class EODReconciliationResponse(BaseModel):
+    date: date
+    location_code: str
+    system_cash_total: Decimal
+    counted_cash: Decimal
+    variance: Decimal
+    transaction_count: int
+    status: str  # "balanced" | "discrepancy"
+
+
+class EODSummaryRow(BaseModel):
+    date: date
+    location_code: str
+    system_cash_total: Decimal
+    transaction_count: int
+
+
+@router.post("/eod-reconciliation", response_model=EODReconciliationResponse)
+async def eod_reconciliation(
+    payload: EODReconciliationRequest,
+    db: Annotated[AsyncSession, Depends(get_async_db)],
+    _: Annotated[User, Depends(get_current_user)],
+) -> EODReconciliationResponse:
+    """Compare system cash totals against counted cash for a location and date."""
+    result = await db.execute(
+        select(
+            func.coalesce(func.sum(POSTransaction.amount), Decimal("0")).label("total"),
+            func.count(POSTransaction.id).label("count"),
+        ).where(
+            POSTransaction.location_code == payload.location_code,
+            func.date(POSTransaction.created_at) == payload.date,
+            POSTransaction.payment_method == "cash",
+            POSTransaction.payment_status.in_(_CASH_STATUSES),
+        )
+    )
+    row = result.one()
+    system_total = Decimal(str(row.total)).quantize(Decimal("0.01"))
+    variance = (payload.counted_cash - system_total).quantize(Decimal("0.01"))
+    return EODReconciliationResponse(
+        date=payload.date,
+        location_code=payload.location_code,
+        system_cash_total=system_total,
+        counted_cash=payload.counted_cash.quantize(Decimal("0.01")),
+        variance=variance,
+        transaction_count=int(row.count),
+        status="balanced" if abs(variance) < Decimal("0.01") else "discrepancy",
+    )
+
+
+@router.get("/eod-reconciliation/summary", response_model=list[EODSummaryRow])
+async def eod_reconciliation_summary(
+    db: Annotated[AsyncSession, Depends(get_async_db)],
+    location_code: str = Query(...),
+    date_from: date = Query(...),
+    date_to: date = Query(...),
+) -> list[EODSummaryRow]:
+    """Aggregate daily cash totals for a location over a date range."""
+    tx_date = func.date(POSTransaction.created_at).label("tx_date")
+    result = await db.execute(
+        select(
+            tx_date,
+            func.coalesce(func.sum(POSTransaction.amount), Decimal("0")).label("total"),
+            func.count(POSTransaction.id).label("count"),
+        )
+        .where(
+            POSTransaction.location_code == location_code,
+            func.date(POSTransaction.created_at) >= date_from,
+            func.date(POSTransaction.created_at) <= date_to,
+            POSTransaction.payment_method == "cash",
+            POSTransaction.payment_status.in_(_CASH_STATUSES),
+        )
+        .group_by(tx_date)
+        .order_by(tx_date)
+    )
+    return [
+        EODSummaryRow(
+            date=r.tx_date,
+            location_code=location_code,
+            system_cash_total=Decimal(str(r.total)).quantize(Decimal("0.01")),
+            transaction_count=int(r.count),
+        )
+        for r in result.all()
+    ]

--- a/apps/backend/src/api/routes/pricing.py
+++ b/apps/backend/src/api/routes/pricing.py
@@ -2,6 +2,7 @@
 
 Manages Bronze/Silver/Gold/Platinum pricing tiers and their
 assignment to customers, enabling discounted pricing for trade accounts.
+Also provides volume/quantity-break pricing (UNI-1843).
 """
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -14,14 +15,111 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from src.api.deps import get_current_user
 from src.config.database import get_async_db
 from src.db.demo_models import Customer, Product  # noqa: F401 (Customer used for FK check)
+from src.db.models import User
 from src.db.pricing_models import CustomerPricingAssignment, PricingTier
 
 router = APIRouter(prefix="/api/pricing", tags=["Pricing Tiers"])
 
+# In-memory store for volume tiers (no suitable DB model yet — UNI-1843)
+_volume_pricing_store: dict[str, list[dict]] = {}
+
+
+# ─── Volume Pricing Schemas ──────────────────────────────────────────────────
+
+
+class VolumePriceTier(BaseModel):
+    min_quantity: int
+    max_quantity: int | None = None
+    unit_price: Decimal
+
+
+class ProductVolumePricing(BaseModel):
+    product_id: UUID
+    tiers: list[VolumePriceTier]
+
+
+class VolumePriceCalculationResponse(BaseModel):
+    product_id: UUID
+    quantity: int
+    unit_price: Decimal
+    line_total: Decimal
+    tier_applied: str
+
 
 # ─── Pydantic schemas ───────────────────────────────────────────────────────
+
+
+# ─── Volume Pricing Endpoints (UNI-1843) ────────────────────────────────────
+
+
+@router.get("/volume/{product_id}", response_model=ProductVolumePricing | dict)
+async def get_volume_pricing(product_id: UUID) -> ProductVolumePricing | dict:
+    """Return volume/quantity-break tiers for a product."""
+    key = str(product_id)
+    if key not in _volume_pricing_store:
+        return {"product_id": str(product_id), "tiers": [], "note": "not yet configured"}
+    tiers = [VolumePriceTier(**t) for t in _volume_pricing_store[key]]
+    return ProductVolumePricing(product_id=product_id, tiers=tiers)
+
+
+@router.post("/volume/{product_id}")
+async def upsert_volume_pricing(
+    product_id: UUID,
+    payload: ProductVolumePricing,
+    _: Annotated[User, Depends(get_current_user)],
+) -> dict:
+    """Upsert volume/quantity-break tiers for a product (auth required)."""
+    _volume_pricing_store[str(product_id)] = [t.model_dump() for t in payload.tiers]
+    return {"saved": True, "tiers": [t.model_dump() for t in payload.tiers]}
+
+
+@router.get("/calculate/volume", response_model=VolumePriceCalculationResponse)
+async def calculate_volume_price(
+    db: Annotated[AsyncSession, Depends(get_async_db)],
+    product_id: UUID = Query(...),
+    quantity: int = Query(..., ge=1),
+) -> VolumePriceCalculationResponse:
+    """Calculate unit price and line total using volume tiers; falls back to list price."""
+    key = str(product_id)
+    matched_tier: VolumePriceTier | None = None
+
+    if key in _volume_pricing_store:
+        raw_tiers = sorted(_volume_pricing_store[key], key=lambda t: t["min_quantity"])
+        for raw in raw_tiers:
+            t = VolumePriceTier(**raw)
+            if quantity >= t.min_quantity and (t.max_quantity is None or quantity <= t.max_quantity):
+                matched_tier = t
+                break
+
+    if matched_tier:
+        unit_price = matched_tier.unit_price
+        tier_label = (
+            f"{matched_tier.min_quantity}+"
+            if matched_tier.max_quantity is None
+            else f"{matched_tier.min_quantity}–{matched_tier.max_quantity}"
+        )
+    else:
+        # Fall through to standard product price
+        product_result = await db.execute(
+            select(Product).where(Product.id == product_id)  # type: ignore[arg-type]
+        )
+        product = product_result.scalar_one_or_none()
+        if not product:
+            raise HTTPException(status_code=404, detail="Product not found")
+        unit_price = Decimal(str(product.price))
+        tier_label = "standard"
+
+    line_total = (unit_price * quantity).quantize(Decimal("0.01"))
+    return VolumePriceCalculationResponse(
+        product_id=product_id,
+        quantity=quantity,
+        unit_price=unit_price.quantize(Decimal("0.01")),
+        line_total=line_total,
+        tier_applied=tier_label,
+    )
 
 
 class PricingTierCreate(BaseModel):

--- a/apps/backend/src/api/routes/purchase_orders.py
+++ b/apps/backend/src/api/routes/purchase_orders.py
@@ -20,7 +20,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from src.api.deps import get_current_user
+from src.api.middleware.tenant_isolation import CurrentOrganization
 from src.config.database import get_async_db
+from src.config.xero_settings import XeroSettings, get_xero_settings
 from src.db.demo_models import Product
 from src.db.inventory_models import (
     ProductStockByLocation,
@@ -28,6 +30,9 @@ from src.db.inventory_models import (
     PurchaseOrderItem,
     Supplier,
 )
+from src.integrations.xero import get_xero_client
+from src.integrations.xero.auth import XeroAuth
+from src.integrations.xero.bills import push_purchase_order_as_bill
 
 router = APIRouter(prefix="/api/purchase-orders", tags=["Purchase Orders"], dependencies=[Depends(get_current_user)])
 
@@ -642,3 +647,84 @@ async def get_unmatched_po_items(
         items=items,
         total=len(items)
     )
+
+
+# ============================================
+# UNI-1815: Sync Purchase Order to Xero as Bill
+# ============================================
+
+
+def _get_xero_auth_for_po(
+    settings: Annotated[XeroSettings, Depends(get_xero_settings)],
+) -> XeroAuth:
+    return XeroAuth(
+        client_id=settings.client_id,
+        client_secret=settings.client_secret,
+        redirect_uri=settings.redirect_uri,
+        scopes=settings.scopes_list,
+    )
+
+
+@router.post("/{po_id}/sync-to-xero")
+async def sync_purchase_order_to_xero(
+    po_id: UUID,
+    org_id: CurrentOrganization,
+    db: Annotated[AsyncSession, Depends(get_async_db)],
+    xero_auth: Annotated[XeroAuth, Depends(_get_xero_auth_for_po)],
+    settings: Annotated[XeroSettings, Depends(get_xero_settings)],
+) -> dict:
+    """Push a purchase order to Xero as an Accounts Payable bill (ACCPAY invoice)."""
+    result = await db.execute(
+        select(PurchaseOrder)
+        .options(selectinload(PurchaseOrder.items))
+        .where(PurchaseOrder.id == po_id)
+    )
+    po = result.scalar_one_or_none()
+    if not po:
+        raise HTTPException(status_code=404, detail="Purchase order not found")
+
+    supplier_result = await db.execute(select(Supplier).where(Supplier.id == po.supplier_id))
+    supplier = supplier_result.scalar_one_or_none()
+    if not supplier or not supplier.xero_contact_id:
+        raise HTTPException(status_code=400, detail="Supplier has no linked Xero contact ID")
+
+    connection = await xero_auth.get_active_connection(db, org_id)
+    if not connection:
+        raise HTTPException(status_code=400, detail="No active Xero connection for this organisation")
+
+    demo_mode = connection.access_token.startswith("demo_")
+    xero_client = get_xero_client(
+        access_token=connection.access_token,
+        tenant_id=connection.tenant_id,
+        demo_mode=demo_mode,
+    )
+
+    try:
+        po_data = {
+            "supplier_contact_id": supplier.xero_contact_id,
+            "reference": po.po_number,
+            "date": po.order_date.date().isoformat() if po.order_date else datetime.now().date().isoformat(),
+            "due_date": (
+                po.expected_delivery_date.date().isoformat()
+                if po.expected_delivery_date
+                else datetime.now().date().isoformat()
+            ),
+            "line_items": [
+                {
+                    "description": f"Product {item.product_id}",
+                    "quantity": item.quantity,
+                    "unit_amount": float(item.unit_cost),
+                }
+                for item in po.items
+            ],
+        }
+
+        bill_id = await push_purchase_order_as_bill(xero_client, po_data)
+
+        po.xero_purchase_order_id = bill_id
+        po.xero_synced_at = datetime.now()
+        await db.commit()
+    finally:
+        await xero_client.close()
+
+    return {"xero_bill_id": bill_id}

--- a/apps/backend/src/api/routes/quotes.py
+++ b/apps/backend/src/api/routes/quotes.py
@@ -2,12 +2,13 @@
 
 Performance optimized with cache invalidation on writes.
 """
-from datetime import UTC, datetime, time, timedelta
+from datetime import UTC, date, datetime, time, timedelta
+from decimal import Decimal
 from uuid import UUID
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from pydantic import BaseModel
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -89,16 +90,32 @@ async def list_quotes(
     search: str | None = None,
     status: str | None = None,
     customer_id: UUID | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
+    min_amount: Decimal | None = None,
+    max_amount: Decimal | None = None,
+    sort_by: str = Query("created_at", pattern="^(created_at|total|valid_until)$"),
+    sort_order: str = Query("desc", pattern="^(asc|desc)$"),
     db: AsyncSession = Depends(get_async_db),
 ):
     """List quotes with pagination and filters."""
-    # Build query
-    query = select(QuoteModel).options(selectinload(QuoteModel.quote_items))
+    # Build query with customer join for name search
+    query = (
+        select(QuoteModel)
+        .options(selectinload(QuoteModel.quote_items))
+        .join(CustomerModel, QuoteModel.customer_id == CustomerModel.id, isouter=True)
+    )
 
     # Apply filters
     if search:
         search_filter = f"%{search}%"
-        query = query.where(QuoteModel.quote_number.ilike(search_filter))
+        query = query.where(
+            or_(
+                QuoteModel.quote_number.ilike(search_filter),
+                CustomerModel.company_name.ilike(search_filter),
+                CustomerModel.contact_name.ilike(search_filter),
+            )
+        )
 
     if status:
         query = query.where(QuoteModel.status == status)
@@ -106,14 +123,29 @@ async def list_quotes(
     if customer_id:
         query = query.where(QuoteModel.customer_id == customer_id)
 
+    if date_from:
+        query = query.where(func.date(QuoteModel.created_at) >= date_from)
+
+    if date_to:
+        query = query.where(func.date(QuoteModel.created_at) <= date_to)
+
+    if min_amount is not None:
+        query = query.where(QuoteModel.total >= min_amount)
+
+    if max_amount is not None:
+        query = query.where(QuoteModel.total <= max_amount)
+
     # Get total count
     count_query = select(func.count()).select_from(query.subquery())
     result = await db.execute(count_query)
     total = result.scalar_one()
 
+    # Apply sort
+    sort_col = getattr(QuoteModel, sort_by, QuoteModel.created_at)
+    query = query.order_by(sort_col.desc() if sort_order == "desc" else sort_col.asc())
+
     # Apply pagination
     query = query.offset((page - 1) * page_size).limit(page_size)
-    query = query.order_by(QuoteModel.created_at.desc())
 
     # Execute query
     result = await db.execute(query)
@@ -497,6 +529,53 @@ async def update_quote_status(
         for item in quote.quote_items
     ]
     return quote_dict
+
+
+@router.post("/expire-overdue", dependencies=[], status_code=200)
+async def expire_overdue_quotes(db: AsyncSession = Depends(get_async_db)):
+    """Expire all sent quotes whose valid_until date is in the past.
+
+    No auth required — intended for scheduler/cron calls.
+    """
+    today = datetime.now(UTC).date()
+    stmt = (
+        update(QuoteModel)
+        .where(QuoteModel.status == "sent")
+        .where(func.date(QuoteModel.valid_until) < today)
+        .values(status="expired")
+    )
+    result = await db.execute(stmt)
+    await db.commit()
+    expired_count = result.rowcount
+    if expired_count:
+        await invalidate_quote_caches()
+    return {"expired": expired_count}
+
+
+@router.get("/expiring-soon")
+async def get_expiring_soon_quotes(
+    days: int = Query(7, ge=1, le=365),
+    db: AsyncSession = Depends(get_async_db),
+):
+    """Return sent quotes expiring within the next N days (default 7)."""
+    today = datetime.now(UTC).date()
+    cutoff = today + timedelta(days=days)
+    query = (
+        select(QuoteModel)
+        .options(selectinload(QuoteModel.quote_items))
+        .where(QuoteModel.status == "sent")
+        .where(func.date(QuoteModel.valid_until) >= today)
+        .where(func.date(QuoteModel.valid_until) <= cutoff)
+        .order_by(QuoteModel.valid_until.asc())
+    )
+    result = await db.execute(query)
+    quotes = result.scalars().all()
+    items = []
+    for q in quotes:
+        quote_dict = Quote.model_validate(q).model_dump()
+        quote_dict["items"] = [QuoteItem.model_validate(i).model_dump() for i in q.quote_items]
+        items.append(quote_dict)
+    return {"items": items, "count": len(items), "days": days}
 
 
 @router.post("/generate", response_model=Quote, status_code=201)

--- a/apps/backend/src/api/routes/shipments.py
+++ b/apps/backend/src/api/routes/shipments.py
@@ -7,13 +7,16 @@ Provides tracking and management for:
 - Carrier webhook integration for tracking updates
 """
 
+import hashlib
+import hmac
+import json
 import os
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Annotated
 from uuid import UUID
 
 import structlog
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
+from fastapi import APIRouter, Body, Depends, Header, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -668,3 +671,65 @@ async def outbound_tracking_webhook(
     await db.commit()
 
     return {"status": "success", "message": "Tracking event recorded"}
+
+
+# Generic shipping webhook router (no auth dependency — carrier-signed)
+_webhook_router = APIRouter(prefix="/api/webhooks", tags=["Shipping Webhooks"])
+
+
+@_webhook_router.post("/shipping")
+async def shipping_webhook(
+    body: bytes = Body(...),
+    x_shipment_signature: str | None = Header(None),
+    x_shipment_provider: str | None = Header(None, alias="x-shipment-provider"),
+    db: AsyncSession = Depends(get_async_db),
+) -> dict:
+    """
+    Generic shipping webhook with HMAC-SHA256 signature verification.
+
+    Carriers POST delivery/return events here. The endpoint verifies the
+    signature against SHIPPING_WEBHOOK_SECRET before processing.
+    """
+    secret = os.getenv("SHIPPING_WEBHOOK_SECRET", "")
+    if not secret or not x_shipment_signature:
+        logger.warning("Shipping webhook rejected: missing secret or signature")
+        raise HTTPException(status_code=401, detail="Missing webhook signature")
+
+    expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected, x_shipment_signature):
+        logger.warning("Shipping webhook rejected: invalid signature", provider=x_shipment_provider)
+        raise HTTPException(status_code=401, detail="Invalid webhook signature")
+
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="Invalid JSON body")
+
+    event_type: str = payload.get("event_type", "")
+    tracking_number: str = payload.get("tracking_number", "")
+
+    logger.info("Shipping webhook received", event_type=event_type, tracking_number=tracking_number, provider=x_shipment_provider)
+
+    if event_type in ("delivered", "returned"):
+        # Try outbound first, then inbound
+        result = await db.execute(select(OutboundShipment).where(OutboundShipment.tracking_number == tracking_number))
+        shipment = result.scalar_one_or_none()
+
+        if shipment is None:
+            inbound_result = await db.execute(select(InboundShipment).where(InboundShipment.tracking_number == tracking_number))
+            shipment = inbound_result.scalar_one_or_none()
+
+        if shipment is not None:
+            shipment.status = event_type
+            if event_type == "delivered":
+                shipment.actual_delivery_date = datetime.now(UTC)
+            await db.commit()
+            logger.info("Shipment updated via webhook", tracking_number=tracking_number, status=event_type)
+        else:
+            logger.warning("Shipping webhook: tracking number not found", tracking_number=tracking_number)
+
+    return {"received": True, "event_type": event_type}
+
+
+# Export the sub-router so the app can mount it alongside the main router
+webhook_router = _webhook_router

--- a/apps/backend/src/api/routes/xero_tracking.py
+++ b/apps/backend/src/api/routes/xero_tracking.py
@@ -1,0 +1,106 @@
+"""Xero Tracking Categories API endpoints.
+
+UNI-1853: Expose tracking categories from Xero and allow assigning them
+to locally-tracked invoices (Orders with a xero_invoice_id).
+"""
+
+from typing import Annotated
+from uuid import UUID
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.api.deps import get_current_user
+from src.api.middleware.tenant_isolation import CurrentOrganization
+from src.config.database import get_async_db
+from src.config.xero_settings import XeroSettings, get_xero_settings
+from src.db.demo_models import Order
+from src.integrations.xero import get_xero_client
+from src.integrations.xero.auth import XeroAuth
+from src.integrations.xero.tracking import assign_tracking_to_invoice, get_tracking_categories
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/api", tags=["Xero Tracking"], dependencies=[Depends(get_current_user)])
+
+
+def _get_xero_auth(settings: Annotated[XeroSettings, Depends(get_xero_settings)]) -> XeroAuth:
+    return XeroAuth(
+        client_id=settings.client_id,
+        client_secret=settings.client_secret,
+        redirect_uri=settings.redirect_uri,
+        scopes=settings.scopes_list,
+    )
+
+
+async def _get_xero_client(
+    org_id: CurrentOrganization,
+    db: AsyncSession,
+    xero_auth: XeroAuth,
+):
+    connection = await xero_auth.get_active_connection(db, org_id)
+    if not connection:
+        raise HTTPException(status_code=400, detail="No active Xero connection for this organisation")
+    demo_mode = connection.access_token.startswith("demo_")
+    return get_xero_client(
+        access_token=connection.access_token,
+        tenant_id=connection.tenant_id,
+        demo_mode=demo_mode,
+    )
+
+
+class TrackingAssignRequest(BaseModel):
+    tracking_category_id: str
+    tracking_option_id: str
+
+
+@router.get("/xero/tracking-categories")
+async def list_tracking_categories(
+    org_id: CurrentOrganization,
+    db: Annotated[AsyncSession, Depends(get_async_db)],
+    xero_auth: Annotated[XeroAuth, Depends(_get_xero_auth)],
+) -> list[dict]:
+    """Return all Xero tracking categories with their options."""
+    xero_client = await _get_xero_client(org_id, db, xero_auth)
+    try:
+        return await get_tracking_categories(xero_client)
+    finally:
+        await xero_client.close()
+
+
+@router.post("/invoices/{invoice_id}/xero-tracking")
+async def assign_xero_tracking(
+    invoice_id: UUID,
+    body: TrackingAssignRequest,
+    org_id: CurrentOrganization,
+    db: Annotated[AsyncSession, Depends(get_async_db)],
+    xero_auth: Annotated[XeroAuth, Depends(_get_xero_auth)],
+) -> dict:
+    """Assign a Xero tracking category option to all line items of an invoice."""
+    result = await db.execute(select(Order).where(Order.id == invoice_id))
+    order = result.scalar_one_or_none()
+    if not order:
+        raise HTTPException(status_code=404, detail="Invoice not found")
+    if not order.xero_invoice_id:
+        raise HTTPException(status_code=400, detail="Invoice has not been synced to Xero yet")
+
+    xero_client = await _get_xero_client(org_id, db, xero_auth)
+    try:
+        await assign_tracking_to_invoice(
+            xero_client,
+            xero_invoice_id=order.xero_invoice_id,
+            tracking_category_id=body.tracking_category_id,
+            tracking_option_id=body.tracking_option_id,
+        )
+    finally:
+        await xero_client.close()
+
+    return {
+        "success": True,
+        "xero_invoice_id": order.xero_invoice_id,
+        "tracking_category_id": body.tracking_category_id,
+        "tracking_option_id": body.tracking_option_id,
+    }

--- a/apps/backend/src/integrations/xero/bills.py
+++ b/apps/backend/src/integrations/xero/bills.py
@@ -1,0 +1,75 @@
+"""Xero bills (Accounts Payable invoices) sync for purchase orders.
+
+Purchase orders are pushed to Xero as ACCPAY invoices (bills).
+"""
+
+import structlog
+
+from src.integrations.xero.client import XeroAPIError  # noqa: F401 (re-exported for callers)
+
+logger = structlog.get_logger(__name__)
+
+
+async def push_purchase_order_as_bill(xero_client, po_data: dict) -> str:
+    """Push a purchase order to Xero as an Accounts Payable bill.
+
+    Args:
+        xero_client: XeroClient (or DemoXeroClient) instance.
+        po_data: Dict with keys:
+            - supplier_contact_id (str): Xero contact ID for the supplier.
+            - reference (str): PO number used as the Xero reference.
+            - date (str): Invoice date in ISO format (YYYY-MM-DD).
+            - due_date (str): Due date in ISO format (YYYY-MM-DD).
+            - line_items (list[dict]): Each item has:
+                - description (str)
+                - quantity (float | int)
+                - unit_amount (float | Decimal)
+                - account_code (str, default "310")
+
+    Returns:
+        The Xero InvoiceID string for the created bill.
+
+    Raises:
+        XeroAPIError: If the Xero API call fails.
+        KeyError: If the response is missing the expected InvoiceID.
+    """
+    line_items = [
+        {
+            "Description": item["description"],
+            "Quantity": float(item["quantity"]),
+            "UnitAmount": float(item["unit_amount"]),
+            "AccountCode": item.get("account_code", "310"),
+            "TaxType": "INPUT2",
+        }
+        for item in po_data["line_items"]
+    ]
+
+    payload = {
+        "Invoices": [
+            {
+                "Type": "ACCPAY",
+                "Status": "AUTHORISED",
+                "Contact": {"ContactID": po_data["supplier_contact_id"]},
+                "Reference": po_data["reference"],
+                "Date": po_data["date"],
+                "DueDate": po_data["due_date"],
+                "LineItems": line_items,
+            }
+        ]
+    }
+
+    response = await xero_client._make_request("POST", "/Invoices", data=payload)
+
+    invoices = response.get("Invoices", [])
+    if not invoices:
+        raise KeyError("Xero response contained no Invoices")
+
+    bill_id: str = invoices[0]["InvoiceID"]
+
+    logger.info(
+        "Purchase order pushed to Xero as bill",
+        reference=po_data["reference"],
+        xero_bill_id=bill_id,
+    )
+
+    return bill_id

--- a/apps/backend/src/integrations/xero/tracking.py
+++ b/apps/backend/src/integrations/xero/tracking.py
@@ -1,0 +1,97 @@
+"""Xero Tracking Categories — read and assign to invoices."""
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+async def get_tracking_categories(xero_client) -> list[dict]:
+    """Fetch all active tracking categories from Xero.
+
+    Args:
+        xero_client: XeroClient instance.
+
+    Returns:
+        List of dicts with keys: id, name, status, options (list of {id, name}).
+    """
+    response = await xero_client._make_request("GET", "/TrackingCategories")
+
+    categories = []
+    for cat in response.get("TrackingCategories", []):
+        categories.append(
+            {
+                "id": cat["TrackingCategoryID"],
+                "name": cat["Name"],
+                "status": cat.get("Status", "ACTIVE"),
+                "options": [
+                    {"id": opt["TrackingOptionID"], "name": opt["Name"]}
+                    for opt in cat.get("Options", [])
+                ],
+            }
+        )
+
+    return categories
+
+
+async def assign_tracking_to_invoice(
+    xero_client,
+    xero_invoice_id: str,
+    tracking_category_id: str,
+    tracking_option_id: str,
+) -> bool:
+    """Assign a tracking category option to every line item on a Xero invoice.
+
+    Fetches the existing invoice, attaches tracking to each line item, then
+    PUTs the updated invoice back to Xero.
+
+    Args:
+        xero_client: XeroClient instance.
+        xero_invoice_id: Xero InvoiceID.
+        tracking_category_id: Xero TrackingCategoryID.
+        tracking_option_id: Xero TrackingOptionID.
+
+    Returns:
+        True on success.
+
+    Raises:
+        XeroAPIError: If any Xero API call fails.
+        KeyError: If the invoice is not found in the response.
+    """
+    # Fetch the existing invoice so we can preserve its line items.
+    get_response = await xero_client._make_request(
+        "GET", f"/Invoices/{xero_invoice_id}"
+    )
+    invoices = get_response.get("Invoices", [])
+    if not invoices:
+        raise KeyError(f"Invoice {xero_invoice_id} not found in Xero")
+
+    invoice = invoices[0]
+    tracking_entry = {
+        "TrackingCategoryID": tracking_category_id,
+        "TrackingOptionID": tracking_option_id,
+    }
+
+    for line_item in invoice.get("LineItems", []):
+        existing = line_item.setdefault("Tracking", [])
+        # Replace any existing entry for this category, or append.
+        replaced = False
+        for i, t in enumerate(existing):
+            if t.get("TrackingCategoryID") == tracking_category_id:
+                existing[i] = tracking_entry
+                replaced = True
+                break
+        if not replaced:
+            existing.append(tracking_entry)
+
+    payload = {"Invoices": [invoice]}
+    await xero_client._make_request(
+        "PUT", f"/Invoices/{xero_invoice_id}", data=payload
+    )
+
+    logger.info(
+        "Tracking assigned to invoice",
+        xero_invoice_id=xero_invoice_id,
+        tracking_category_id=tracking_category_id,
+        tracking_option_id=tracking_option_id,
+    )
+    return True


### PR DESCRIPTION
## Summary

- **UNI-1852** — `POST /api/quotes/expire-overdue` bulk-expires sent quotes past `valid_until`; `GET /api/quotes/expiring-soon?days=7` returns upcoming expirations
- **UNI-1875** — Extended quote list with date range, amount range, dynamic sort, and customer name search
- **UNI-1815** — `POST /api/purchase-orders/{id}/sync-to-xero` pushes PO as Xero `ACCPAY` bill via new `integrations/xero/bills.py`
- **UNI-1853** — `GET /api/xero/tracking-categories` + `POST /api/invoices/{id}/xero-tracking` via new `integrations/xero/tracking.py`
- **UNI-1870** — `POST /api/webhooks/shipping` with HMAC-SHA256 verification (`SHIPPING_WEBHOOK_SECRET`), updates shipment status on delivered/returned events
- **UNI-1864** — `GET /api/audit/retention-policy` + `DELETE /api/audit/purge-expired` (admin only, 7-year default retention)
- **UNI-1843** — Volume quantity-break pricing: `GET/POST /api/pricing/volume/{product_id}` + `GET /api/pricing/calculate/volume`
- **UNI-1849** — `POST /api/pos/eod-reconciliation` cash variance calculation + daily summary endpoint

## Test plan

- [ ] `POST /api/quotes/expire-overdue` expires only quotes with `status=sent` and past `valid_until`
- [ ] `GET /api/quotes?min_amount=100&sort_by=total&sort_order=asc` returns correctly filtered/sorted results
- [ ] `POST /api/purchase-orders/{id}/sync-to-xero` requires active Xero connection, returns `xero_bill_id`
- [ ] `POST /api/webhooks/shipping` with wrong signature returns 401
- [ ] `DELETE /api/audit/purge-expired` returns 403 for non-admin users
- [ ] `GET /api/pricing/calculate/volume?product_id=X&quantity=50` applies correct tier
- [ ] `POST /api/pos/eod-reconciliation` variance = counted_cash - system_cash_total

🤖 Generated with [Claude Code](https://claude.com/claude-code)