### PR TITLE
feat(inventory): serial number and lot/batch tracking schema — Phase 1 (UNI-1823)

### DIFF
--- a/apps/backend/src/api/routes/inventory.py
+++ b/apps/backend/src/api/routes/inventory.py
@@ -18,6 +18,10 @@ from src.api.deps import get_current_user
 from src.config.database import get_async_db
 from src.db.demo_models import Product
 from src.db.inventory_models import (
+    InventoryLot,
+    InventoryLotRead,
+    InventorySerial,
+    InventorySerialRead,
     ProductAttribute,
     ProductBarcode,
     ProductStockByLocation,
@@ -56,4 +60,50 @@ class AutoReorderRequest(BaseModel):
     """Request for auto-reorder trigger."""
 
     organization_id: UUID
- 
+
+
+# ============================================
+# Serial number and lot/batch read endpoints
+# UNI-1823 Phase 1 — schema + read API only
+# ============================================
+
+
+@router.get(
+    "/products/{product_id}/serials",
+    response_model=list[InventorySerialRead],
+    summary="List serial numbers for a product",
+)
+async def list_product_serials(
+    product_id: UUID,
+    status: str | None = Query(default=None, description="Filter by status"),
+    location: str | None = Query(default=None, description="Filter by location"),
+    db: AsyncSession = Depends(get_async_db),
+) -> list[InventorySerial]:
+    """Return all serial records for *product_id*, optionally filtered."""
+    stmt = select(InventorySerial).where(InventorySerial.product_id == product_id)
+    if status is not None:
+        stmt = stmt.where(InventorySerial.status == status)
+    if location is not None:
+        stmt = stmt.where(InventorySerial.location == location)
+    stmt = stmt.order_by(InventorySerial.created_at.desc())
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+@router.get(
+    "/products/{product_id}/lots",
+    response_model=list[InventoryLotRead],
+    summary="List lot/batch records for a product",
+)
+async def list_product_lots(
+    product_id: UUID,
+    location: str | None = Query(default=None, description="Filter by location"),
+    db: AsyncSession = Depends(get_async_db),
+) -> list[InventoryLot]:
+    """Return all lot/batch records for *product_id*, optionally filtered."""
+    stmt = select(InventoryLot).where(InventoryLot.product_id == product_id)
+    if location is not None:
+        stmt = stmt.where(InventoryLot.location == location)
+    stmt = stmt.order_by(InventoryLot.created_at.desc())
+    result = await db.execute(stmt)
+    return list(result.scalars().all())

--- a/apps/backend/src/db/inventory_models.py
+++ b/apps/backend/src/db/inventory_models.py
@@ -956,3 +956,152 @@ class RMAStatusUpdate(BaseModel):
     """Request body for advancing RMA status."""
 
     status: str
+
+
+# ----------------------------------------------------------------------------
+# Serial number and lot/batch tracking — Phase 1 (UNI-1823)
+# ----------------------------------------------------------------------------
+
+
+class InventorySerial(Base):
+    """Serial number tracking for individual serialised units.
+
+    Enables unit-level traceability from receipt (GRN) through sale
+    (order_item) and into service history. Required for warranty lookups
+    and WHS traceability recalls.
+    """
+
+    __tablename__ = "inventory_serials"
+
+    __table_args__ = (
+        UniqueConstraint("serial_number", name="uq_inventory_serial_number"),
+    )
+
+    id: UUID = Column(PostgresUUID(as_uuid=True), primary_key=True, default=uuid4)
+    product_id: UUID = Column(
+        PostgresUUID(as_uuid=True),
+        ForeignKey("products.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    serial_number: str = Column(String(200), nullable=False, index=True)
+    # available | reserved | sold | servicing | retired
+    status: str = Column(String(50), default="available", nullable=False, index=True)
+    location: str | None = Column(String(50), nullable=True, index=True)
+    grn_line_id: UUID | None = Column(
+        PostgresUUID(as_uuid=True),
+        ForeignKey("grn_line.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    order_item_id: UUID | None = Column(
+        PostgresUUID(as_uuid=True),
+        ForeignKey("order_items.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    notes: str | None = Column(Text, nullable=True)
+    created_at: datetime = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
+    updated_at: datetime = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+        nullable=False,
+    )
+
+    def __repr__(self) -> str:
+        return f"<InventorySerial(product_id={self.product_id}, sn={self.serial_number}, status={self.status})>"
+
+
+class InventoryLot(Base):
+    """Lot/batch tracking for bulk consumables and chemicals.
+
+    Enables batch-level traceability for WHS recall capability. Tracks
+    received quantity vs remaining quantity for depletion accounting.
+    """
+
+    __tablename__ = "inventory_lots"
+
+    __table_args__ = (
+        UniqueConstraint("product_id", "lot_number", name="uq_inventory_lot_product_lot"),
+        CheckConstraint("quantity_received >= 0", name="ck_lot_received_non_negative"),
+        CheckConstraint("quantity_remaining >= 0", name="ck_lot_remaining_non_negative"),
+    )
+
+    id: UUID = Column(PostgresUUID(as_uuid=True), primary_key=True, default=uuid4)
+    product_id: UUID = Column(
+        PostgresUUID(as_uuid=True),
+        ForeignKey("products.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    lot_number: str = Column(String(200), nullable=False, index=True)
+    batch_number: str | None = Column(String(200), nullable=True)  # vendor batch alias
+    quantity_received: int = Column(Integer, nullable=False, default=0)
+    quantity_remaining: int = Column(Integer, nullable=False, default=0)
+    expiry_date: datetime | None = Column(DateTime(timezone=True), nullable=True)
+    received_date: datetime | None = Column(DateTime(timezone=True), nullable=True)
+    location: str | None = Column(String(50), nullable=True, index=True)
+    grn_line_id: UUID | None = Column(
+        PostgresUUID(as_uuid=True),
+        ForeignKey("grn_line.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    notes: str | None = Column(Text, nullable=True)
+    created_at: datetime = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), nullable=False
+    )
+    updated_at: datetime = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+        nullable=False,
+    )
+
+    def __repr__(self) -> str:
+        return f"<InventoryLot(product_id={self.product_id}, lot={self.lot_number}, remaining={self.quantity_remaining})>"
+
+
+# ---------------------------------------------------------------------------
+# Pydantic read schemas for serial/lot API (UNI-1823)
+# ---------------------------------------------------------------------------
+
+
+class InventorySerialRead(BaseModel):
+    """Response schema for an inventory serial record."""
+
+    id: UUID
+    product_id: UUID
+    serial_number: str
+    status: str
+    location: str | None
+    grn_line_id: UUID | None
+    order_item_id: UUID | None
+    notes: str | None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class InventoryLotRead(BaseModel):
+    """Response schema for an inventory lot/batch record."""
+
+    id: UUID
+    product_id: UUID
+    lot_number: str
+    batch_number: str | None
+    quantity_received: int
+    quantity_remaining: int
+    expiry_date: datetime | None
+    received_date: datetime | None
+    location: str | None
+    grn_line_id: UUID | None
+    notes: str | None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/apps/backend/tests/api/test_inventory.py
+++ b/apps/backend/tests/api/test_inventory.py
@@ -391,3 +391,98 @@ class TestProductVariantEndpoints:
         body = resp.json()
         for field in ("id", "variant_sku", "name"):
             assert field in body, f"Missing field: {field}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Serial number and lot/batch endpoints (UNI-1823)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+class TestSerialLotEndpoints:
+    """Tests for serial number and lot/batch read endpoints (UNI-1823 Phase 1)."""
+
+    async def test_list_serials_serial_lot_returns_200(
+        self, client: AsyncClient, auth_headers: dict
+    ):
+        products_resp = await client.get("/api/products?page_size=1", headers=auth_headers)
+        products = products_resp.json().get("items", [])
+        if not products:
+            pytest.skip("No products in DB")
+
+        product_id = products[0]["id"]
+        resp = await client.get(
+            f"/api/inventory/products/{product_id}/serials", headers=auth_headers
+        )
+        assert resp.status_code == 200
+
+    async def test_list_serials_serial_lot_returns_list(
+        self, client: AsyncClient, auth_headers: dict
+    ):
+        products_resp = await client.get("/api/products?page_size=1", headers=auth_headers)
+        products = products_resp.json().get("items", [])
+        if not products:
+            pytest.skip("No products in DB")
+
+        product_id = products[0]["id"]
+        resp = await client.get(
+            f"/api/inventory/products/{product_id}/serials", headers=auth_headers
+        )
+        assert isinstance(resp.json(), list)
+
+    async def test_list_serials_serial_lot_status_filter(
+        self, client: AsyncClient, auth_headers: dict
+    ):
+        products_resp = await client.get("/api/products?page_size=1", headers=auth_headers)
+        products = products_resp.json().get("items", [])
+        if not products:
+            pytest.skip("No products in DB")
+
+        product_id = products[0]["id"]
+        resp = await client.get(
+            f"/api/inventory/products/{product_id}/serials?status=available",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+
+    async def test_list_lots_serial_lot_returns_200(
+        self, client: AsyncClient, auth_headers: dict
+    ):
+        products_resp = await client.get("/api/products?page_size=1", headers=auth_headers)
+        products = products_resp.json().get("items", [])
+        if not products:
+            pytest.skip("No products in DB")
+
+        product_id = products[0]["id"]
+        resp = await client.get(
+            f"/api/inventory/products/{product_id}/lots", headers=auth_headers
+        )
+        assert resp.status_code == 200
+
+    async def test_list_lots_serial_lot_returns_list(
+        self, client: AsyncClient, auth_headers: dict
+    ):
+        products_resp = await client.get("/api/products?page_size=1", headers=auth_headers)
+        products = products_resp.json().get("items", [])
+        if not products:
+            pytest.skip("No products in DB")
+
+        product_id = products[0]["id"]
+        resp = await client.get(
+            f"/api/inventory/products/{product_id}/lots", headers=auth_headers
+        )
+        assert isinstance(resp.json(), list)
+
+    async def test_list_lots_serial_lot_location_filter(
+        self, client: AsyncClient, auth_headers: dict
+    ):
+        products_resp = await client.get("/api/products?page_size=1", headers=auth_headers)
+        products = products_resp.json().get("items", [])
+        if not products:
+            pytest.skip("No products in DB")
+
+        product_id = products[0]["id"]
+        resp = await client.get(
+            f"/api/inventory/products/{product_id}/lots?location=brisbane",
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200

--- a/apps/web/app/(dashboard)/inventory/[sku]/page.tsx
+++ b/apps/web/app/(dashboard)/inventory/[sku]/page.tsx
@@ -1,0 +1,234 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Package, AlertCircle } from 'lucide-react';
+import { apiClient } from '@/lib/api/client';
+
+interface InventorySerial {
+  id: string;
+  product_id: string;
+  serial_number: string;
+  status: string;
+  location: string | null;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface InventoryLot {
+  id: string;
+  product_id: string;
+  lot_number: string;
+  batch_number: string | null;
+  quantity_received: number;
+  quantity_remaining: number;
+  expiry_date: string | null;
+  received_date: string | null;
+  location: string | null;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface Product {
+  id: string;
+  name: string;
+  sku: string;
+}
+
+const STATUS_COLOURS: Record<string, string> = {
+  available: 'bg-green-100 text-green-800',
+  reserved: 'bg-yellow-100 text-yellow-800',
+  sold: 'bg-blue-100 text-blue-800',
+  servicing: 'bg-purple-100 text-purple-800',
+  retired: 'bg-gray-100 text-gray-800',
+};
+
+export default function InventorySkuPage() {
+  const params = useParams<{ sku: string }>();
+  const sku = decodeURIComponent(params.sku ?? '');
+
+  const [product, setProduct] = useState<Product | null>(null);
+  const [serials, setSerials] = useState<InventorySerial[]>([]);
+  const [lots, setLots] = useState<InventoryLot[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!sku) return;
+
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        // Look up the product by SKU via the search parameter
+        const productsResp = await apiClient.get<{ items: Product[] }>(
+          `/api/products?search=${encodeURIComponent(sku)}&page_size=1`
+        );
+        const found = productsResp.items?.find(
+          (p) => p.sku.toLowerCase() === sku.toLowerCase()
+        );
+        if (!found) {
+          setError(`No product found with SKU "${sku}"`);
+          return;
+        }
+        setProduct(found);
+
+        // Fetch serials and lots in parallel
+        const [serialsResp, lotsResp] = await Promise.all([
+          apiClient.get<InventorySerial[]>(
+            `/api/inventory/products/${found.id}/serials`
+          ),
+          apiClient.get<InventoryLot[]>(
+            `/api/inventory/products/${found.id}/lots`
+          ),
+        ]);
+        setSerials(serialsResp ?? []);
+        setLots(lotsResp ?? []);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load inventory data');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    load();
+  }, [sku]);
+
+  if (loading) {
+    return (
+      <div className="p-6">
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 w-48 rounded bg-muted" />
+          <div className="h-64 rounded bg-muted" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-6">
+        <Card>
+          <CardContent className="flex items-center gap-3 py-8 text-destructive">
+            <AlertCircle className="h-5 w-5 shrink-0" />
+            <span>{error}</span>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 p-6">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <Package className="h-6 w-6 text-muted-foreground" />
+        <div>
+          <h1 className="text-2xl font-semibold">{product?.name ?? sku}</h1>
+          <p className="text-sm text-muted-foreground">SKU: {sku}</p>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <Tabs defaultValue="serials">
+        <TabsList>
+          <TabsTrigger value="serials">
+            Serials
+            {serials.length > 0 && (
+              <Badge variant="secondary" className="ml-2">
+                {serials.length}
+              </Badge>
+            )}
+          </TabsTrigger>
+          <TabsTrigger value="lots">
+            Lots / Batches
+            {lots.length > 0 && (
+              <Badge variant="secondary" className="ml-2">
+                {lots.length}
+              </Badge>
+            )}
+          </TabsTrigger>
+        </TabsList>
+
+        {/* Serials tab */}
+        <TabsContent value="serials">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Serial Numbers</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {serials.length === 0 ? (
+                <p className="py-8 text-center text-sm text-muted-foreground">
+                  No serial numbers recorded for this product yet.
+                </p>
+              ) : (
+                <div className="divide-y">
+                  {serials.map((s) => (
+                    <div key={s.id} className="flex items-center justify-between py-3">
+                      <span className="font-mono text-sm">{s.serial_number}</span>
+                      <div className="flex items-center gap-2">
+                        {s.location && (
+                          <span className="text-xs text-muted-foreground">{s.location}</span>
+                        )}
+                        <Badge
+                          className={STATUS_COLOURS[s.status] ?? 'bg-gray-100 text-gray-800'}
+                          variant="outline"
+                        >
+                          {s.status}
+                        </Badge>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* Lots tab */}
+        <TabsContent value="lots">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Lot / Batch Records</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {lots.length === 0 ? (
+                <p className="py-8 text-center text-sm text-muted-foreground">
+                  No lot or batch records for this product yet.
+                </p>
+              ) : (
+                <div className="divide-y">
+                  {lots.map((l) => (
+                    <div key={l.id} className="flex items-center justify-between py-3">
+                      <div>
+                        <span className="font-mono text-sm">{l.lot_number}</span>
+                        {l.batch_number && (
+                          <span className="ml-2 text-xs text-muted-foreground">
+                            ({l.batch_number})
+                          </span>
+                        )}
+                      </div>
+                      <div className="text-right text-sm">
+                        <span className="text-muted-foreground">
+                          {l.quantity_remaining} / {l.quantity_received} remaining
+                        </span>
+                        {l.location && (
+                          <span className="ml-2 text-xs text-muted-foreground">{l.location}</span>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/supabase/migrations/20260419000001_serial_lot_tracking.sql
+++ b/supabase/migrations/20260419000001_serial_lot_tracking.sql
@@ -1,0 +1,65 @@
+-- =============================================================================
+-- Migration: Serial number and lot/batch tracking — Phase 1
+-- Ticket: UNI-1823
+-- Description: New tables inventory_serials (unit-level traceability) and
+--              inventory_lots (bulk lot/batch traceability). Phase 1 covers
+--              schema + migration only; UI and reports follow in Phase 2.
+-- Applied: 2026-04-19
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- inventory_serials: one row per individual serialised unit
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.inventory_serials (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  product_id      UUID NOT NULL REFERENCES public.products(id) ON DELETE CASCADE,
+  serial_number   TEXT NOT NULL,
+  status          TEXT NOT NULL DEFAULT 'available'
+                    CHECK (status IN ('available', 'reserved', 'sold', 'servicing', 'retired')),
+  location        TEXT,
+  grn_line_id     UUID REFERENCES public.grn_line(id) ON DELETE SET NULL,
+  order_item_id   UUID REFERENCES public.order_items(id) ON DELETE SET NULL,
+  notes           TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT uq_inventory_serial_number UNIQUE (serial_number)
+);
+
+ALTER TABLE public.inventory_serials ENABLE ROW LEVEL SECURITY;
+CREATE POLICY inventory_serials_service_role ON public.inventory_serials
+  FOR ALL USING (auth.role() = 'service_role');
+
+CREATE INDEX IF NOT EXISTS idx_inv_serials_product_id ON public.inventory_serials(product_id);
+CREATE INDEX IF NOT EXISTS idx_inv_serials_status      ON public.inventory_serials(status);
+CREATE INDEX IF NOT EXISTS idx_inv_serials_location    ON public.inventory_serials(location);
+
+-- ---------------------------------------------------------------------------
+-- inventory_lots: one row per received lot/batch
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.inventory_lots (
+  id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  product_id         UUID NOT NULL REFERENCES public.products(id) ON DELETE CASCADE,
+  lot_number         TEXT NOT NULL,
+  batch_number       TEXT,                                         -- vendor batch alias
+  quantity_received  INTEGER NOT NULL DEFAULT 0 CHECK (quantity_received >= 0),
+  quantity_remaining INTEGER NOT NULL DEFAULT 0 CHECK (quantity_remaining >= 0),
+  expiry_date        TIMESTAMPTZ,
+  received_date      TIMESTAMPTZ,
+  location           TEXT,
+  grn_line_id        UUID REFERENCES public.grn_line(id) ON DELETE SET NULL,
+  notes              TEXT,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT uq_inventory_lot_product_lot UNIQUE (product_id, lot_number)
+);
+
+ALTER TABLE public.inventory_lots ENABLE ROW LEVEL SECURITY;
+CREATE POLICY inventory_lots_service_role ON public.inventory_lots
+  FOR ALL USING (auth.role() = 'service_role');
+
+CREATE INDEX IF NOT EXISTS idx_inv_lots_product_id ON public.inventory_lots(product_id);
+CREATE INDEX IF NOT EXISTS idx_inv_lots_location   ON public.inventory_lots(location);
+CREATE INDEX IF NOT EXISTS idx_inv_lots_lot_number ON public.inventory_lots(lot_number);
+CREATE INDEX IF NOT EXISTS idx_inv_lots_expiry     ON public.inventory_lots(expiry_date);


### PR DESCRIPTION
## Summary

- `inventory_serials` + `inventory_lots` tables with proper FK, RLS (service_role), CHECK constraints, and covering indexes
- Supabase migration `20260419000001_serial_lot_tracking.sql` applied
- Read endpoints: `GET /api/inventory/products/{id}/serials` and `/lots` (optional status/location filters)
- Minimal `/inventory/[sku]` page with Serials + Lots tabs rendering empty state
- 6 pytest tests (`-k serial_lot`) covering all new endpoints

## Phase scope

Phase 1 (this PR): schema + migration + read API + empty-state UI tab  
Phase 2 (future): write endpoints, full UI, serial-based service history in workshop

## Test plan

- [ ] `cd apps/backend && uv run pytest tests/api/test_inventory.py -k serial_lot` passes
- [ ] Supabase `list_tables` shows `inventory_serials` and `inventory_lots`
- [ ] `/inventory/{any-sku}` renders Serials tab with empty state (no JS errors)

Linear: UNI-1823

🤖 Generated with [Claude Code](https://claude.com/claude-code)