### PR TITLE
chore: add missing .github/CODEOWNERS (Plan 02 fix)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# CODEOWNERS — sole owner is the CleanExpo account (solo founder workflow)
+# Self-review is acceptable for this single-owner setup.
+* @CleanExpo


### PR DESCRIPTION
Adds missing portfolio template file from Plan 02.