### PR TITLE
fix(ci): remove stale ai-updates branch trigger (RA-1160)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, ai-updates]
+    branches: [main]
   pull_request:
-    branches: [main, ai-updates]
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## RA-1160 — Remove stale ai-updates CI trigger

### What happened

The `ai-updates` branch was the production branch while `main` lacked
`apps/web/`. Every push to main triggered a Vercel build that failed
with "Root Directory 'apps/web' does not exist".

Between 2026-04-17 and 2026-04-19 the branch was merged into main and
deleted. `apps/web/` now exists on main; the Root Directory failures
have stopped.

### What this PR changes

- Removes `ai-updates` from the `push` and `pull_request` branch
  triggers in `.github/workflows/ci.yml` (2 lines).

The branch no longer exists. Keeping it in CI triggers has no effect
today but creates false documentation — implying a branch that will
never receive commits is a valid target.

### What this PR does NOT change

The Vercel project `ccw-crm-web` still has `productionBranch=ai-updates`
in its dashboard settings. This is a project-level setting, not stored
in the repo. **A human (or Rana) needs to update it manually:**

> Vercel Dashboard → ccw-crm-web → Settings → Git → Production Branch → change to `main`

Or via CLI:
```
vercel project update --production-branch main
```

Until that's done, Vercel production deploys won't auto-trigger on
pushes to main.

### Manual verification path

1. Merge this PR.
2. Push any commit to `main`.
3. Check GitHub Actions — CI should trigger (previously it did run on
   main, this PR doesn't break that).
4. Go to Vercel Dashboard → ccw-crm-web → Settings → Git and update
   Production Branch to `main`.
5. Push again — confirm Vercel builds from main successfully.

### Risk register

| Risk | Mitigation |
|------|-----------|
| Vercel productionBranch still points to deleted branch | Documented above; requires manual Vercel Dashboard update |
| PRs targeting branches other than main won't trigger CI | Expected — all work flows through main via PRs |
| None | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)