### PR TITLE
docs: add review skills mandate (RA-1744)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,3 +2,19 @@
 
 Portfolio repo (Unite-Group). Refer to portfolio standards and Pi-CEO orchestration in `Pi-Dev-Ops/`.
 
+## Review Skills — Mandatory Discipline (2026-04-27)
+
+Four skills live at `~/.claude/skills/` and form the lifecycle review gate for every Unite-Group portfolio repo. These are not the noisy Vercel/Next-upgrade advisories — these are mandatory and apply to interactive Claude Code sessions automatically.
+
+| Skill | Phase | Trigger | Cost |
+|---|---|---|---|
+| `design-pressure-test` | Before code | Non-trivial feature plan, before writing | $0 (Opus on Max) |
+| `parallel-delegate` | During code | 2+ independent subtasks | $0 (Sonnet subagents) |
+| `opus-adversary` | After code, before push | Any non-trivial diff | $0 (Opus on Max) |
+| `codex-adversarial` | Before merge, high-stakes only | Auth / payments / migrations / data-loss / security / races | ~1/day ChatGPT Plus quota |
+
+Hard rules:
+- `opus-adversary` runs before every push. Verdict BLOCK = do not push.
+- `codex-adversarial` is never wired into autonomous loops; manual invocation only on dangerous changes.
+- Skills are user-level — they fire automatically in any interactive Claude Code session.
+- Trial criteria for codex-adversarial tracked in RA-1741.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+# CCW-CRM
+
+Portfolio repo (Unite-Group). Refer to portfolio standards and Pi-CEO orchestration in `Pi-Dev-Ops/`.
+


### PR DESCRIPTION
## Summary

Adds the "Review Skills — Mandatory Discipline" section to this repo, propagating the convention established in `Pi-Dev-Ops/CLAUDE.md` on 2026-04-27.

Codifies the four user-level review skills as the lifecycle review gate for every interactive Claude Code session in this repo:

- `design-pressure-test` — before code, non-trivial feature plans
- `parallel-delegate` — during code, 2+ independent subtasks
- `opus-adversary` — after code, before push (BLOCK verdict = do not push)
- `codex-adversarial` — manual only, high-stakes diffs (auth / payments / migrations / data-loss / security / races)

Part of the 10-repo propagation set tracked by [RA-1744](https://linear.app/unite-group/issue/RA-1744).

## Test plan

- [x] Section appended to existing CLAUDE.md (or created if missing) using verbatim wording from the issue (no drift across repos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)