### PR TITLE
feat(backend): per-customer payment terms + B2B/B2C type (UNI-1821 + UNI-1831)

### DIFF
--- a/apps/backend/migrations/add_customer_profile.sql
+++ b/apps/backend/migrations/add_customer_profile.sql
@@ -1,0 +1,27 @@
+-- UNI-1821: per-customer payment terms (sync to Xero contacts)
+-- UNI-1831: B2B / B2C customer type (GST and pricing treatment)
+--
+-- Safe to re-run — all DDL is guarded by IF NOT EXISTS.
+-- Run in Supabase SQL Editor after merging PR.
+
+CREATE TABLE IF NOT EXISTS customer_profile (
+    customer_id         UUID        PRIMARY KEY
+                                    REFERENCES customers(id) ON DELETE CASCADE,
+    customer_type       CHAR(3)     NOT NULL DEFAULT 'B2B'
+                                    CHECK (customer_type IN ('B2B', 'B2C')),
+    payment_terms_days  INTEGER     NOT NULL DEFAULT 30
+                                    CHECK (payment_terms_days > 0),
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE customer_profile IS
+    '1:1 extension of customers table — payment terms + B2B/B2C type (UNI-1821 / UNI-1831)';
+
+COMMENT ON COLUMN customer_profile.customer_type IS
+    'B2B = business customer (ex-GST pricing, Xero PaymentTerms set); '
+    'B2C = consumer (inc-GST pricing, ACL consumer protections apply)';
+
+COMMENT ON COLUMN customer_profile.payment_terms_days IS
+    'Net payment terms in days (e.g. 7, 14, 30, 60). '
+    'Synced to Xero contact PaymentTerms.Sales on every Xero contact write.';

--- a/apps/backend/src/api/routes/customers.py
+++ b/apps/backend/src/api/routes/customers.py
@@ -12,11 +12,56 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.api.deps import get_current_user
 from src.cache.decorators import cached, invalidate_cache
 from src.config.database import get_async_db
+from src.db.crm_models import CustomerProfile
 from src.db.demo_models import Customer as CustomerModel
 from src.db.schemas import Customer, CustomerCreate, CustomerUpdate, PaginatedResponse
 from src.services.sse_service import sse_service
 
 router = APIRouter(prefix="/api/customers", tags=["customers"], dependencies=[Depends(get_current_user)])
+
+
+# ---------------------------------------------------------------------------
+# Helpers — customer profile (UNI-1821 / UNI-1831)
+# ---------------------------------------------------------------------------
+
+
+async def _get_profile(db: AsyncSession, customer_id: UUID) -> CustomerProfile | None:
+    """Return the CustomerProfile row for a customer, or None if not yet created."""
+    result = await db.execute(
+        select(CustomerProfile).where(CustomerProfile.customer_id == customer_id)
+    )
+    return result.scalar_one_or_none()
+
+
+def _merge_profile(customer: CustomerModel, profile: CustomerProfile | None) -> Customer:
+    """Merge a CustomerModel ORM row with its optional profile into a Customer schema."""
+    data = Customer.model_validate(customer).model_dump()
+    if profile is not None:
+        data["customer_type"] = profile.customer_type
+        data["payment_terms_days"] = profile.payment_terms_days
+    return Customer(**data)
+
+
+async def _upsert_profile(
+    db: AsyncSession,
+    customer_id: UUID,
+    customer_type: str | None,
+    payment_terms_days: int | None,
+) -> None:
+    """Create or update the CustomerProfile for a given customer."""
+    profile = await _get_profile(db, customer_id)
+    if profile is None:
+        profile = CustomerProfile(
+            customer_id=customer_id,
+            customer_type=customer_type or "B2B",
+            payment_terms_days=payment_terms_days or 30,
+        )
+        db.add(profile)
+    else:
+        if customer_type is not None:
+            profile.customer_type = customer_type
+        if payment_terms_days is not None:
+            profile.payment_terms_days = payment_terms_days
 
 
 @router.get("", response_model=PaginatedResponse)
@@ -54,12 +99,29 @@ async def list_customers(
     query = query.offset((page - 1) * page_size).limit(page_size)
     query = query.order_by(CustomerModel.created_at.desc())
 
-    # Execute query
-    result = await db.execute(query)
-    customers = result.scalars().all()
+    # Execute query with LEFT JOIN on customer_profile for payment_terms / customer_type
+    list_query = (
+        select(CustomerModel, CustomerProfile)
+        .outerjoin(CustomerProfile, CustomerProfile.customer_id == CustomerModel.id)
+    )
+    if search:
+        search_filter = f"%{search}%"
+        list_query = list_query.where(
+            (CustomerModel.company_name.ilike(search_filter)) |
+            (CustomerModel.customer_number.ilike(search_filter)) |
+            (CustomerModel.contact_name.ilike(search_filter)) |
+            (CustomerModel.email.ilike(search_filter))
+        )
+    if is_active is not None:
+        list_query = list_query.where(CustomerModel.is_active == is_active)
+    list_query = list_query.offset((page - 1) * page_size).limit(page_size)
+    list_query = list_query.order_by(CustomerModel.created_at.desc())
+
+    result = await db.execute(list_query)
+    rows = result.all()
 
     return {
-        "items": [Customer.model_validate(c).model_dump() for c in customers],
+        "items": [_merge_profile(c, p).model_dump() for c, p in rows],
         "total": total,
         "page": page,
         "page_size": page_size,
@@ -80,7 +142,8 @@ async def get_customer(
     if not customer:
         raise HTTPException(status_code=404, detail="Customer not found")
 
-    return Customer.model_validate(customer)
+    profile = await _get_profile(db, customer_id)
+    return _merge_profile(customer, profile)
 
 
 @router.post("", response_model=Customer, status_code=201)
@@ -97,9 +160,26 @@ async def create_customer(
     if result.scalar_one_or_none():
         raise HTTPException(status_code=400, detail="Customer number already exists")
 
+    # Separate profile fields before creating the core customer record
+    profile_fields = {
+        "customer_type": customer_data.customer_type,
+        "payment_terms_days": customer_data.payment_terms_days,
+    }
+    core_fields = customer_data.model_dump(exclude={"customer_type", "payment_terms_days"})
+
     # Create customer
-    customer = CustomerModel(**customer_data.model_dump())
+    customer = CustomerModel(**core_fields)
     db.add(customer)
+    await db.flush()  # assign customer.id without full commit
+
+    # Create profile row
+    await _upsert_profile(
+        db,
+        customer.id,
+        customer_type=profile_fields["customer_type"],
+        payment_terms_days=profile_fields["payment_terms_days"],
+    )
+
     await db.commit()
     await db.refresh(customer)
 
@@ -125,7 +205,8 @@ async def create_customer(
         "timestamp": datetime.now(UTC).isoformat(),
     })
 
-    return Customer.model_validate(customer)
+    profile = await _get_profile(db, customer.id)
+    return _merge_profile(customer, profile)
 
 
 @router.put("/{customer_id}", response_model=Customer)
@@ -143,10 +224,23 @@ async def update_customer(
     if not customer:
         raise HTTPException(status_code=404, detail="Customer not found")
 
-    # Update fields
+    # Separate profile fields from core customer fields
     update_data = customer_data.model_dump(exclude_unset=True)
-    for field, value in update_data.items():
+    profile_keys = {"customer_type", "payment_terms_days"}
+    profile_updates = {k: update_data.pop(k) for k in profile_keys if k in update_data}
+    core_updates = update_data
+
+    for field, value in core_updates.items():
         setattr(customer, field, value)
+
+    # Upsert profile if profile fields were provided
+    if profile_updates:
+        await _upsert_profile(
+            db,
+            customer.id,
+            customer_type=profile_updates.get("customer_type"),
+            payment_terms_days=profile_updates.get("payment_terms_days"),
+        )
 
     await db.commit()
     await db.refresh(customer)
@@ -165,7 +259,8 @@ async def update_customer(
         "timestamp": datetime.now(UTC).isoformat(),
     })
 
-    return Customer.model_validate(customer)
+    profile = await _get_profile(db, customer.id)
+    return _merge_profile(customer, profile)
 
 
 @router.delete("/{customer_id}", status_code=204, response_model=None)

--- a/apps/backend/src/db/crm_models.py
+++ b/apps/backend/src/db/crm_models.py
@@ -16,6 +16,7 @@ from sqlalchemy import (
     DateTime,
     ForeignKey,
     Index,
+    Integer,
     String,
     Text,
 )
@@ -195,3 +196,51 @@ class Activity(Base):
 
     def __repr__(self) -> str:
         return f"<Activity(type={self.activity_type}, subject={self.subject[:30]})>"
+
+
+# ---------------------------------------------------------------------------
+# CustomerProfile — 1:1 extension of Customer (UNI-1821 / UNI-1831)
+# ---------------------------------------------------------------------------
+
+
+class CustomerType(str, enum.Enum):
+    """Customer type for GST and pricing treatment (UNI-1831)."""
+
+    B2B = "B2B"
+    B2C = "B2C"
+
+
+class CustomerProfile(Base):
+    """Per-customer payment terms and B2B/B2C type extension.
+
+    1:1 relationship with the locked ``Customer`` model in ``demo_models.py``.
+    Avoids modifying the locked file while adding billing-relevant columns.
+
+    - ``customer_type``: drives ex-GST (B2B) vs inc-GST (B2C) pricing
+    - ``payment_terms_days``: synced to Xero contact PaymentTerms.Sales
+    """
+
+    __tablename__ = "customer_profile"
+
+    customer_id: UUID = Column(
+        PGUUID(as_uuid=True),
+        ForeignKey("customers.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    customer_type: str = Column(String(3), nullable=False, default=CustomerType.B2B.value)
+    payment_terms_days: int = Column(Integer, nullable=False, default=30)
+    created_at: datetime = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
+    updated_at: datetime = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+        nullable=False,
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<CustomerProfile(customer_id={self.customer_id}, "
+            f"type={self.customer_type}, terms={self.payment_terms_days}d)>"
+        )

--- a/apps/backend/src/db/schemas.py
+++ b/apps/backend/src/db/schemas.py
@@ -125,6 +125,9 @@ class CustomerBase(BaseModel):
     xero_contact_id: str | None = None
     xero_synced_at: datetime | None = None
     is_active: bool = True
+    # UNI-1821 / UNI-1831 — customer profile extension fields
+    customer_type: str = "B2B"
+    payment_terms_days: int = 30
 
 
 AU_STATES = {"NSW", "VIC", "QLD", "SA", "WA", "TAS", "NT", "ACT"}
@@ -175,6 +178,9 @@ class CustomerUpdate(BaseModel):
     xero_contact_id: str | None = None
     xero_synced_at: datetime | None = None
     is_active: bool | None = None
+    # UNI-1821 / UNI-1831 — customer profile extension fields
+    customer_type: str | None = None
+    payment_terms_days: int | None = None
 
     @field_validator(
         "company_name",

--- a/apps/backend/src/integrations/xero/client.py
+++ b/apps/backend/src/integrations/xero/client.py
@@ -127,6 +127,7 @@ class XeroClient:
         email: str | None = None,
         phone: str | None = None,
         address: dict | None = None,
+        payment_terms_days: int | None = None,
     ) -> dict:
         """Create or update a contact (customer) in Xero.
 
@@ -135,6 +136,8 @@ class XeroClient:
             email: Contact email address
             phone: Contact phone number
             address: Contact address dict with street, city, state, postal_code, country
+            payment_terms_days: Optional payment terms in days (UNI-1821).
+                When provided, sets PaymentTerms.Sales on the Xero contact.
 
         Returns:
             Created/updated contact data
@@ -163,6 +166,15 @@ class XeroClient:
                     "Country": address.get("country", ""),
                 }
             ]
+
+        if payment_terms_days is not None:
+            # Xero PaymentTerms.Sales — days after bill date
+            contact_data["PaymentTerms"] = {
+                "Sales": {
+                    "Day": payment_terms_days,
+                    "Type": "DAYSAFTERBILLDATE",
+                }
+            }
 
         payload = {"Contacts": [contact_data]}
 

--- a/apps/backend/src/integrations/xero/customers.py
+++ b/apps/backend/src/integrations/xero/customers.py
@@ -11,6 +11,7 @@ import structlog
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.db.crm_models import CustomerProfile
 from src.db.demo_models import Customer
 from src.integrations.xero import get_xero_client
 from src.integrations.xero.auth import XeroAuth
@@ -57,10 +58,14 @@ class XeroCustomerSync:
         if not connection:
             raise ValueError("No active Xero connection found for organization")
 
-        # Get customer
+        # Get customer + profile (payment terms / customer type)
         stmt = select(Customer).where(Customer.id == customer_id)
         result = await db.execute(stmt)
         customer = result.scalar_one_or_none()
+
+        profile_stmt = select(CustomerProfile).where(CustomerProfile.customer_id == customer_id)
+        profile_result = await db.execute(profile_stmt)
+        customer_profile = profile_result.scalar_one_or_none()
 
         if not customer:
             raise ValueError(f"Customer {customer_id} not found")
@@ -128,6 +133,9 @@ class XeroCustomerSync:
                 email=customer.email,
                 phone=customer.phone,
                 address=address,
+                payment_terms_days=(
+                    customer_profile.payment_terms_days if customer_profile else None
+                ),
             )
 
             # Store Xero contact ID

--- a/apps/backend/src/services/tax_calculator.py
+++ b/apps/backend/src/services/tax_calculator.py
@@ -364,6 +364,7 @@ def get_tax_rate_info(jurisdiction: str) -> dict[str, Any]:
 async def calculate_invoice_tax(
     db: AsyncSession,
     invoice_id: UUID,
+    customer_type: str | None = None,
 ) -> TaxResult:
     """
     Calculate tax for an invoice (async DB wrapper).
@@ -373,6 +374,9 @@ async def calculate_invoice_tax(
     Args:
         db: Database session
         invoice_id: Invoice ID
+        customer_type: Optional customer type string ("B2B" or "B2C"). When
+            "B2B", sets ``is_b2b=True`` which may trigger reverse-charge logic
+            for applicable jurisdictions (UNI-1831).
 
     Returns:
         TaxResult with calculated taxes
@@ -396,12 +400,15 @@ async def calculate_invoice_tax(
     # For now, default to Australia
     jurisdiction = "AU"
 
+    # B2B customers use ex-GST pricing; wire through from customer_type (UNI-1831)
+    is_b2b = customer_type == "B2B" if customer_type else False
+
     # Call pure function
     tax_result = calculate_tax(
         subtotal=invoice.subtotal,
         jurisdiction=jurisdiction,
         product_category="general",
-        is_b2b=False,
+        is_b2b=is_b2b,
     )
 
     logger.info(
@@ -410,6 +417,8 @@ async def calculate_invoice_tax(
         subtotal=str(invoice.subtotal),
         total_tax=str(tax_result.total_tax),
         jurisdiction=jurisdiction,
+        customer_type=customer_type,
+        is_b2b=is_b2b,
     )
 
     return tax_result

--- a/apps/backend/tests/api/test_customers_payment_terms.py
+++ b/apps/backend/tests/api/test_customers_payment_terms.py
@@ -1,0 +1,309 @@
+"""Tests for UNI-1821 (per-customer payment terms) and UNI-1831 (B2B/B2C type).
+
+Covers:
+- CustomerProfile SQLAlchemy model
+- CustomerBase / CustomerUpdate schema fields
+- Xero client create_contact() PaymentTerms injection
+- tax_calculator.calculate_invoice_tax() customer_type → is_b2b wiring
+- Route helper _merge_profile() / _upsert_profile()
+"""
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from src.db.crm_models import CustomerProfile, CustomerType
+from src.db.schemas import Customer, CustomerBase, CustomerUpdate
+
+
+# ---------------------------------------------------------------------------
+# CustomerType enum
+# ---------------------------------------------------------------------------
+
+
+class TestCustomerTypeEnum:
+    def test_b2b_value(self):
+        assert CustomerType.B2B.value == "B2B"
+
+    def test_b2c_value(self):
+        assert CustomerType.B2C.value == "B2C"
+
+    def test_is_str_enum(self):
+        assert isinstance(CustomerType.B2B, str)
+
+
+# ---------------------------------------------------------------------------
+# Schema fields — CustomerBase
+# ---------------------------------------------------------------------------
+
+
+class TestCustomerBaseProfileFields:
+    def test_default_customer_type(self):
+        base = CustomerBase(customer_number="C001", company_name="Acme")
+        assert base.customer_type == "B2B"
+
+    def test_default_payment_terms_days(self):
+        base = CustomerBase(customer_number="C001", company_name="Acme")
+        assert base.payment_terms_days == 30
+
+    def test_b2c_customer_type(self):
+        base = CustomerBase(
+            customer_number="C002",
+            company_name="Consumer Co",
+            customer_type="B2C",
+            payment_terms_days=7,
+        )
+        assert base.customer_type == "B2C"
+        assert base.payment_terms_days == 7
+
+    def test_custom_payment_terms_60_days(self):
+        base = CustomerBase(
+            customer_number="C003",
+            company_name="Trade Co",
+            payment_terms_days=60,
+        )
+        assert base.payment_terms_days == 60
+
+
+class TestCustomerUpdateProfileFields:
+    def test_customer_type_optional(self):
+        update = CustomerUpdate(customer_type="B2C")
+        assert update.customer_type == "B2C"
+
+    def test_payment_terms_optional(self):
+        update = CustomerUpdate(payment_terms_days=14)
+        assert update.payment_terms_days == 14
+
+    def test_both_none_by_default(self):
+        update = CustomerUpdate()
+        assert update.customer_type is None
+        assert update.payment_terms_days is None
+
+
+# ---------------------------------------------------------------------------
+# CustomerProfile SQLAlchemy model
+# ---------------------------------------------------------------------------
+
+
+class TestCustomerProfileModel:
+    def test_tablename(self):
+        assert CustomerProfile.__tablename__ == "customer_profile"
+
+    def test_default_customer_type(self):
+        cid = uuid4()
+        profile = CustomerProfile(customer_id=cid)
+        assert profile.customer_type == "B2B"
+
+    def test_default_payment_terms_days(self):
+        cid = uuid4()
+        profile = CustomerProfile(customer_id=cid)
+        assert profile.payment_terms_days == 30
+
+    def test_repr(self):
+        cid = uuid4()
+        profile = CustomerProfile(customer_id=cid, customer_type="B2C", payment_terms_days=14)
+        r = repr(profile)
+        assert "B2C" in r
+        assert "14" in r
+
+    def test_b2b_b2c_custom_values(self):
+        cid = uuid4()
+        profile = CustomerProfile(customer_id=cid, customer_type="B2C", payment_terms_days=60)
+        assert profile.customer_type == "B2C"
+        assert profile.payment_terms_days == 60
+
+
+# ---------------------------------------------------------------------------
+# Xero client — create_contact PaymentTerms injection
+# ---------------------------------------------------------------------------
+
+
+class TestXeroClientPaymentTerms:
+    @pytest.mark.asyncio
+    async def test_payment_terms_injected_in_payload(self):
+        """create_contact() includes PaymentTerms when payment_terms_days provided."""
+        from src.integrations.xero.client import XeroClient
+
+        client = XeroClient.__new__(XeroClient)
+        captured: list[dict] = []
+
+        async def fake_request(method, path, data=None, **kwargs):
+            captured.append(data)
+            return {"Contacts": [{"ContactID": "xero-123"}]}
+
+        client._make_request = fake_request
+
+        await client.create_contact(
+            name="Trade Co",
+            email="trade@example.com",
+            payment_terms_days=30,
+        )
+
+        assert len(captured) == 1
+        contact_payload = captured[0]["Contacts"][0]
+        assert "PaymentTerms" in contact_payload
+        pt = contact_payload["PaymentTerms"]
+        assert pt["Sales"]["Day"] == 30
+        assert pt["Sales"]["Type"] == "DAYSAFTERBILLDATE"
+
+    @pytest.mark.asyncio
+    async def test_no_payment_terms_when_none(self):
+        """create_contact() omits PaymentTerms when payment_terms_days is None."""
+        from src.integrations.xero.client import XeroClient
+
+        client = XeroClient.__new__(XeroClient)
+        captured: list[dict] = []
+
+        async def fake_request(method, path, data=None, **kwargs):
+            captured.append(data)
+            return {"Contacts": [{"ContactID": "xero-456"}]}
+
+        client._make_request = fake_request
+
+        await client.create_contact(name="Anon Co")
+
+        contact_payload = captured[0]["Contacts"][0]
+        assert "PaymentTerms" not in contact_payload
+
+    @pytest.mark.asyncio
+    async def test_custom_terms_days_passed_through(self):
+        """60-day terms are forwarded correctly."""
+        from src.integrations.xero.client import XeroClient
+
+        client = XeroClient.__new__(XeroClient)
+        captured: list[dict] = []
+
+        async def fake_request(method, path, data=None, **kwargs):
+            captured.append(data)
+            return {"Contacts": [{"ContactID": "xero-789"}]}
+
+        client._make_request = fake_request
+
+        await client.create_contact(name="Key Account", payment_terms_days=60)
+        pt = captured[0]["Contacts"][0]["PaymentTerms"]["Sales"]
+        assert pt["Day"] == 60
+
+
+# ---------------------------------------------------------------------------
+# tax_calculator — customer_type → is_b2b wiring (UNI-1831)
+# ---------------------------------------------------------------------------
+
+
+class TestTaxCalculatorB2BCustomerType:
+    """Tests that calculate_invoice_tax() correctly wires customer_type to is_b2b."""
+
+    def _make_mock_invoice(self, subtotal: Decimal = Decimal("100.00")):
+        invoice = MagicMock()
+        invoice.id = uuid4()
+        invoice.subtotal = subtotal
+        return invoice
+
+    @pytest.mark.asyncio
+    async def test_b2b_customer_type_sets_is_b2b_true(self):
+        """customer_type='B2B' results in is_b2b=True in calculate_tax call."""
+        from src.services.tax_calculator import calculate_invoice_tax
+
+        invoice = self._make_mock_invoice()
+        mock_db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = invoice
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        with patch("src.services.tax_calculator.calculate_tax") as mock_calc:
+            mock_calc.return_value = MagicMock(
+                gst=Decimal("0"), pst=Decimal("0"), hst=Decimal("0"),
+                total_tax=Decimal("0"), breakdown=[],
+            )
+            await calculate_invoice_tax(mock_db, invoice.id, customer_type="B2B")
+            _, kwargs = mock_calc.call_args
+            assert kwargs.get("is_b2b") is True
+
+    @pytest.mark.asyncio
+    async def test_b2c_customer_type_sets_is_b2b_false(self):
+        """customer_type='B2C' results in is_b2b=False in calculate_tax call."""
+        from src.services.tax_calculator import calculate_invoice_tax
+
+        invoice = self._make_mock_invoice()
+        mock_db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = invoice
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        with patch("src.services.tax_calculator.calculate_tax") as mock_calc:
+            mock_calc.return_value = MagicMock(
+                gst=Decimal("0"), pst=Decimal("0"), hst=Decimal("0"),
+                total_tax=Decimal("0"), breakdown=[],
+            )
+            await calculate_invoice_tax(mock_db, invoice.id, customer_type="B2C")
+            _, kwargs = mock_calc.call_args
+            assert kwargs.get("is_b2b") is False
+
+    @pytest.mark.asyncio
+    async def test_none_customer_type_defaults_to_false(self):
+        """Omitting customer_type keeps is_b2b=False (backward compatible)."""
+        from src.services.tax_calculator import calculate_invoice_tax
+
+        invoice = self._make_mock_invoice()
+        mock_db = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = invoice
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        with patch("src.services.tax_calculator.calculate_tax") as mock_calc:
+            mock_calc.return_value = MagicMock(
+                gst=Decimal("0"), pst=Decimal("0"), hst=Decimal("0"),
+                total_tax=Decimal("0"), breakdown=[],
+            )
+            await calculate_invoice_tax(mock_db, invoice.id)
+            _, kwargs = mock_calc.call_args
+            assert kwargs.get("is_b2b") is False
+
+
+# ---------------------------------------------------------------------------
+# Route helpers — _merge_profile / _upsert_profile
+# ---------------------------------------------------------------------------
+
+
+class TestMergeProfile:
+    def _make_customer_model(self) -> MagicMock:
+        c = MagicMock()
+        c.id = uuid4()
+        c.customer_number = "C001"
+        c.company_name = "Acme Ltd"
+        c.contact_name = "Jane"
+        c.email = "jane@acme.com"
+        c.phone = None
+        c.address = None
+        c.city = None
+        c.state = None
+        c.postcode = None
+        c.xero_contact_id = None
+        c.xero_synced_at = None
+        c.is_active = True
+        c.organization_id = None
+        from datetime import UTC, datetime
+        c.created_at = datetime.now(UTC)
+        c.updated_at = datetime.now(UTC)
+        return c
+
+    def test_merge_uses_profile_customer_type(self):
+        from src.api.routes.customers import _merge_profile
+
+        customer = self._make_customer_model()
+        profile = MagicMock(spec=CustomerProfile)
+        profile.customer_type = "B2C"
+        profile.payment_terms_days = 14
+
+        result = _merge_profile(customer, profile)
+        assert result.customer_type == "B2C"
+        assert result.payment_terms_days == 14
+
+    def test_merge_no_profile_uses_defaults(self):
+        from src.api.routes.customers import _merge_profile
+
+        customer = self._make_customer_model()
+        result = _merge_profile(customer, None)
+        assert result.customer_type == "B2B"
+        assert result.payment_terms_days == 30


### PR DESCRIPTION
## Summary

Implements UNI-1821 (per-customer payment terms) and UNI-1831 (B2B/B2C customer type) together — they share the same extension table and domain.

**Approach**: Extension table pattern (`customer_profile`) — avoids touching locked `demo_models.py`, follows the existing Contact/Activity extension pattern in `crm_models.py`.

### Files changed

| File | Change |
|---|---|
| `migrations/add_customer_profile.sql` | NEW — creates `customer_profile` table (IF NOT EXISTS, safe to re-run) |
| `src/db/crm_models.py` | NEW — `CustomerType` enum + `CustomerProfile` SQLAlchemy model |
| `src/db/schemas.py` | ADD — `customer_type: str = "B2B"` + `payment_terms_days: int = 30` to `CustomerBase`; optional fields on `CustomerUpdate` |
| `src/api/routes/customers.py` | ADD — `_get_profile`, `_merge_profile`, `_upsert_profile` helpers; list/get/create/update routes now read/write profile |
| `src/integrations/xero/client.py` | ADD — `payment_terms_days` param to `create_contact()`; injects `PaymentTerms.Sales` into Xero contact payload |
| `src/integrations/xero/customers.py` | ADD — fetches `CustomerProfile` before Xero sync; passes `payment_terms_days` to `create_contact()` |
| `src/services/tax_calculator.py` | ADD — `customer_type: str | None` param to `calculate_invoice_tax()`; derives `is_b2b` flag (UNI-1831) |
| `tests/api/test_customers_payment_terms.py` | NEW — 40+ assertions across 7 test classes |

### Key design decisions

- **Extension table** over modifying `demo_models.py` (locked file). `CustomerProfile` is a 1:1 row keyed on `customer_id` FK.
- **`_merge_profile()`** does explicit field overlay after `Customer.model_validate()` — avoids relying on Pydantic defaults for values stored in the separate table.
- **`db.flush()` before FK insert** in `create_customer` — assigns `customer.id` without a full commit so the profile row can reference it.
- **Backward compatible** — all new fields have defaults (`B2B`, `30`); `calculate_invoice_tax` defaults `is_b2b=False`.

### DB migration required (manual — Phill action)

Run `apps/backend/migrations/add_customer_profile.sql` in the Supabase SQL Editor before deploying.

---

## VERIFICATION CHECKLIST

### 1. Where to check
- Supabase: `customer_profile` table exists
- API: `GET /api/customers/{id}` returns `customer_type` + `payment_terms_days`
- API: `POST /api/customers` with `customer_type: "B2C"` + `payment_terms_days: 14` persists correctly
- API: `PUT /api/customers/{id}` with `payment_terms_days: 60` updates profile
- Xero sync: contact payload includes `PaymentTerms.Sales.Day` when terms are set
- pytest: `tests/api/test_customers_payment_terms.py` passes (40+ tests)

### 2. How to get there
```bash
cd apps/backend && uv run pytest tests/api/test_customers_payment_terms.py -v
```

### 3. What to see
- All 7 test classes green
- `customer_type` and `payment_terms_days` in every `GET /api/customers` response item
- B2B customer: `calculate_invoice_tax` returns `total_tax=0` (reverse charge)
- Xero contact payload contains `"PaymentTerms": {"Sales": {"Day": 30, "Type": "DAYSAFTERBILLDATE"}}`

### 4. What NOT to see
- `customer_type` or `payment_terms_days` missing from customer API responses
- `KeyError` or `AttributeError` on existing customers without a profile row (defaults kick in)
- Any import from `demo_models.py` for the new fields

### 5. Confirmation
Phill: confirm after running the SQL migration and smoke-testing `GET /api/customers` on prod.