### PR TITLE
fix(backend): add OUTPUT2 tax_type to Xero POS line items (UNI-1802)

### DIFF
--- a/apps/backend/src/integrations/xero/pos_reconciliation.py
+++ b/apps/backend/src/integrations/xero/pos_reconciliation.py
@@ -85,7 +85,7 @@ class POSXeroReconciliation:
         if not connection:
             raise ValueError("No active Xero connection found for organization")
 
-        # Get POS transaction with related data
+        # Get POS@transaction with related data
         stmt = (
             select(POSTransaction)
             .where(POSTransaction.id == pos_transaction_id)
@@ -305,6 +305,7 @@ class POSXeroReconciliation:
                     "description": f"{item.product.name} (SKU: {item.product.sku})",
                     "quantity": float(item.quantity),
                     "unit_amount": float(item.unit_price),
+                    "tax_type": "OUTPUT2",
                 })
             return line_items
         else:
@@ -313,6 +314,7 @@ class POSXeroReconciliation:
                 "description": description,
                 "quantity": 1.0,
                 "unit_amount": float(pos_txn.amount),
+                "tax_type": "OUTPUT2",
             }]
 
     def _build_reference(self, pos_txn: POSTransaction) -> str:


### PR DESCRIPTION
## Summary

Xero POS reconciliation was creating invoices without the `tax_type` field on line items, causing Xero to treat the sale as tax-exempt. GST was not being captured in BAS reports — a compliance risk.

### Change
- `apps/backend/src/integrations/xero/pos_reconciliation.py` — `_build_line_items()`: added `"tax_type": "OUTPUT2"` to both the order-based path and the walk-in (Cash Sales) path.

`OUTPUT2` is the correct Xero tax type for Australian GST on sales (10%).

### Risk
Low. Additive field only. Existing invoices already sent to Xero are unaffected.

Closes UNI-1802