### PR TITLE
fix(security): HMAC-SHA256 verification on /api/webhooks (RA-3814)

### DIFF
--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -1,22 +1,57 @@
 import { NextRequest, NextResponse } from "next/server";
-import { headers } from "next/headers";
+import { createHmac, timingSafeEqual } from "node:crypto";
 import { logger } from "@/lib/logger";
 
+// RA-3814 — HMAC-SHA256 verification of webhook payloads.
+// Sibling of RA-3020 (CleanExpo/CARSI#111). Helper logic is identical.
+//
+// Caller contract:
+//   Header  x-webhook-signature   value of `sha256=<hex>` OR raw hex
+//   Body    raw bytes (request.text() — DO NOT parse JSON before verifying)
+//   Secret  process.env.WEBHOOK_SECRET — required; route 503s if unset.
+//
+// Mismatches return 401 without logging the payload (avoid log poisoning).
+function verifySignature(rawBody: string, signature: string, secret: string): boolean {
+  const provided = signature.startsWith("sha256=") ? signature.slice(7) : signature;
+  if (!/^[0-9a-f]+$/i.test(provided)) return false;
+
+  const expected = createHmac("sha256", secret).update(rawBody, "utf8").digest("hex");
+  if (provided.length !== expected.length) return false;
+  return timingSafeEqual(Buffer.from(provided, "hex"), Buffer.from(expected, "hex"));
+}
+
 export async function POST(request: NextRequest) {
+  const webhookSecret = process.env.WEBHOOK_SECRET;
+  if (!webhookSecret?.trim()) {
+    return NextResponse.json(
+      { error: "Webhook not configured (WEBHOOK_SECRET)." },
+      { status: 503 }
+    );
+  }
+
+  const signature = request.headers.get("x-webhook-signature");
+  if (!signature) {
+    return NextResponse.json({ error: "Missing x-webhook-signature" }, { status: 401 });
+  }
+
+  // Read raw body for HMAC verification BEFORE parsing JSON.
+  const rawBody = await request.text();
+
+  if (!verifySignature(rawBody, signature, webhookSecret)) {
+    return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+  }
+
+  // Signature verified — safe to parse + dispatch.
+  let body: { event?: string; data?: unknown };
   try {
-    const headersList = await headers();
-    const signature = headersList.get("x-webhook-signature");
+    body = JSON.parse(rawBody);
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
 
-    // Validate webhook signature if configured
-    const webhookSecret = process.env.WEBHOOK_SECRET;
-    if (webhookSecret && signature) {
-      // Add your signature validation logic here
-      // Example: const isValid = validateSignature(body, signature, webhookSecret);
-    }
+  const { event, data } = body;
 
-    const body = await request.json();
-    const { event, data } = body;
-
+  try {
     switch (event) {
       case "task.completed":
         logger.info("Task completed", { data });
@@ -30,7 +65,6 @@ export async function POST(request: NextRequest) {
       default:
         logger.warn("Unknown webhook event", { event, data });
     }
-
     return NextResponse.json({ received: true });
   } catch (error) {
     logger.error("Webhook error", error);


### PR DESCRIPTION
## Summary
Sibling of RA-3020 — CCW-CRM had the identical placeholder vulnerability that was just fixed in [CleanExpo/CARSI#111](https://github.com/CleanExpo/CARSI/pull/111). The route handler is structurally identical, so this patch is the mechanical port: same `verifySignature` helper, same response codes, same security properties.

## What changed
- `src/app/api/webhooks/route.ts:13` placeholder TODO removed
- Constant-time HMAC-SHA256 verification (`createHmac` + `timingSafeEqual`)
- 503 if `WEBHOOK_SECRET` unset (fails closed)
- 401 if header missing / signature invalid
- Raw body read BEFORE JSON parse

## Smoke verification
All 7 verification branches pass (verified during the parent CARSI PR):
valid bare hex, `sha256=<hex>` prefix, wrong secret, tampered body, wrong-length hex, non-hex signature, empty signature.

## Test plan
- [ ] CI build + lint pass
- [ ] Post-deploy: send signed POST → 200; send unsigned POST → 401
- [ ] Update sender (whichever external infra is calling this) with `WEBHOOK_SECRET` + signature header

🤖 Generated with [Claude Code](https://claude.com/claude-code)