### PR TITLE
fix(backend,web): orders search/filter end-to-end (UNI-1781)

### DIFF
--- a/apps/backend/src/api/routes/orders.py
+++ b/apps/backend/src/api/routes/orders.py
@@ -411,21 +411,38 @@ async def list_orders(
     search: str | None = None,
     status: str | None = None,
     customer_id: UUID | None = None,
+    date_from: str | None = Query(None, description="ISO date, inclusive (YYYY-MM-DD)"),
+    date_to: str | None = Query(None, description="ISO date, inclusive (YYYY-MM-DD)"),
     db: AsyncSession = Depends(get_async_db),
 ):
-    """List orders with pagination and filters."""
-    # Build query
+    """List orders with pagination and filters.
+
+    UNI-1781: search now covers both order_number AND customer company name.
+    Accepts date_from/date_to as inclusive YYYY-MM-DD bounds over order_date.
+    Treats status=\"all\" (or empty) as no filter to match UI default.
+    """
+    # Join Customer so we can filter by company name in search
+    from src.db.demo_models import Customer as CustomerModel
+
     query = select(OrderModel).options(
         selectinload(OrderModel.order_items),
-        joinedload(OrderModel.customer)
-    )
+        joinedload(OrderModel.customer),
+    ).join(CustomerModel, OrderModel.customer_id == CustomerModel.id, isouter=True)
 
     # Apply filters
     if search:
-        search_filter = f"%{search}%"
-        query = query.where(OrderModel.order_number.ilike(search_filter))
+        search_filter = f"%{search.strip()}%"
+        # Match order_number OR customer name (case-insensitive)
+        from sqlalchemy import or_
+        query = query.where(
+            or_(
+                OrderModel.order_number.ilike(search_filter),
+                CustomerModel.company_name.ilike(search_filter),
+            )
+        )
 
-    if status:
+    # UNI-1781: treat status="all" as no filter (frontend sends this as default)
+    if status and status != "all":
         try:
             # Convert string to OrderStatus enum
             from src.db.demo_models import OrderStatus
@@ -439,6 +456,30 @@ async def list_orders(
 
     if customer_id:
         query = query.where(OrderModel.customer_id == customer_id)
+
+    # UNI-1781: date range on order_date (inclusive)
+    if date_from:
+        try:
+            from_dt = datetime.fromisoformat(date_from)
+            query = query.where(OrderModel.order_date >= from_dt)
+        except ValueError:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid date_from: {date_from}. Expected YYYY-MM-DD.",
+            )
+
+    if date_to:
+        try:
+            # End of day for inclusive upper bound
+            to_dt = datetime.fromisoformat(date_to) + timedelta(
+                hours=23, minutes=59, seconds=59
+            )
+            query = query.where(OrderModel.order_date <= to_dt)
+        except ValueError:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid date_to: {date_to}. Expected YYYY-MM-DD.",
+            )
 
     # Get total count
     count_query = select(func.count()).select_from(query.subquery())

--- a/apps/web/app/(dashboard)/orders/page.tsx
+++ b/apps/web/app/(dashboard)/orders/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 // PHASE 4: Search state persistence
 import { useSearchState } from '@/lib/hooks/use-search-state';
@@ -40,22 +40,58 @@ export default function OrdersPage() {
   const [loading, setLoading] = useState(true);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null); // PHASE 4: Last updated timestamp
 
-  // PHASE 4: Search state persistence - remembers pagination on navigation
-  const { state: searchState, updateField } = useSearchState({
+  // PHASE 4: Search state persistence - remembers pagination + filters on navigation
+  const { state: searchState, updateField, isHydrated } = useSearchState({
     key: 'orders-list',
-    defaultState: { page: 1, pageSize: 50 },
+    defaultState: {
+      page: 1,
+      pageSize: 50,
+      search: '',
+      statusFilter: 'all',
+      dateFrom: '',
+      dateTo: '',
+    },
   });
 
-  const page = searchState.page || 1;
-  const pageSize = searchState.pageSize || 50;
+  const page = (searchState.page as number | undefined) || 1;
+  const pageSize = (searchState.pageSize as number | undefined) || 50;
   const setPage = (value: number) => updateField('page', value);
   const setPageSize = (value: number) => updateField('pageSize', value);
 
-  // UNI-1781: Client-side search and filter state
-  const [search, setSearch] = useState('');
-  const [statusFilter, setStatusFilter] = useState('all');
-  const [dateFrom, setDateFrom] = useState('');
-  const [dateTo, setDateTo] = useState('');
+  // UNI-1781: server-side search and filter state (persisted via useSearchState)
+  const [search, setSearch] = useState<string>(
+    (searchState.search as string | undefined) ?? ''
+  );
+  const [statusFilter, setStatusFilter] = useState<string>(
+    (searchState.statusFilter as string | undefined) ?? 'all'
+  );
+  const [dateFrom, setDateFrom] = useState<string>(
+    (searchState.dateFrom as string | undefined) ?? ''
+  );
+  const [dateTo, setDateTo] = useState<string>(
+    (searchState.dateTo as string | undefined) ?? ''
+  );
+  // Debounced search value — keeps typing snappy without spamming the backend
+  const [debouncedSearch, setDebouncedSearch] = useState<string>(search);
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => clearTimeout(id);
+  }, [search]);
+
+  // UNI-1781: one-shot hydration from sessionStorage after the hook finishes loading.
+  // useState initializers only see the hook's defaultState, so without this the
+  // persisted filters from a previous visit would be ignored.
+  const [hasHydrated, setHasHydrated] = useState(false);
+  useEffect(() => {
+    if (isHydrated && !hasHydrated) {
+      setSearch((searchState.search as string | undefined) ?? '');
+      setStatusFilter((searchState.statusFilter as string | undefined) ?? 'all');
+      setDateFrom((searchState.dateFrom as string | undefined) ?? '');
+      setDateTo((searchState.dateTo as string | undefined) ?? '');
+      setDebouncedSearch((searchState.search as string | undefined) ?? '');
+      setHasHydrated(true);
+    }
+  }, [isHydrated, hasHydrated, searchState]);
   const [formOpen, setFormOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [bulkDeleteDialogOpen, setBulkDeleteDialogOpen] = useState(false);
@@ -66,8 +102,18 @@ export default function OrdersPage() {
   const loadOrders = useCallback(async () => {
     setLoading(true);
     try {
+      // UNI-1781: build server-side query params from current filter state
+      const params = new URLSearchParams({
+        page: String(page),
+        page_size: String(pageSize),
+      });
+      if (debouncedSearch.trim()) params.set('search', debouncedSearch.trim());
+      if (statusFilter && statusFilter !== 'all') params.set('status', statusFilter);
+      if (dateFrom) params.set('date_from', dateFrom);
+      if (dateTo) params.set('date_to', dateTo);
+
       const response = await apiClient.get<PaginatedResponse>(
-        `/api/orders?page=${page}&page_size=${pageSize}`
+        `/api/orders?${params.toString()}`
       );
 
       // Map API response to frontend format
@@ -94,11 +140,27 @@ export default function OrdersPage() {
       setLoading(false);
       setLastUpdated(new Date()); // PHASE 4: Track last update time
     }
-  }, [page, pageSize, toast]);
+  }, [page, pageSize, debouncedSearch, statusFilter, dateFrom, dateTo, toast]);
 
   useEffect(() => {
     loadOrders();
   }, [loadOrders]);
+
+  // UNI-1781: after hydration, when a filter changes snap back to page 1 and persist.
+  // Guarded on hasHydrated so we don't clobber the persisted page on first mount.
+  useEffect(() => {
+    if (!hasHydrated) return;
+    if (page !== 1) {
+      updateField('page', 1);
+    }
+    updateField('search', debouncedSearch);
+    updateField('statusFilter', statusFilter);
+    updateField('dateFrom', dateFrom);
+    updateField('dateTo', dateTo);
+    // intentionally excludes page / updateField from deps to avoid loops;
+    // updateField is stable and page snaps to 1 only when a filter flips post-hydration
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedSearch, statusFilter, dateFrom, dateTo, hasHydrated]);
 
   const handleAddOrder = () => {
     setSelectedOrder(null);
@@ -172,20 +234,10 @@ export default function OrdersPage() {
     }
   };
 
-  // UNI-1781: Client-side filtered view of fetched orders
-  const filteredOrders = useMemo(() => {
-    return orders.filter((o) => {
-      const matchSearch =
-        !search ||
-        o.order_number?.toLowerCase().includes(search.toLowerCase()) ||
-        o.customer_name?.toLowerCase().includes(search.toLowerCase());
-      const matchStatus = statusFilter === 'all' || o.status === statusFilter;
-      const orderDate = o.order_date ? new Date(o.order_date) : null;
-      const matchDateFrom = !dateFrom || (orderDate && orderDate >= new Date(dateFrom));
-      const matchDateTo = !dateTo || (orderDate && orderDate <= new Date(dateTo + 'T23:59:59'));
-      return matchSearch && matchStatus && matchDateFrom && matchDateTo;
-    });
-  }, [orders, search, statusFilter, dateFrom, dateTo]);
+  // UNI-1781: filtering is now server-side — `orders` already reflects
+  // the active search/status/date filters. Previously there was a
+  // client-side `orders` memo that only filtered the current page,
+  // which gave wrong totals and hid matches on other pages.
 
   const handleExport = () => {
     exportOrdersToCSV(orders as unknown as Record<string, unknown>[]);
@@ -207,10 +259,10 @@ export default function OrdersPage() {
   };
 
   const handleToggleSelectAll = () => {
-    if (selectedOrderIds.length === filteredOrders.length) {
+    if (selectedOrderIds.length === orders.length) {
       setSelectedOrderIds([]);
     } else {
-      setSelectedOrderIds(filteredOrders.map((o) => o.id));
+      setSelectedOrderIds(orders.map((o) => o.id));
     }
   };
 
@@ -353,22 +405,26 @@ export default function OrdersPage() {
                 ))}
               </div>
             ) : orders.length === 0 ? (
-              <EmptyState
-                icon={ShoppingCart}
-                title="No equipment orders yet"
-                description="Create your first cleaning equipment order to get started."
-                action={{
-                  label: 'Create Order',
-                  onClick: handleAddOrder,
-                }}
-              />
-            ) : filteredOrders.length === 0 ? (
-              <div className="text-muted-foreground py-10 text-center text-sm">
-                No orders match the current filters.
-              </div>
+              // UNI-1781: when filters are active, show a filter-aware empty
+              // message instead of the "create your first order" onboarding.
+              search || statusFilter !== 'all' || dateFrom || dateTo ? (
+                <div className="text-muted-foreground py-10 text-center text-sm">
+                  No orders match the current filters.
+                </div>
+              ) : (
+                <EmptyState
+                  icon={ShoppingCart}
+                  title="No equipment orders yet"
+                  description="Create your first cleaning equipment order to get started."
+                  action={{
+                    label: 'Create Order',
+                    onClick: handleAddOrder,
+                  }}
+                />
+              )
             ) : (
               <ResponsiveTable
-                data={filteredOrders}
+                data={orders}
                 keyExtractor={(order) => order.id}
                 columns={[
                   {
@@ -376,8 +432,8 @@ export default function OrdersPage() {
                     label: (
                       <Checkbox
                         checked={
-                          filteredOrders.length > 0 &&
-                          selectedOrderIds.length === filteredOrders.length
+                          orders.length > 0 &&
+                          selectedOrderIds.length === orders.length
                         }
                         onCheckedChange={handleToggleSelectAll}
                         aria-label="Select all orders"


### PR DESCRIPTION
# UNI-1781 — Orders search/filter end-to-end

## What was wrong

1. **Search/filter only covered the current page.** Frontend did a client-side `.filter()` on the already-paginated response — page 2+ matches were invisible, and the result count was wrong.
2. **Backend `search` only matched `order_number`.** A user searching for a customer name ("Apex Plumbing") got zero results even when the order existed.
3. **Backend rejected `status="all"`** as an invalid enum even though the UI sends it as the default.
4. **No date range on the backend** — `date_from`/`date_to` query params were simply unsupported.
5. **Filter state didn't persist across navigation** — the existing `useSearchState` hook was only wired to `page`/`pageSize`.

## What was changed

### Backend — `apps/backend/src/api/routes/orders.py`
- `list_orders` now accepts `date_from` and `date_to` as `YYYY-MM-DD` query params (inclusive bounds on `order_date`; `date_to` pushed to end-of-day).
- `search` now matches `order_number` OR `customer.company_name` via an OUTER JOIN on `Customer` and an `OR(ilike, ilike)` predicate.
- `status="all"` (or empty) is treated as no filter — matches the UI default.
- Bad `date_from`/`date_to` strings return `400` with a helpful message, not a 500.

### Frontend — `apps/web/app/(dashboard)/orders/page.tsx`
- Filters moved from client-side to **server-side**: search, status, date range are now URL query params on `/api/orders`.
- Search input is **debounced 300ms** so typing doesn't spam the backend.
- Removed the legacy `useMemo(filteredOrders)` block.
- Filter state (`search`, `statusFilter`, `dateFrom`, `dateTo`) is now persisted via `useSearchState` — if you navigate to `/orders/{id}` and back, your filters survive.
- One-shot hydration effect pulls persisted filters into local state once `isHydrated` flips.
- When any filter flips post-hydration, page snaps back to `1`.
- Empty state is filter-aware: "No orders match the current filters" vs. the onboarding "Create your first order" empty state.

## Files changed

| File | Change |
| ---- | ------ |
| `apps/backend/src/api/routes/orders.py` | Customer-name search, date range, status="all" passthrough |
| `apps/web/app/(dashboard)/orders/page.tsx` | Filter state -> server-side, debounce, persistence, filter-aware empty state |

**Total**: 2 files, 0 locked files touched, 0 schema changes, 0 new migrations.

## Verification checklist (post-merge + deploy)

1. **Where**: `/orders` on `ccw-crm-web.vercel.app`
2. **How**:
   - Type a customer name in the search box. Wait 300ms. Results should narrow and `total` count should drop.
   - Pick a status from the dropdown. Results narrow further.
   - Set a date-from (e.g., last 30 days). Results narrow.
   - Click into an order, then the browser back button — filters should still be set.
   - Clear filters — full list reappears.
3. **What to see**:
   - Count under "Equipment Sales Orders" updates with the filter.
   - Pagination reflects the filtered result set.
   - Empty state reads "No orders match the current filters" when filters hide everything.
4. **What NOT to see**:
   - Stale results from before the filter.
   - A 500 error if you pick `status=all` or a date.
   - The "Create your first order" CTA firing after applying a filter to a non-empty DB.

Linear: UNI-1781