### PR TITLE
feat(cin7): add PO and invoice events to Cin7 polling handler (UNI-1830)

### DIFF
--- a/apps/backend/migrations/add_cin7_po_watermark.sql
+++ b/apps/backend/migrations/add_cin7_po_watermark.sql
@@ -1,0 +1,13 @@
+-- Migration: Add purchase order polling watermark to cin7_connections
+-- Ticket: UNI-1830 — Add PO and invoice events to Cin7 polling handler
+--
+-- Run this against your Supabase project:
+--   Settings → SQL Editor → paste and execute
+--
+-- Safe to re-run (IF NOT EXISTS guard).
+
+ALTER TABLE cin7_connections
+    ADD COLUMN IF NOT EXISTS last_purchase_order_sync_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN cin7_connections.last_purchase_order_sync_at
+    IS 'Watermark timestamp for purchase-order polling (UNI-1830)';

--- a/apps/backend/src/config/cin7_settings.py
+++ b/apps/backend/src/config/cin7_settings.py
@@ -60,6 +60,7 @@ class Cin7Settings(BaseSettings):
     sync_customers: bool = Field(default=True, alias="CIN7_SYNC_CUSTOMERS")
     sync_sales: bool = Field(default=True, alias="CIN7_SYNC_SALES")
     sync_inventory: bool = Field(default=True, alias="CIN7_SYNC_INVENTORY")
+    sync_purchase_orders: bool = Field(default=True, alias="CIN7_SYNC_PURCHASE_ORDERS")
 
     # Polling configuration (seconds) — Core has no webhooks, polling is primary
     polling_enabled: bool = Field(default=True, alias="CIN7_POLLING_ENABLED")
@@ -67,6 +68,7 @@ class Cin7Settings(BaseSettings):
     poll_interval_customers: int = Field(default=300, alias="CIN7_POLL_INTERVAL_CUSTOMERS")
     poll_interval_sales: int = Field(default=120, alias="CIN7_POLL_INTERVAL_SALES")
     poll_interval_inventory: int = Field(default=60, alias="CIN7_POLL_INTERVAL_INVENTORY")
+    poll_interval_purchase_orders: int = Field(default=300, alias="CIN7_POLL_INTERVAL_PURCHASE_ORDERS")
 
     @property
     def is_demo_mode(self) -> bool:

--- a/apps/backend/src/db/cin7_models.py
+++ b/apps/backend/src/db/cin7_models.py
@@ -84,6 +84,9 @@ class Cin7Connection(Base):
     last_sales_sync_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    last_purchase_order_sync_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     # Flexible sync configuration
     sync_settings: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
@@ -171,9 +174,7 @@ class Cin7CustomerMapping(Base):
         PGUUID(as_uuid=True),
         primary_key=True,
         default=uuid4,
-    )
-
-    # ERP customer reference
+    )    # ERP customer reference
     customer_id: Mapped[str] = mapped_column(
         PGUUID(as_uuid=True),
         index=True,

--- a/apps/backend/src/integrations/cin7/change_detector.py
+++ b/apps/backend/src/integrations/cin7/change_detector.py
@@ -153,6 +153,72 @@ def detect_inventory_changes(
     return events
 
 
+# Cin7 Core status values that indicate a PO has reached a billing milestone.
+_BILLED_STATUSES = frozenset({"Billed", "PartlyBilled"})
+
+
+def detect_purchase_order_changes(
+    purchase_orders: list[dict[str, Any]], source: Literal["core", "omni"]
+) -> list[dict[str, Any]]:
+    """Extract change events from a purchase-order poll result.
+
+    Emits two event types per PO:
+
+    - ``entity_type="purchase_order"`` — always emitted for every changed PO.
+    - ``entity_type="invoice"`` — emitted additionally when the PO status
+      indicates a supplier invoice has been raised (Cin7 Core surfaces invoices
+      as POs in "Billed" or "PartlyBilled" status because there is no dedicated
+      supplier-invoice endpoint).
+
+    Returns:
+        List of event dicts with ``entity_type``, ``entity_id``, ``action``,
+        ``source``, ``reference``, ``status``, and ``data``.
+    """
+    events: list[dict[str, Any]] = []
+    for po in purchase_orders:
+        if source == "core":
+            entity_id = po.get("PurchaseOrderID") or po.get("ID", "unknown")
+            ref = po.get("OrderNumber", "")
+            status = po.get("Status", "")
+        else:
+            entity_id = str(po.get("id", "unknown"))
+            ref = po.get("reference", "")
+            status = po.get("status", "")
+
+        # Determine action from status
+        if status in _BILLED_STATUSES:
+            po_action = "invoiced"
+        elif status == "Received":
+            po_action = "received"
+        else:
+            po_action = "updated"
+
+        base = {
+            "entity_id": str(entity_id),
+            "action": po_action,
+            "source": source,
+            "reference": ref,
+            "status": status,
+            "data": po,
+        }
+
+        # Always emit a purchase_order event
+        events.append({**base, "entity_type": "purchase_order"})
+
+        # Emit an invoice event when billing status is reached
+        if status in _BILLED_STATUSES:
+            invoice_action = (
+                "partly_invoiced" if status == "PartlyBilled" else "invoiced"
+            )
+            events.append({
+                **base,
+                "entity_type": "invoice",
+                "action": invoice_action,
+            })
+
+    return events
+
+
 # ---------------------------------------------------------------------------
 # Cin7ChangeDetector class
 # ---------------------------------------------------------------------------
@@ -179,7 +245,7 @@ class Cin7ChangeDetector:
         await db.commit()
     """
 
-    ENTITY_TYPES = ("products", "customers", "sales", "inventory")
+    ENTITY_TYPES = ("products", "customers", "sales", "inventory", "purchase_orders")
 
     # Mapping from detector entity key → Cin7Connection column name
     _CONNECTION_ATTR: dict[str, str] = {
@@ -187,6 +253,7 @@ class Cin7ChangeDetector:
         "customers": "last_customer_sync_at",
         "sales": "last_sales_sync_at",
         "inventory": "last_inventory_sync_at",
+        "purchase_orders": "last_purchase_order_sync_at",
     }
 
     def __init__(self, client: Cin7Client, settings: Cin7Settings) -> None:
@@ -267,6 +334,11 @@ class Cin7ChangeDetector:
         if self.settings.sync_inventory:
             changes = await self.poll_inventory(source)
             results["inventory"] = changes
+            total_changes += len(changes)
+
+        if self.settings.sync_purchase_orders:
+            changes = await self.poll_purchase_orders(source)
+            results["purchase_orders"] = changes
             total_changes += len(changes)
 
         results["total_changes"] = total_changes
@@ -380,6 +452,43 @@ class Cin7ChangeDetector:
             return detect_inventory_changes(items, source)
         except Exception as exc:
             logger.error("cin7_poll_inventory_failed", source=source, error=str(exc))
+            return []
+
+    async def poll_purchase_orders(
+        self, source: Literal["core", "omni"] = "core"
+    ) -> list[dict[str, Any]]:
+        """Poll purchase orders endpoint with modified_since.
+
+        Emits both ``purchase_order`` and ``invoice`` events (see
+        :func:`detect_purchase_order_changes` for the dual-event logic).
+        Only Cin7 Core is supported; Omni purchase order polling does not
+        support a ``modified_since`` filter so we return an empty list for
+        that source to avoid full-catalogue noise on every poll cycle.
+        """
+        if source != "core":
+            logger.debug(
+                "cin7_poll_purchase_orders_skipped",
+                reason="omni_no_modified_since",
+            )
+            return []
+
+        modified_since = self._last_polled.get("purchase_orders")
+        kwargs: dict[str, Any] = {"page": 1, "limit": 100}
+        if modified_since:
+            kwargs["modified_since"] = format_modified_since(modified_since)
+
+        try:
+            data = await self.client.core.get_purchase_list(**kwargs)
+            purchase_orders = data.get("PurchaseOrderList", [])
+            if not isinstance(purchase_orders, list):
+                purchase_orders = []
+
+            self._update_last_polled("purchase_orders")
+            return detect_purchase_order_changes(purchase_orders, source)
+        except Exception as exc:
+            logger.error(
+                "cin7_poll_purchase_orders_failed", source=source, error=str(exc)
+            )
             return []
 
     def get_last_polled(self, entity_type: str) -> datetime | None:

--- a/apps/backend/src/integrations/cin7/client.py
+++ b/apps/backend/src/integrations/cin7/client.py
@@ -159,11 +159,13 @@ class Cin7CoreLiveClient:
         self,
         page: int = 1,
         limit: int = 100,
+        modified_since: str | None = None,
     ) -> dict[str, Any]:
-        """Get purchase orders list with pagination."""
-        return await self._request(
-            "GET", "/purchaseList", params={"Page": page, "Limit": limit}
-        )
+        """Get purchase orders list with pagination and optional modified_since filter."""
+        params: dict[str, Any] = {"Page": page, "Limit": limit}
+        if modified_since:
+            params["ModifiedSince"] = modified_since
+        return await self._request("GET", "/purchaseList", params=params)
 
     async def get_product_availability(
         self,

--- a/apps/backend/src/integrations/cin7/event_dispatcher.py
+++ b/apps/backend/src/integrations/cin7/event_dispatcher.py
@@ -21,6 +21,8 @@ CIN7_EVENT_PRODUCT_CHANGED = "cin7.product.changed"
 CIN7_EVENT_CUSTOMER_CHANGED = "cin7.customer.changed"
 CIN7_EVENT_SALES_CHANGED = "cin7.sales.changed"
 CIN7_EVENT_INVENTORY_CHANGED = "cin7.inventory.changed"
+CIN7_EVENT_PO_CHANGED = "cin7.purchase_order.changed"
+CIN7_EVENT_INVOICE_CHANGED = "cin7.invoice.changed"
 CIN7_EVENT_SYNC_COMPLETED = "cin7.sync.completed"
 CIN7_EVENT_SYNC_FAILED = "cin7.sync.failed"
 CIN7_EVENT_POLL_COMPLETED = "cin7.poll.completed"
@@ -30,6 +32,8 @@ ALL_CIN7_EVENTS = [
     CIN7_EVENT_CUSTOMER_CHANGED,
     CIN7_EVENT_SALES_CHANGED,
     CIN7_EVENT_INVENTORY_CHANGED,
+    CIN7_EVENT_PO_CHANGED,
+    CIN7_EVENT_INVOICE_CHANGED,
     CIN7_EVENT_SYNC_COMPLETED,
     CIN7_EVENT_SYNC_FAILED,
     CIN7_EVENT_POLL_COMPLETED,
@@ -109,6 +113,58 @@ def build_inventory_event(
         "entity_id": inventory_data.get("entity_id", "unknown"),
         "location": inventory_data.get("location", ""),
         "available": inventory_data.get("available", 0),
+        "action": action,
+        "source": source,
+        "timestamp": datetime.now(UTC).isoformat(),
+    }
+
+
+def build_purchase_order_event(
+    po_data: dict[str, Any], source: str, action: str = "updated"
+) -> dict[str, Any]:
+    """Build a standardized purchase order change event dict.
+
+    Args:
+        po_data: Raw PO data from change detection.
+        source: "core" or "omni".
+        action: "created", "updated", "received", or "invoiced".
+
+    Returns:
+        Standardized event dict with ``event_type``, ``timestamp``, etc.
+    """
+    return {
+        "event_type": CIN7_EVENT_PO_CHANGED,
+        "entity_type": "purchase_order",
+        "entity_id": po_data.get("entity_id", "unknown"),
+        "reference": po_data.get("reference", ""),
+        "status": po_data.get("status", ""),
+        "action": action,
+        "source": source,
+        "timestamp": datetime.now(UTC).isoformat(),
+    }
+
+
+def build_invoice_event(
+    po_data: dict[str, Any], source: str, action: str = "invoiced"
+) -> dict[str, Any]:
+    """Build a standardized supplier invoice event from a billed PO.
+
+    Cin7 Core does not have a dedicated supplier-invoice endpoint; invoices
+    are surfaced as purchase orders reaching "Billed" / "PartlyBilled" status.
+    This builder produces an ``invoice`` entity event so downstream handlers
+    can update AP without needing to inspect the raw PO status.
+
+    Args:
+        po_data: Raw PO data from change detection (already confirmed billed).
+        source: "core" or "omni".
+        action: typically "invoiced" or "partly_invoiced".
+    """
+    return {
+        "event_type": CIN7_EVENT_INVOICE_CHANGED,
+        "entity_type": "invoice",
+        "entity_id": po_data.get("entity_id", "unknown"),
+        "reference": po_data.get("reference", ""),
+        "status": po_data.get("status", ""),
         "action": action,
         "source": source,
         "timestamp": datetime.now(UTC).isoformat(),
@@ -200,6 +256,10 @@ class Cin7EventDispatcher:
                 sse_event = build_sales_event(event, event.get("source", "core"))
             elif entity_type == "inventory":
                 sse_event = build_inventory_event(event, event.get("source", "core"))
+            elif entity_type == "purchase_order":
+                sse_event = build_purchase_order_event(event, event.get("source", "core"))
+            elif entity_type == "invoice":
+                sse_event = build_invoice_event(event, event.get("source", "core"))
             else:
                 sse_event = event
 

--- a/apps/backend/tests/integration/test_cin7_po_invoice_events.py
+++ b/apps/backend/tests/integration/test_cin7_po_invoice_events.py
@@ -1,0 +1,379 @@
+"""Tests for UNI-1830: Cin7 PO and invoice events in polling handler.
+
+Covers:
+- detect_purchase_order_changes() pure function
+- Cin7EventDispatcher.dispatch_change_events() for purchase_order / invoice
+- Cin7ChangeDetector.poll_purchase_orders() including Omni skip path
+- ENTITY_TYPES / _CONNECTION_ATTR completeness
+- build_purchase_order_event() / build_invoice_event() event builders
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.integrations.cin7.change_detector import (
+    Cin7ChangeDetector,
+    _BILLED_STATUSES,
+    detect_purchase_order_changes,
+    format_modified_since,
+)
+from src.integrations.cin7.event_dispatcher import (
+    ALL_CIN7_EVENTS,
+    CIN7_EVENT_INVOICE_CHANGED,
+    CIN7_EVENT_PO_CHANGED,
+    Cin7EventDispatcher,
+    build_invoice_event,
+    build_purchase_order_event,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_core_po(
+    po_id: str = "PO-001",
+    order_number: str = "ORD-9001",
+    status: str = "Draft",
+) -> dict:
+    return {"PurchaseOrderID": po_id, "OrderNumber": order_number, "Status": status}
+
+
+# ---------------------------------------------------------------------------
+# Event builder tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPurchaseOrderEvent:
+    def test_event_type(self):
+        event = build_purchase_order_event(
+            {"entity_id": "123", "reference": "PO-1", "status": "Draft"},
+            source="core",
+        )
+        assert event["event_type"] == CIN7_EVENT_PO_CHANGED
+
+    def test_entity_type(self):
+        event = build_purchase_order_event({}, source="core")
+        assert event["entity_type"] == "purchase_order"
+
+    def test_fields_populated(self):
+        event = build_purchase_order_event(
+            {"entity_id": "42", "reference": "PO-99", "status": "Billed"},
+            source="core",
+            action="invoiced",
+        )
+        assert event["entity_id"] == "42"
+        assert event["reference"] == "PO-99"
+        assert event["status"] == "Billed"
+        assert event["action"] == "invoiced"
+        assert event["source"] == "core"
+
+    def test_timestamp_is_iso(self):
+        event = build_purchase_order_event({}, source="core")
+        # Should parse without raising
+        datetime.fromisoformat(event["timestamp"])
+
+    def test_unknown_defaults(self):
+        event = build_purchase_order_event({}, source="omni")
+        assert event["entity_id"] == "unknown"
+        assert event["reference"] == ""
+        assert event["status"] == ""
+
+
+class TestBuildInvoiceEvent:
+    def test_event_type(self):
+        event = build_invoice_event({}, source="core")
+        assert event["event_type"] == CIN7_EVENT_INVOICE_CHANGED
+
+    def test_entity_type(self):
+        event = build_invoice_event({}, source="core")
+        assert event["entity_type"] == "invoice"
+
+    def test_default_action(self):
+        event = build_invoice_event({}, source="core")
+        assert event["action"] == "invoiced"
+
+    def test_partly_invoiced_action(self):
+        event = build_invoice_event({}, source="core", action="partly_invoiced")
+        assert event["action"] == "partly_invoiced"
+
+
+class TestAllCin7Events:
+    def test_po_in_all_events(self):
+        assert CIN7_EVENT_PO_CHANGED in ALL_CIN7_EVENTS
+
+    def test_invoice_in_all_events(self):
+        assert CIN7_EVENT_INVOICE_CHANGED in ALL_CIN7_EVENTS
+
+
+# ---------------------------------------------------------------------------
+# detect_purchase_order_changes() pure function
+# ---------------------------------------------------------------------------
+
+
+class TestDetectPurchaseOrderChanges:
+    def test_returns_po_event_for_draft_po(self):
+        pos = [_make_core_po(status="Draft")]
+        events = detect_purchase_order_changes(pos, source="core")
+        assert len(events) == 1
+        ev = events[0]
+        assert ev["entity_type"] == "purchase_order"
+        assert ev["action"] == "updated"
+        assert ev["entity_id"] == "PO-001"
+
+    def test_billed_emits_both_po_and_invoice_events(self):
+        pos = [_make_core_po(status="Billed")]
+        events = detect_purchase_order_changes(pos, source="core")
+        assert len(events) == 2
+        types = {e["entity_type"] for e in events}
+        assert types == {"purchase_order", "invoice"}
+
+    def test_partly_billed_emits_both_events(self):
+        pos = [_make_core_po(status="PartlyBilled")]
+        events = detect_purchase_order_changes(pos, source="core")
+        assert len(events) == 2
+        invoice_ev = next(e for e in events if e["entity_type"] == "invoice")
+        assert invoice_ev["action"] == "partly_invoiced"
+
+    def test_received_action(self):
+        pos = [_make_core_po(status="Received")]
+        events = detect_purchase_order_changes(pos, source="core")
+        assert events[0]["action"] == "received"
+        # No invoice event for received
+        assert all(e["entity_type"] == "purchase_order" for e in events)
+
+    def test_billed_po_action_is_invoiced(self):
+        pos = [_make_core_po(status="Billed")]
+        events = detect_purchase_order_changes(pos, source="core")
+        po_ev = next(e for e in events if e["entity_type"] == "purchase_order")
+        assert po_ev["action"] == "invoiced"
+
+    def test_empty_list_returns_empty(self):
+        assert detect_purchase_order_changes([], source="core") == []
+
+    def test_multiple_pos_mixed_statuses(self):
+        pos = [
+            _make_core_po("A", status="Draft"),
+            _make_core_po("B", status="Billed"),
+            _make_core_po("C", status="PartlyBilled"),
+        ]
+        events = detect_purchase_order_changes(pos, source="core")
+        # A → 1, B → 2, C → 2 = 5
+        assert len(events) == 5
+
+    def test_entity_id_from_id_fallback(self):
+        po = {"ID": "fallback-id", "Status": "Draft"}
+        events = detect_purchase_order_changes([po], source="core")
+        assert events[0]["entity_id"] == "fallback-id"
+
+    def test_omni_po_fields(self):
+        po = {"id": 77, "reference": "REF-77", "status": "Billed"}
+        events = detect_purchase_order_changes([po], source="omni")
+        assert len(events) == 2
+        po_ev = next(e for e in events if e["entity_type"] == "purchase_order")
+        assert po_ev["entity_id"] == "77"
+        assert po_ev["reference"] == "REF-77"
+
+    def test_data_field_preserved(self):
+        raw = {"PurchaseOrderID": "X", "Status": "Draft", "extra": "value"}
+        events = detect_purchase_order_changes([raw], source="core")
+        assert events[0]["data"] == raw
+
+    def test_billed_statuses_constant(self):
+        assert "Billed" in _BILLED_STATUSES
+        assert "PartlyBilled" in _BILLED_STATUSES
+
+
+# ---------------------------------------------------------------------------
+# Cin7EventDispatcher — dispatch_change_events()
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcherPOAndInvoiceRouting:
+    @pytest.fixture()
+    def mock_sse(self):
+        svc = MagicMock()
+        svc.publish = AsyncMock()
+        return svc
+
+    @pytest.fixture()
+    def dispatcher(self, mock_sse):
+        return Cin7EventDispatcher(sse_service=mock_sse)
+
+    @pytest.mark.asyncio
+    async def test_purchase_order_entity_dispatched(self, dispatcher, mock_sse):
+        events = [
+            {
+                "entity_type": "purchase_order",
+                "entity_id": "PO-1",
+                "reference": "ORD-1",
+                "status": "Draft",
+                "action": "updated",
+                "source": "core",
+            }
+        ]
+        count = await dispatcher.dispatch_change_events(events)
+        assert count == 1
+        published = mock_sse.publish.call_args[0][1]
+        assert published["event_type"] == CIN7_EVENT_PO_CHANGED
+
+    @pytest.mark.asyncio
+    async def test_invoice_entity_dispatched(self, dispatcher, mock_sse):
+        events = [
+            {
+                "entity_type": "invoice",
+                "entity_id": "PO-1",
+                "reference": "ORD-1",
+                "status": "Billed",
+                "action": "invoiced",
+                "source": "core",
+            }
+        ]
+        count = await dispatcher.dispatch_change_events(events)
+        assert count == 1
+        published = mock_sse.publish.call_args[0][1]
+        assert published["event_type"] == CIN7_EVENT_INVOICE_CHANGED
+
+    @pytest.mark.asyncio
+    async def test_mixed_batch_dispatches_all(self, dispatcher, mock_sse):
+        events = [
+            {"entity_type": "purchase_order", "entity_id": "A", "action": "updated", "source": "core"},
+            {"entity_type": "invoice", "entity_id": "A", "action": "invoiced", "source": "core"},
+            {"entity_type": "product", "entity_id": "P1", "action": "updated", "source": "core", "name": "Foo"},
+        ]
+        count = await dispatcher.dispatch_change_events(events)
+        assert count == 3
+        assert mock_sse.publish.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_unknown_entity_passthrough(self, dispatcher, mock_sse):
+        raw = {"entity_type": "unknown_future_type", "data": "xyz"}
+        await dispatcher.dispatch_change_events([raw])
+        published = mock_sse.publish.call_args[0][1]
+        assert published == raw
+
+
+# ---------------------------------------------------------------------------
+# Cin7ChangeDetector — poll_purchase_orders()
+# ---------------------------------------------------------------------------
+
+
+class TestPollPurchaseOrders:
+    def _make_detector(self, purchase_orders: list[dict]) -> tuple[Cin7ChangeDetector, MagicMock]:
+        mock_settings = MagicMock()
+        mock_settings.sync_purchase_orders = True
+        mock_settings.sync_products = False
+        mock_settings.sync_customers = False
+        mock_settings.sync_sales = False
+        mock_settings.sync_inventory = False
+
+        mock_client = MagicMock()
+        mock_client.core = MagicMock()
+        mock_client.core.get_purchase_list = AsyncMock(
+            return_value={"PurchaseOrderList": purchase_orders}
+        )
+
+        detector = Cin7ChangeDetector(client=mock_client, settings=mock_settings)
+        return detector, mock_client
+
+    @pytest.mark.asyncio
+    async def test_returns_events_for_changed_pos(self):
+        pos = [_make_core_po("P1", status="Draft")]
+        detector, _ = self._make_detector(pos)
+        events = await detector.poll_purchase_orders(source="core")
+        assert len(events) == 1
+        assert events[0]["entity_type"] == "purchase_order"
+
+    @pytest.mark.asyncio
+    async def test_billed_po_emits_invoice_event_too(self):
+        pos = [_make_core_po("P1", status="Billed")]
+        detector, _ = self._make_detector(pos)
+        events = await detector.poll_purchase_orders(source="core")
+        assert len(events) == 2
+        types = {e["entity_type"] for e in events}
+        assert "invoice" in types
+
+    @pytest.mark.asyncio
+    async def test_watermark_updated_after_poll(self):
+        detector, _ = self._make_detector([])
+        assert detector.get_last_polled("purchase_orders") is None
+        await detector.poll_purchase_orders(source="core")
+        assert detector.get_last_polled("purchase_orders") is not None
+
+    @pytest.mark.asyncio
+    async def test_omni_source_skipped_returns_empty(self):
+        detector, mock_client = self._make_detector([])
+        events = await detector.poll_purchase_orders(source="omni")
+        assert events == []
+        mock_client.core.get_purchase_list.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_modified_since_passed_when_watermark_set(self):
+        detector, mock_client = self._make_detector([])
+        # Seed a watermark
+        seed_dt = datetime(2025, 11, 15, 8, 0, 0, tzinfo=UTC)
+        detector._last_polled["purchase_orders"] = seed_dt
+        await detector.poll_purchase_orders(source="core")
+        call_kwargs = mock_client.core.get_purchase_list.call_args[1]
+        assert call_kwargs["modified_since"] == format_modified_since(seed_dt)
+
+    @pytest.mark.asyncio
+    async def test_api_error_returns_empty_list(self):
+        mock_settings = MagicMock()
+        mock_settings.sync_purchase_orders = True
+        mock_client = MagicMock()
+        mock_client.core.get_purchase_list = AsyncMock(side_effect=Exception("API down"))
+        detector = Cin7ChangeDetector(client=mock_client, settings=mock_settings)
+        events = await detector.poll_purchase_orders(source="core")
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_poll_all_includes_purchase_orders(self):
+        pos = [_make_core_po("P1", status="Draft")]
+        detector, _ = self._make_detector(pos)
+        results = await detector.poll_all(source="core")
+        assert "purchase_orders" in results
+        assert len(results["purchase_orders"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Cin7ChangeDetector — class-level completeness checks
+# ---------------------------------------------------------------------------
+
+
+class TestChangeDetectorEntityCompleteness:
+    def test_purchase_orders_in_entity_types(self):
+        assert "purchase_orders" in Cin7ChangeDetector.ENTITY_TYPES
+
+    def test_purchase_orders_in_connection_attr_map(self):
+        assert "purchase_orders" in Cin7ChangeDetector._CONNECTION_ATTR
+
+    def test_connection_attr_maps_to_correct_column(self):
+        assert (
+            Cin7ChangeDetector._CONNECTION_ATTR["purchase_orders"]
+            == "last_purchase_order_sync_at"
+        )
+
+    def test_seed_from_connection_loads_po_watermark(self):
+        mock_conn = MagicMock()
+        mock_conn.last_purchase_order_sync_at = datetime(2025, 1, 1, tzinfo=UTC)
+        # Set other attrs to None to avoid leakage
+        for attr in ["last_product_sync_at", "last_customer_sync_at",
+                     "last_sales_sync_at", "last_inventory_sync_at"]:
+            setattr(mock_conn, attr, None)
+
+        detector = Cin7ChangeDetector(
+            client=MagicMock(), settings=MagicMock()
+        )
+        detector.seed_from_connection(mock_conn)
+        assert detector.get_last_polled("purchase_orders") == datetime(2025, 1, 1, tzinfo=UTC)
+
+    def test_get_updated_watermarks_includes_po(self):
+        detector = Cin7ChangeDetector(client=MagicMock(), settings=MagicMock())
+        now = datetime.now(UTC)
+        detector._last_polled["purchase_orders"] = now
+        watermarks = detector.get_updated_watermarks()
+        assert watermarks.get("purchase_orders") == now


### PR DESCRIPTION
## Summary

Resolves **UNI-1830** — Add PO and invoice events to Cin7 polling handler.

Cin7 Core has no native webhook support and no dedicated supplier-invoice endpoint. This PR wires purchase orders into the existing polling loop and derives invoice events from PO billing status changes.

### What changed

**`src/integrations/cin7/change_detector.py`**
- New pure function `detect_purchase_order_changes()` — maps Core/Omni PO fields, derives action from status (`updated` / `received` / `invoiced`), and emits a secondary `entity_type="invoice"` event whenever a PO reaches `Billed` or `PartlyBilled` status (the only way Cin7 Core surfaces supplier invoices)
- `ENTITY_TYPES` and `_CONNECTION_ATTR` extended with `"purchase_orders"` → `"last_purchase_order_sync_at"`
- New `poll_purchase_orders()` method — Core-only (Omni skipped; no `modified_since` support), with `modified_since` watermark via `get_purchase_list()`
- `poll_all()` calls `poll_purchase_orders()` when `settings.sync_purchase_orders=True`

**`src/integrations/cin7/event_dispatcher.py`**
- `dispatch_change_events()` now routes `purchase_order` and `invoice` entity types to `build_purchase_order_event()` / `build_invoice_event()`
- Both constants (`CIN7_EVENT_PO_CHANGED`, `CIN7_EVENT_INVOICE_CHANGED`) added to `ALL_CIN7_EVENTS`

**`src/config/cin7_settings.py`**
- `sync_purchase_orders` toggle (`CIN7_SYNC_PURCHASE_ORDERS`, default `True`)
- `poll_interval_purchase_orders` (`CIN7_POLL_INTERVAL_PURCHASE_ORDERS`, default 300s)

**`src/integrations/cin7/client.py`**
- `get_purchase_list()` now accepts `modified_since` — passes as `ModifiedSince` query param

**`src/db/cin7_models.py`**
- `last_purchase_order_sync_at` watermark column on `Cin7Connection`

**`migrations/add_cin7_po_watermark.sql`**
- `ALTER TABLE cin7_connections ADD COLUMN IF NOT EXISTS last_purchase_order_sync_at TIMESTAMPTZ` (idempotent)

**`tests/integration/test_cin7_po_invoice_events.py`** — 40+ assertions:
- Event builder shape and field defaults
- `detect_purchase_order_changes()` — Draft/Received/Billed/PartlyBilled paths, dual-event emission, Omni field mapping, data preservation
- `dispatch_change_events()` — PO routing, invoice routing, mixed batch, unknown entity passthrough
- `poll_purchase_orders()` — watermark update, Omni skip, `modified_since` forwarding, API error resilience, `poll_all()` integration
- `ENTITY_TYPES` and `_CONNECTION_ATTR` completeness, `seed_from_connection()` PO watermark load

### DB migration required
Run `migrations/add_cin7_po_watermark.sql` against Supabase (Settings → SQL Editor). Safe to re-run.

🤖 Generated with Claude (Cowork mode)