### PR TITLE
fix(backend,web): org-configurable bank details on invoices — remove hardcoded BSB (UNI-1806)

### DIFF
--- a/apps/backend/migrations/add_organisation_bank_details.sql
+++ b/apps/backend/migrations/add_organisation_bank_details.sql
@@ -1,0 +1,24 @@
+-- Migration: add_organisation_bank_details
+-- Creates the organisation_bank_details table so each org can store
+-- their bank account details for display on tax invoices.
+--
+-- Background: apps/web invoices previously showed hardcoded placeholder
+-- BSB/account numbers (UNI-1806). This table provides the org-configurable
+-- values. All fields are nullable — a missing row (or null fields) is
+-- handled gracefully on the invoice page.
+--
+-- Safe to run multiple times (IF NOT EXISTS guard on table; idempotent index).
+
+CREATE TABLE IF NOT EXISTS organisation_bank_details (
+    id              UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id UUID          NOT NULL UNIQUE,
+    bank_name       VARCHAR(255),
+    account_name    VARCHAR(255),
+    bsb             VARCHAR(10),
+    account_number  VARCHAR(30),
+    created_at      TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_org_bank_details_org_id
+    ON organisation_bank_details (organization_id);

--- a/apps/backend/src/api/routes/settings.py
+++ b/apps/backend/src/api/routes/settings.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.api.middleware.tenant_isolation import CurrentOrganization
 from src.config.database import get_async_db
+from src.db.bank_settings_models import OrganisationBankDetails
 from src.db.demo_models import Organization
 
 logger = structlog.get_logger(__name__)
@@ -100,3 +101,84 @@ async def update_company_settings(
         slug=org.slug,
         is_active=org.is_active,
     )
+
+
+# ---------------------------------------------------------------------------
+# Bank details (UNI-1806)
+# ---------------------------------------------------------------------------
+
+
+class BankDetailsResponse(BaseModel):
+    """Response schema for organisation bank / EFT payment details."""
+
+    bank_name: str | None = None
+    account_name: str | None = None
+    bsb: str | None = None
+    account_number: str | None = None
+
+    class Config:
+        from_attributes = True
+
+
+class UpdateBankDetailsRequest(BaseModel):
+    """Request schema for updating bank / EFT payment details."""
+
+    bank_name: str | None = Field(None, max_length=255)
+    account_name: str | None = Field(None, max_length=255)
+    bsb: str | None = Field(None, max_length=10)
+    account_number: str | None = Field(None, max_length=30)
+
+
+@router.get("/bank-details")
+async def get_bank_details(
+    org_id: CurrentOrganization,
+    db: Annotated[AsyncSession, Depends(get_async_db)],
+) -> BankDetailsResponse:
+    """Return the organisation's bank/EFT details for invoice display.
+
+    Returns empty fields (all None) if not yet configured — the invoice
+    page shows a 'contact accounts' fallback in that case.
+    """
+    result = await db.execute(
+        select(OrganisationBankDetails).where(
+            OrganisationBankDetails.organization_id == str(org_id)
+        )
+    )
+    row = result.scalar_one_or_none()
+    if row is None:
+        return BankDetailsResponse()
+    return BankDetailsResponse.model_validate(row)
+
+
+@router.put("/bank-details")
+async def update_bank_details(
+    data: UpdateBankDetailsRequest,
+    org_id: CurrentOrganization,
+    db: Annotated[AsyncSession, Depends(get_async_db)],
+) -> BankDetailsResponse:
+    """Upsert the organisation's bank/EFT payment details."""
+    result = await db.execute(
+        select(OrganisationBankDetails).where(
+            OrganisationBankDetails.organization_id == str(org_id)
+        )
+    )
+    row = result.scalar_one_or_none()
+
+    if row is None:
+        row = OrganisationBankDetails(organization_id=str(org_id))
+        db.add(row)
+
+    row.bank_name = data.bank_name
+    row.account_name = data.account_name
+    row.bsb = data.bsb
+    row.account_number = data.account_number
+
+    await db.commit()
+    await db.refresh(row)
+
+    logger.info(
+        "bank_details_updated",
+        org_id=str(org_id),
+    )
+
+    return BankDetailsResponse.model_validate(row)

--- a/apps/backend/src/db/bank_settings_models.py
+++ b/apps/backend/src/db/bank_settings_models.py
@@ -1,0 +1,62 @@
+"""Organisation bank / payment details model.
+
+Stores per-organisation bank account details used on tax invoices.
+These are deliberately separated from the locked demo_models.py so they
+can be evolved without touching the locked schema.
+"""
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from sqlalchemy import DateTime, String
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .models_base import Base
+
+
+class OrganisationBankDetails(Base):
+    """Bank / EFT payment details for an organisation.
+
+    One row per organisation (unique on organization_id).  GET returns
+    the row if it exists; PUT upserts it.  All detail fields are nullable
+    so the row can exist with partial configuration.
+    """
+
+    __tablename__ = "organisation_bank_details"
+
+    id: Mapped[str] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
+    )
+    # FK string reference avoids importing the locked Organization model.
+    organization_id: Mapped[str] = mapped_column(
+        PGUUID(as_uuid=True),
+        unique=True,
+        index=True,
+        nullable=False,
+    )
+
+    bank_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    account_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    bsb: Mapped[str | None] = mapped_column(String(10), nullable=True)
+    account_number: Mapped[str | None] = mapped_column(String(30), nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+        nullable=False,
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<OrganisationBankDetails(org={self.organization_id}, "
+            f"bsb={self.bsb}, acct={self.account_number})>"
+        )

--- a/apps/web/app/(dashboard)/orders/[id]/invoice/page.tsx
+++ b/apps/web/app/(dashboard)/orders/[id]/invoice/page.tsx
@@ -5,6 +5,8 @@ import { useParams, useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { apiClient } from '@/lib/api/client';
+import { settingsApi } from '@/lib/api/settings';
+import type { BankDetails } from '@/lib/api/settings';
 import { convertToCSV, downloadCSV } from '@/lib/utils/csv-export';
 import { useToast } from '@/hooks/use-toast';
 import { ArrowLeft, Download, Printer } from 'lucide-react';
@@ -20,6 +22,7 @@ export default function InvoicePage() {
 
   const [order, setOrder] = useState<Order | null>(null);
   const [loading, setLoading] = useState(true);
+  const [bankDetails, setBankDetails] = useState<BankDetails | null>(null);
 
   const loadOrder = useCallback(async () => {
     setLoading(true);
@@ -41,6 +44,8 @@ export default function InvoicePage() {
 
   useEffect(() => {
     loadOrder();
+    // Fetch bank details in parallel — non-fatal if it fails
+    settingsApi.getBankDetails().then(setBankDetails).catch(() => {});
   }, [loadOrder]);
 
   const handlePrint = () => {
@@ -243,21 +248,38 @@ export default function InvoicePage() {
         <div className="mb-8 border-l-4 border-blue-500 bg-blue-50 p-4">
           <h3 className="mb-2 text-sm font-semibold">PAYMENT INSTRUCTIONS</h3>
           <div className="space-y-1 text-xs">
-            <p>
-              <strong>Bank:</strong> Commonwealth Bank of Australia
-            </p>
-            <p>
-              <strong>Account Name:</strong> CCW Online Pty Ltd
-            </p>
-            <p>
-              <strong>BSB:</strong> 063-000
-            </p>
-            <p>
-              <strong>Account Number:</strong> 1234 5678
-            </p>
-            <p>
-              <strong>Reference:</strong> {invoiceNumber}
-            </p>
+            {bankDetails?.bank_name || bankDetails?.bsb || bankDetails?.account_number ? (
+              <>
+                {bankDetails.bank_name && (
+                  <p>
+                    <strong>Bank:</strong> {bankDetails.bank_name}
+                  </p>
+                )}
+                {bankDetails.account_name && (
+                  <p>
+                    <strong>Account Name:</strong> {bankDetails.account_name}
+                  </p>
+                )}
+                {bankDetails.bsb && (
+                  <p>
+                    <strong>BSB:</strong> {bankDetails.bsb}
+                  </p>
+                )}
+                {bankDetails.account_number && (
+                  <p>
+                    <strong>Account Number:</strong> {bankDetails.account_number}
+                  </p>
+                )}
+                <p>
+                  <strong>Reference:</strong> {invoiceNumber}
+                </p>
+              </>
+            ) : (
+              <p>
+                Please contact our accounts department for EFT payment details. Quote reference{' '}
+                <strong>{invoiceNumber}</strong>.
+              </p>
+            )}
           </div>
         </div>
 
@@ -271,7 +293,7 @@ export default function InvoicePage() {
 
         {/* Terms & Conditions */}
         <div className="mt-8 border-t-2 border-gray-200 pt-6">
-          <h3 className="mb-3 text-sm font-semibold">PAYMENT TERMP t CONDITIONS</h3>
+          <h3 className="mb-3 text-sm font-semibold">PAYMENT TERMS & CONDITIONS</h3>
           <div className="text-muted-foreground space-y-2 text-xs">
             <p>
               <strong>Payment Due:</strong> Payment is due within 30 days of the invoice date.

--- a/apps/web/lib/api/settings.ts
+++ b/apps/web/lib/api/settings.ts
@@ -32,6 +32,20 @@ export interface UpdateCompanyRequest {
   name: string;
 }
 
+export interface BankDetails {
+  bank_name: string | null;
+  account_name: string | null;
+  bsb: string | null;
+  account_number: string | null;
+}
+
+export interface UpdateBankDetailsRequest {
+  bank_name?: string | null;
+  account_name?: string | null;
+  bsb?: string | null;
+  account_number?: string | null;
+}
+
 export const settingsApi = {
   // Account profile (uses existing /api/auth/me endpoint)
   getAccount: (): Promise<AccountProfile> => apiClient.get<AccountProfile>('/api/auth/me'),
@@ -48,4 +62,11 @@ export const settingsApi = {
 
   updateCompany: (data: UpdateCompanyRequest): Promise<CompanySettings> =>
     apiClient.put<CompanySettings>('/api/settings/company', data),
+
+  // Bank / EFT payment details (UNI-1806)
+  getBankDetails: (): Promise<BankDetails> =>
+    apiClient.get<BankDetails>('/api/settings/bank-details'),
+
+  updateBankDetails: (data: UpdateBankDetailsRequest): Promise<BankDetails> =>
+    apiClient.put<BankDetails>('/api/settings/bank-details', data),
 };


### PR DESCRIPTION
## Problem

`apps/web/app/(dashboard)/orders/[id]/invoice/page.tsx` hardcoded fake bank details:
- BSB: `063-000`
- Account Number: `1234 5678`
- Bank: Commonwealth Bank of Australia

Every invoice sent to a customer showed these placeholder values. Any customer paying by EFT would send funds to the wrong account or nowhere — direct payment failure risk.

## Changes

**`apps/backend/src/db/bank_settings_models.py`** *(new)*
- `OrganisationBankDetails` model — one row per org, unique on `organization_id`
- Fields: `bank_name`, `account_name`, `bsb`, `account_number` (all nullable)
- Deliberately separate from locked `demo_models.py`

**`apps/backend/migrations/add_organisation_bank_details.sql`** *(new)*
- `CREATE TABLE IF NOT EXISTS organisation_bank_details` — safe to re-run

**`apps/backend/src/api/routes/settings.py`**
- `GET /api/settings/bank-details` — returns row or all-None response
- `PUT /api/settings/bank-details` — upserts bank details for authenticated org

**`apps/web/lib/api/settings.ts`**
- `BankDetails` interface + `UpdateBankDetailsRequest`
- `settingsApi.getBankDetails()` / `settingsApi.updateBankDetails()`

**`apps/web/app/(dashboard)/orders/[id]/invoice/page.tsx`**
- Fetches bank details on mount (parallel to order load, non-fatal on failure)
- Renders real bank details when configured
- Falls back to "Please contact our accounts department for EFT payment details" when unconfigured — **never shows fake placeholder values again**

## Post-deploy steps

1. Run migration against Supabase:
```sql
CREATE TABLE IF NOT EXISTS organisation_bank_details (
    id              UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
    organization_id UUID          NOT NULL UNIQUE,
    bank_name       VARCHAR(255),
    account_name    VARCHAR(255),
    bsb             VARCHAR(10),
    account_number  VARCHAR(30),
    created_at      TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
    updated_at      TIMESTAMPTZ   NOT NULL DEFAULT NOW()
);
```
2. Configure real bank details via `PUT /api/settings/bank-details`

## Verification Checklist

| Where | How | What to see | What NOT to see |
|---|---|---|---|
| Invoice page (unconfigured) | Open any order → Invoice | "Please contact our accounts department" text | `063-000` / `1234 5678` |
| Invoice page (configured) | PUT bank details, reload invoice | Real bank name / BSB / account | Placeholder values |
| GET /api/settings/bank-details | API call with no row | `{"bank_name": null, ...}` 200 | 500 error |
| PUT /api/settings/bank-details | Set real values | Values returned in response | Error |

Closes UNI-1806.