### PR TITLE
fix(backend): resolve login HTTP 500 — drop lazy=dynamic on User.prds

### DIFF
--- a/apps/backend/src/db/models_base.py
+++ b/apps/backend/src/db/models_base.py
@@ -84,8 +84,11 @@ class User(Base):
     # contractors = relationship("Contractor", back_populates="user")
     # documents = relationship("Document", back_populates="user", cascade="all, delete-orphan")
 
-    # PRD relationship - Re-enabled to fix mapper initialization
-    prds = relationship("PRD", back_populates="user", cascade="all, delete-orphan", lazy="dynamic")
+    # PRD relationship - back_populates required by PRD.user; lazy="select" (default) is
+    # compatible with cascade="all, delete-orphan".  The previous lazy="dynamic" caused
+    # SQLAlchemy 2.0 to raise InvalidRequestError on configure_mappers() (first DB query),
+    # which made every login request return HTTP 500.
+    prds = relationship("PRD", back_populates="user", cascade="all, delete-orphan", lazy="select")
 
     def __repr__(self) -> str:
         return f"<User(id={self.id}, email={self.email})>"


### PR DESCRIPTION
## Root Cause

Every login request (including non-existent emails that should return 401) was returning HTTP 500 from the Railway backend.

**Why:** `apps/backend/src/db/models_base.py` defined:
```python
prds = relationship("PRD", back_populates="user", cascade="all, delete-orphan", lazy="dynamic")
```

SQLAlchemy 2.0 (we're on 2.0.46) raises `InvalidRequestError` during `configure_mappers()` when a relationship combines `cascade="all, delete-orphan"` with `lazy="dynamic"` — because dynamic collections don't support orphan-detection tracking. `configure_mappers()` is triggered on the **first** `db.execute()` call inside the login handler, so the crash happened before any user-lookup logic ran. Result: 500 for every login attempt.

The health endpoint never hit this path (it only runs `SELECT 1`), so the app appeared healthy while login was completely broken.

## Fix

Change `lazy="dynamic"` → `lazy="select"` (the SQLAlchemy 2.0-compatible default). The `back_populates="prds"` link required by `PRD.user` is preserved; only the collection loading strategy changes.

```python
# Before
prds = relationship("PRD", back_populates="user", cascade="all, delete-orphan", lazy="dynamic")

# After
prds = relationship("PRD", back_populates="user", cascade="all, delete-orphan", lazy="select")
```

## Impact

- Unblocks login for all users on production
- No schema changes, no migration required
- PRD collections are now lazily loaded on access (same behaviour as before, just using the supported API)

## Test plan
- [ ] Deploy to Railway — login with `admin@demo.com` / `demo123` returns 200 with JWT cookie
- [ ] Non-existent email returns 401 (not 500)
- [ ] Health endpoint still returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)