### PR TITLE
fix(backend): align ServiceStatus enum with frontend — eliminate 422 errors (UNI-1847)

### DIFF
--- a/apps/backend/migrations/fix_service_status_enum.sql
+++ b/apps/backend/migrations/fix_service_status_enum.sql
@@ -1,0 +1,14 @@
+-- Migration: fix_service_status_enum
+-- Adds missing service_status_enum values so the backend enum matches the frontend.
+--
+-- Background: The frontend (lib/api/service-requests.ts) defines 8 statuses but the
+-- PostgreSQL enum only had 6. PATCH /api/service-requests/:id returned 422 whenever
+-- staff tried to set under_review, quote_sent, or scheduled via the UI.
+--
+-- Safe to run multiple times (IF NOT EXISTS guards each ADD VALUE).
+-- NOTE: PostgreSQL does not support removing enum values; 'quoted' is retained for
+-- backward compatibility with any existing rows.
+
+ALTER TYPE service_status_enum ADD VALUE IF NOT EXISTS 'under_review' AFTER 'submitted';
+ALTER TYPE service_status_enum ADD VALUE IF NOT EXISTS 'quote_sent'   AFTER 'quoted';
+ALTER TYPE service_status_enum ADD VALUE IF NOT EXISTS 'scheduled'    AFTER 'approved';

--- a/apps/backend/src/db/service_models.py
+++ b/apps/backend/src/db/service_models.py
@@ -30,11 +30,19 @@ class RequestType(str, enum.Enum):
 
 
 class ServiceStatus(str, enum.Enum):
-    """Service request status."""
+    """Service request status.
+
+    Values are kept in sync with the frontend ServiceStatus type in
+    apps/web/lib/api/service-requests.ts. Any addition here requires a
+    corresponding ALTER TYPE migration (see migrations/fix_service_status_enum.sql).
+    """
 
     submitted = "submitted"
-    quoted = "quoted"
+    under_review = "under_review"
+    quoted = "quoted"       # legacy alias — prefer quote_sent for new records
+    quote_sent = "quote_sent"
     approved = "approved"
+    scheduled = "scheduled"
     in_progress = "in_progress"
     completed = "completed"
     cancelled = "cancelled"


### PR DESCRIPTION
## Summary

Workshop staff couldn't update service request statuses via the UI — any attempt to set `under_review`, `quote_sent`, or `scheduled` returned a 422 Unprocessable Entity because those values existed in the frontend type but not in the backend Python enum.

### Root cause
`ServiceStatus` in `service_models.py` had 6 values; the frontend `ServiceStatus` type in `lib/api/service-requests.ts` had 8.

### Changes
1. **`apps/backend/src/db/service_models.py`** — expanded `ServiceStatus` enum to include `under_review`, `quote_sent`, and `scheduled`. Kept `quoted` for backward compatibility with existing rows.
2. **`apps/backend/migrations/fix_service_status_enum.sql`** — idempotent `ALTER TYPE ... ADD VALUE IF NOT EXISTS` migration to extend the PostgreSQL enum type. Run this against the database after deploy.

### Risk
Low. Purely additive — no existing values changed or removed.

Closes UNI-1847