### PR TITLE
ci(security): grant trivy-scan job security-events:write to upload SARIF

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -113,6 +113,16 @@ jobs:
   trivy-scan:
     name: Trivy Container Scan
     runs-on: ubuntu-latest
+    # Required so the SARIF upload below can write to GitHub's
+    # code-scanning API. Without this the Upload Trivy results step
+    # fails with "Resource not accessible by integration" — the
+    # default GITHUB_TOKEN permissions in this repo do not include
+    # security-events: write, so the per-job permissions block is
+    # needed to grant it locally. `contents: read` retains the read
+    # access the checkout step needs.
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Why this PR

Security Scanning has failed on every main-branch run with:

\`\`\`
##[error]Resource not accessible by integration - https://docs.github.com/rest
\`\`\`

…from the Trivy job's "Upload Trivy results to GitHub Security tab" step. The default \`GITHUB_TOKEN\` permissions in this repo don't include \`security-events: write\`, so \`github/codeql-action/upload-sarif\` gets rejected by GitHub's code-scanning REST endpoint.

## Fix

Per-job \`permissions:\` block on \`trivy-scan\` granting the two scopes the job actually needs:

\`\`\`yaml
permissions:
  contents: read         # for checkout
  security-events: write # for SARIF upload
\`\`\`

Other jobs in the workflow are unaffected — their default permissions are still adequate. Pattern matches [GitHub's security-hardening guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-secrets) for least-privilege per-job scopes.

## Net effect

- Security Scanning → \`trivy-scan\` goes from FAILURE → SUCCESS
- Trivy findings now appear in repo Security tab
- Reduces the rolling main-branch failure count by 1 of 3 active gates

## Out of scope

Two other CCW-CRM workflows are still failing on every push (genuine blockers needing repo secrets you'd have to add):
- \`Deploy to Staging\` — missing \`STAGING_SSH_KEY\` (+ host/user)
- \`rollback.yml\` — same SSH secrets

Those need credential setup in Settings → Secrets → Actions; can't be fixed in code.

## Test plan

- [ ] CI on this PR is green for trivy-scan step.
- [ ] After merge: next main-branch \`Security Scanning\` run shows trivy-scan = success, findings populate Security tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved security scanning workflow to ensure vulnerability reports are properly recorded in GitHub's Code Scanning features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CleanExpo/CCW-CRM/pull/195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->