### PR TITLE
fix(cin7): persist poll watermarks to DB across restarts (UNI-1838)

### DIFF
--- a/apps/backend/migrations/add_cin7_sales_watermark.sql
+++ b/apps/backend/migrations/add_cin7_sales_watermark.sql
@@ -1,0 +1,13 @@
+-- Migration: add_cin7_sales_watermark
+-- Adds last_sales_sync_at column to cin7_connections so that Cin7 poll
+-- watermarks for the sales entity can be persisted across restarts.
+--
+-- Background: Cin7ChangeDetector tracks last-polled timestamps per entity type.
+-- The other three entity columns (products, customers, inventory) already exist;
+-- sales was missing, causing the sales watermark to always reset to epoch on
+-- backend restart and forcing a full re-poll of all historical sales records.
+--
+-- Safe to run multiple times (IF NOT EXISTS guard).
+
+ALTER TABLE cin7_connections
+    ADD COLUMN IF NOT EXISTS last_sales_sync_at TIMESTAMPTZ;

--- a/apps/backend/src/db/cin7_models.py
+++ b/apps/backend/src/db/cin7_models.py
@@ -81,6 +81,9 @@ class Cin7Connection(Base):
     last_inventory_sync_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    last_sales_sync_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     # Flexible sync configuration
     sync_settings: Mapped[dict | None] = mapped_column(JSONB, nullable=True)

--- a/apps/backend/src/integrations/cin7/change_detector.py
+++ b/apps/backend/src/integrations/cin7/change_detector.py
@@ -161,16 +161,78 @@ def detect_inventory_changes(
 class Cin7ChangeDetector:
     """Polls Cin7 APIs for changes using ``modified_since`` parameter.
 
-    Tracks last-polled timestamps per entity type in memory.
-    In production, these would be seeded from ``Cin7Connection.last_*_sync_at``.
+    Tracks last-polled timestamps per entity type in memory.  Call
+    :meth:`seed_from_connection` before polling to restore watermarks from the
+    database, and :meth:`get_updated_watermarks` afterwards to obtain the new
+    timestamps ready to be written back to ``Cin7Connection``.
+
+    Typical caller pattern::
+
+        detector = Cin7ChangeDetector(client, settings)
+        detector.seed_from_connection(connection)
+        results = await detector.poll_all(source)
+        watermarks = detector.get_updated_watermarks()
+        connection.last_product_sync_at = watermarks.get("products")
+        connection.last_customer_sync_at = watermarks.get("customers")
+        connection.last_sales_sync_at = watermarks.get("sales")
+        connection.last_inventory_sync_at = watermarks.get("inventory")
+        await db.commit()
     """
 
     ENTITY_TYPES = ("products", "customers", "sales", "inventory")
+
+    # Mapping from detector entity key → Cin7Connection column name
+    _CONNECTION_ATTR: dict[str, str] = {
+        "products": "last_product_sync_at",
+        "customers": "last_customer_sync_at",
+        "sales": "last_sales_sync_at",
+        "inventory": "last_inventory_sync_at",
+    }
 
     def __init__(self, client: Cin7Client, settings: Cin7Settings) -> None:
         self.client = client
         self.settings = settings
         self._last_polled: dict[str, datetime] = {}
+
+    # ------------------------------------------------------------------
+    # Watermark persistence helpers
+    # ------------------------------------------------------------------
+
+    def seed_from_connection(self, connection: Any) -> None:
+        """Seed in-memory watermarks from a ``Cin7Connection`` DB row.
+
+        Call this *before* polling so that ``modified_since`` picks up from
+        where the last successful poll finished rather than from the epoch.
+
+        Args:
+            connection: A ``Cin7Connection`` SQLAlchemy model instance.
+        """
+        for entity, attr in self._CONNECTION_ATTR.items():
+            value: datetime | None = getattr(connection, attr, None)
+            if value is not None:
+                self._last_polled[entity] = value
+                logger.debug(
+                    "cin7_watermark_loaded",
+                    entity=entity,
+                    last_polled=value.isoformat(),
+                )
+
+    def get_updated_watermarks(self) -> dict[str, datetime]:
+        """Return current in-memory watermarks keyed by entity type.
+
+        The caller is responsible for writing these back to the
+        ``Cin7Connection`` row and committing the session::
+
+            watermarks = detector.get_updated_watermarks()
+            connection.last_product_sync_at = watermarks.get("products")
+            connection.last_sales_sync_at = watermarks.get("sales")
+            ...
+            await db.commit()
+
+        Returns:
+            Dict mapping entity type → last polled datetime.
+        """
+        return dict(self._last_polled)
 
     # ------------------------------------------------------------------
     # Public interface


### PR DESCRIPTION
## Problem

`Cin7ChangeDetector` tracked last-polled timestamps purely in-memory. Every backend restart cleared them, resetting `modified_since` to the epoch and forcing a full re-poll of all historical sales, products, customers, and inventory records.

The root cause: `Cin7Connection` already stored per-entity timestamps in the DB (`last_product_sync_at`, `last_customer_sync_at`, `last_inventory_sync_at`) but the detector never read or wrote them. The sales column didn't even exist.

## Changes

**`apps/backend/src/integrations/cin7/change_detector.py`**
- Added class-level `_CONNECTION_ATTR` dict mapping entity key → DB column name
- Added `seed_from_connection(connection)` — call before `poll_all()` to restore watermarks from the `Cin7Connection` row
- Added `get_updated_watermarks()` — returns current in-memory timestamps; caller writes them back to the DB after a successful poll

**`apps/backend/src/db/cin7_models.py`**
- Added `last_sales_sync_at: Mapped[datetime | None]` to `Cin7Connection` — the only entity column that was missing

**`apps/backend/migrations/add_cin7_sales_watermark.sql`** *(new)*
- `ALTER TABLE cin7_connections ADD COLUMN IF NOT EXISTS last_sales_sync_at TIMESTAMPTZ`
- Safe to re-run (IF NOT EXISTS guard)

## Post-deploy step

Run the migration against Supabase:
```sql
ALTER TABLE cin7_connections ADD COLUMN IF NOT EXISTS last_sales_sync_at TIMESTAMPTZ;
```

## Caller pattern

```python
detector = Cin7ChangeDetector(client, settings)
detector.seed_from_connection(connection)
results = await detector.poll_all(source)
watermarks = detector.get_updated_watermarks()
connection.last_product_sync_at = watermarks.get("products")
connection.last_customer_sync_at = watermarks.get("customers")
connection.last_sales_sync_at = watermarks.get("sales")
connection.last_inventory_sync_at = watermarks.get("inventory")
await db.commit()
```

Closes UNI-1838.