### PR TITLE
feat(workshop): digital job card Phase 1 — frontend UI + API client (UNI-1825)

### DIFF
--- a/apps/web/app/(dashboard)/workshop/jobs/[id]/page.tsx
+++ b/apps/web/app/(dashboard)/workshop/jobs/[id]/page.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useToast } from '@/hooks/use-toast';
+import { workshopApi, type JobCard, type TimeLog, type JobCardStatus } from '@/lib/api/workshop';
+import { ArrowLeft, PlayCircle, StopCircle, Clock } from 'lucide-react';
+
+const STATUS_COLORS: Record<JobCardStatus, string> = {
+  open: 'bg-blue-100 text-blue-800',
+  in_progress: 'bg-yellow-100 text-yellow-800',
+  completed: 'bg-green-100 text-green-800',
+  cancelled: 'bg-red-100 text-red-800',
+};
+
+function fmtDuration(minutes: number | null): string {
+  if (minutes === null) return '—';
+  const h = Math.floor(minutes / 60);
+  const m = Math.round(minutes % 60);
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
+function fmtTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function fmtDate(iso: string): string {
+  return new Date(iso).toLocaleDateString([], { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+export default function JobCardDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const { toast } = useToast();
+
+  const [card, setCard] = useState<JobCard | null>(null);
+  const [logs, setLogs] = useState<TimeLog[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [timerRunning, setTimerRunning] = useState(false);
+  const [activeLogId, setActiveLogId] = useState<string | null>(null);
+  const [techName, setTechName] = useState('');
+  const [acting, setActing] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const data = await workshopApi.getJob(id);
+      setCard(data.job_card);
+      setLogs(data.time_logs);
+      // Find any running timer (stopped_at is null)
+      const running = data.time_logs.find((l) => l.stopped_at === null);
+      setTimerRunning(!!running);
+      setActiveLogId(running?.id ?? null);
+    } catch (error: unknown) {
+      toast({
+        title: 'Error',
+        description: error instanceof Error ? error.message : 'Failed to load job card',
+        variant: 'destructive',
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [id, toast]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function handleStartTimer() {
+    if (!techName.trim()) {
+      toast({ title: 'Enter technician name before starting the timer', variant: 'destructive' });
+      return;
+    }
+    setActing(true);
+    try {
+      const log = await workshopApi.createTimeLog(id, {
+        technician_name: techName.trim(),
+        started_at: new Date().toISOString(),
+      });
+      setLogs((prev) => [log, ...prev]);
+      setTimerRunning(true);
+      setActiveLogId(log.id);
+      toast({ title: 'Timer started' });
+      load();
+    } catch (error: unknown) {
+      toast({
+        title: 'Error',
+        description: error instanceof Error ? error.message : 'Failed to start timer',
+        variant: 'destructive',
+      });
+    } finally {
+      setActing(false);
+    }
+  }
+
+  async function handleStopTimer() {
+    if (!activeLogId) return;
+    setActing(true);
+    try {
+      await workshopApi.stopTimeLog(id, activeLogId, new Date().toISOString());
+      setTimerRunning(false);
+      setActiveLogId(null);
+      toast({ title: 'Timer stopped' });
+      load();
+    } catch (error: unknown) {
+      toast({
+        title: 'Error',
+        description: error instanceof Error ? error.message : 'Failed to stop timer',
+        variant: 'destructive',
+      });
+    } finally {
+      setActing(false);
+    }
+  }
+
+  const totalMinutes = logs.reduce((sum, l) => sum + (l.duration_minutes ?? 0), 0);
+
+  if (loading) {
+    return <div className="p-6 text-muted-foreground">Loading…</div>;
+  }
+
+  if (!card) {
+    return <div className="p-6 text-muted-foreground">Job card not found.</div>;
+  }
+
+  return (
+    <div className="space-y-6 p-6">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div className="flex items-start gap-3">
+          <Link href="/workshop/jobs">
+            <Button variant="ghost" size="sm">
+              <ArrowLeft className="mr-1 h-4 w-4" />
+              Jobs
+            </Button>
+          </Link>
+          <div>
+            <div className="flex items-center gap-2">
+              <span className="font-mono text-sm text-muted-foreground">{card.job_number}</span>
+              <Badge className={STATUS_COLORS[card.status]}>{card.status.replace('_', ' ')}</Badge>
+            </div>
+            <h1 className="mt-1 text-2xl font-bold">{card.title}</h1>
+            {card.assigned_technician && (
+              <p className="text-sm text-muted-foreground">
+                Assigned to: {card.assigned_technician}
+              </p>
+            )}
+            {card.description && (
+              <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-400">
+                {card.description}
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Timer control */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Clock className="h-5 w-5" />
+            Time Tracking
+            {totalMinutes > 0 && (
+              <span className="ml-auto text-base font-normal text-muted-foreground">
+                Total: {fmtDuration(totalMinutes)}
+              </span>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {timerRunning ? (
+            <div className="flex items-center gap-4">
+              <div className="flex items-center gap-2 text-sm text-yellow-700 dark:text-yellow-400">
+                <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-yellow-500" />
+                Timer running…
+              </div>
+              <Button
+                onClick={handleStopTimer}
+                disabled={acting}
+                variant="destructive"
+                size="sm"
+              >
+                <StopCircle className="mr-2 h-4 w-4" />
+                Stop timer
+              </Button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-3">
+              <input
+                type="text"
+                placeholder="Technician name"
+                value={techName}
+                onChange={(e) => setTechName(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleStartTimer()}
+                className="flex h-9 flex-1 rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              />
+              <Button onClick={handleStartTimer} disabled={acting || !techName.trim()} size="sm">
+                <PlayCircle className="mr-2 h-4 w-4" />
+                Start timer
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Time log entries */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Time Log ({logs.length} entries)</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {logs.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No time entries yet.</p>
+          ) : (
+            <div className="divide-y">
+              {logs.map((log) => (
+                <div key={log.id} className="flex items-center justify-between py-3">
+                  <div className="space-y-0.5">
+                    <p className="text-sm font-medium">{log.technician_name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {fmtDate(log.started_at)} · {fmtTime(log.started_at)}
+                      {log.stopped_at ? ` → ${fmtTime(log.stopped_at)}` : ''}
+                    </p>
+                    {log.notes && (
+                      <p className="text-xs text-neutral-500">{log.notes}</p>
+                    )}
+                  </div>
+                  <div className="text-right">
+                    {log.stopped_at ? (
+                      <span className="text-sm font-medium">{fmtDuration(log.duration_minutes)}</span>
+                    ) : (
+                      <span className="inline-flex items-center gap-1 text-xs text-yellow-600">
+                        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-yellow-500" />
+                        Running
+                      </span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/app/(dashboard)/workshop/jobs/page.tsx
+++ b/apps/web/app/(dashboard)/workshop/jobs/page.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import Link from 'next/link';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { useToast } from '@/hooks/use-toast';
+import { workshopApi, type JobCard, type JobCardStatus } from '@/lib/api/workshop';
+import { Plus, Wrench, ArrowLeft } from 'lucide-react';
+
+const STATUS_COLORS: Record<JobCardStatus, string> = {
+  open: 'bg-blue-100 text-blue-800',
+  in_progress: 'bg-yellow-100 text-yellow-800',
+  completed: 'bg-green-100 text-green-800',
+  cancelled: 'bg-red-100 text-red-800',
+};
+
+export default function JobCardsPage() {
+  const { toast } = useToast();
+  const [cards, setCards] = useState<JobCard[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [statusFilter, setStatusFilter] = useState('');
+  const [showCreate, setShowCreate] = useState(false);
+  const [newTitle, setNewTitle] = useState('');
+  const [creating, setCreating] = useState(false);
+
+  const loadCards = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await workshopApi.listJobs({ status: statusFilter || undefined });
+      setCards(data.items);
+      setTotal(data.total);
+    } catch (error: unknown) {
+      toast({
+        title: 'Error',
+        description: error instanceof Error ? error.message : 'Failed to load job cards',
+        variant: 'destructive',
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [statusFilter, toast]);
+
+  useEffect(() => {
+    loadCards();
+  }, [loadCards]);
+
+  async function handleCreate() {
+    if (!newTitle.trim()) return;
+    setCreating(true);
+    try {
+      await workshopApi.createJob({ title: newTitle.trim() });
+      setNewTitle('');
+      setShowCreate(false);
+      toast({ title: 'Job card created' });
+      loadCards();
+    } catch (error: unknown) {
+      toast({
+        title: 'Error',
+        description: error instanceof Error ? error.message : 'Failed to create job card',
+        variant: 'destructive',
+      });
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  const STATUSES: Array<{ value: string; label: string }> = [
+    { value: '', label: 'All' },
+    { value: 'open', label: 'Open' },
+    { value: 'in_progress', label: 'In Progress' },
+    { value: 'completed', label: 'Completed' },
+    { value: 'cancelled', label: 'Cancelled' },
+  ];
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Link href="/workshop">
+            <Button variant="ghost" size="sm">
+              <ArrowLeft className="mr-1 h-4 w-4" />
+              Workshop
+            </Button>
+          </Link>
+          <div>
+            <h1 className="text-2xl font-bold">Job Cards</h1>
+            <p className="text-neutral-600 dark:text-neutral-400">{total} total job cards</p>
+          </div>
+        </div>
+        <Button onClick={() => setShowCreate(!showCreate)}>
+          <Plus className="mr-2 h-4 w-4" /> New Job Card
+        </Button>
+      </div>
+
+      {showCreate && (
+        <Card>
+          <CardHeader>
+            <CardTitle>New Job Card</CardTitle>
+          </CardHeader>
+          <CardContent className="flex gap-3">
+            <Input
+              placeholder="Job title (e.g. 100-hour service — TM400)"
+              value={newTitle}
+              onChange={(e) => setNewTitle(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+              className="flex-1"
+            />
+            <Button onClick={handleCreate} disabled={creating || !newTitle.trim()}>
+              {creating ? 'Creating…' : 'Create'}
+            </Button>
+            <Button variant="outline" onClick={() => setShowCreate(false)}>
+              Cancel
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Status filter */}
+      <div className="flex gap-2">
+        {STATUSES.map(({ value, label }) => (
+          <button
+            key={value}
+            onClick={() => setStatusFilter(value)}
+            className={`rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
+              statusFilter === value
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-muted text-muted-foreground hover:bg-muted/80'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {loading ? (
+        <p className="text-muted-foreground text-sm">Loading…</p>
+      ) : cards.length === 0 ? (
+        <div className="py-12 text-center">
+          <Wrench className="mx-auto mb-3 h-8 w-8 text-muted-foreground" />
+          <p className="text-muted-foreground">No job cards found.</p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {cards.map((card) => (
+            <Link key={card.id} href={`/workshop/jobs/${card.id}`}>
+              <Card className="cursor-pointer transition-shadow hover:shadow-md">
+                <CardContent className="flex items-center justify-between p-4">
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2">
+                      <span className="font-mono text-xs text-muted-foreground">
+                        {card.job_number}
+                      </span>
+                      <Badge className={STATUS_COLORS[card.status]}>
+                        {card.status.replace('_', ' ')}
+                      </Badge>
+                    </div>
+                    <p className="font-medium">{card.title}</p>
+                    {card.assigned_technician && (
+                      <p className="text-sm text-muted-foreground">
+                        Technician: {card.assigned_technician}
+                      </p>
+                    )}
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {new Date(card.created_at).toLocaleDateString()}
+                  </p>
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/lib/api/workshop.ts
+++ b/apps/web/lib/api/workshop.ts
@@ -121,6 +121,43 @@ export interface Paginated<T> {
   total_pages: number;
 }
 
+// Job Card types (UNI-1825 Phase 1)
+export type JobCardStatus = 'open' | 'in_progress' | 'completed' | 'cancelled';
+
+export interface JobCard {
+  id: string;
+  job_number: string;
+  booking_id: string | null;
+  service_request_id: string | null;
+  equipment_id: string | null;
+  title: string;
+  description: string | null;
+  status: JobCardStatus;
+  assigned_technician: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TimeLog {
+  id: string;
+  job_card_id: string;
+  technician_name: string;
+  started_at: string;
+  stopped_at: string | null;
+  duration_minutes: number | null;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PaginatedJobCards {
+  items: JobCard[];
+  total: number;
+  page: number;
+  page_size: number;
+  total_pages: number;
+}
+
 export interface DashboardData {
   location: string;
   today: { bookings: WorkshopBooking[]; count: number };
@@ -269,4 +306,34 @@ export const workshopApi = {
     const qs = location ? `?location=${location}` : '';
     return apiClient.get<DashboardData>(`/api/workshop/dashboard${qs}`);
   },
+
+  // Job Cards (UNI-1825 Phase 1)
+  listJobs: (params?: {
+    page?: number;
+    page_size?: number;
+    status?: string;
+    equipment_id?: string;
+    booking_id?: string;
+  }) => {
+    const query = new URLSearchParams();
+    if (params?.page) query.set('page', String(params.page));
+    if (params?.page_size) query.set('page_size', String(params.page_size));
+    if (params?.status) query.set('status', params.status);
+    if (params?.equipment_id) query.set('equipment_id', params.equipment_id);
+    if (params?.booking_id) query.set('booking_id', params.booking_id);
+    const qs = query.toString();
+    return apiClient.get<PaginatedJobCards>(`/api/workshop/jobs${qs ? '?' + qs : ''}`);
+  },
+  createJob: (data: { title: string; description?: string; assigned_technician?: string; equipment_id?: string; booking_id?: string }) =>
+    apiClient.post<JobCard>('/api/workshop/jobs', data),
+  getJob: (id: string) =>
+    apiClient.get<{ job_card: JobCard; time_logs: TimeLog[] }>(`/api/workshop/jobs/${id}`),
+  updateJob: (id: string, data: { title?: string; description?: string; status?: JobCardStatus; assigned_technician?: string }) =>
+    apiClient.patch<JobCard>(`/api/workshop/jobs/${id}`, data),
+  listTimeLogs: (jobId: string) =>
+    apiClient.get<TimeLog[]>(`/api/workshop/jobs/${jobId}/time-logs`),
+  createTimeLog: (jobId: string, data: { technician_name: string; started_at: string; stopped_at?: string; notes?: string }) =>
+    apiClient.post<TimeLog>(`/api/workshop/jobs/${jobId}/time-logs`, data),
+  stopTimeLog: (jobId: string, logId: string, stopped_at: string) =>
+    apiClient.patch<TimeLog>(`/api/workshop/jobs/${jobId}/time-logs/${logId}`, { stopped_at }),
 };


### PR DESCRIPTION
## Summary
- Adds `JobCard`, `TimeLog`, `PaginatedJobCards` TypeScript interfaces to `workshop.ts` API client
- Adds 7 `workshopApi` methods: `listJobs`, `createJob`, `getJob`, `updateJob`, `listTimeLogs`, `createTimeLog`, `stopTimeLog`
- Creates `/workshop/jobs` list page (filterable by status, inline create form)
- Creates `/workshop/jobs/[id]` detail page with Start/Stop timer controls and time log table

## Backend (already merged on main)
- `apps/backend/src/db/workshop_models.py` — `JobCard` + `TimeLog` SQLAlchemy models
- `supabase/migrations/20260418000001_add_workshop_job_cards.sql` — tables, indexes, RLS
- `apps/backend/src/api/routes/workshop/job_cards.py` — full REST API (7 endpoints)
- `apps/backend/tests/api/test_job_card.py` — comprehensive test suite

## Verification
1. Supabase: `job_cards` and `time_logs` tables exist (migration already applied)
2. `cd apps/backend && uv run pytest tests/api/ -k job_card`
3. Navigate to `/workshop/jobs` → click job → "Start timer" → time log appears → "Stop" → duration recorded

Linear: UNI-1825

🤖 Generated with Claude Code