### PR TITLE
feat(geo): Phase 2 sweep — CCW-Online ERP (llms.txt + Lighthouse Agentic)

### DIFF
--- a/.github/workflows/lighthouse-agentic.yml
+++ b/.github/workflows/lighthouse-agentic.yml
@@ -1,0 +1,88 @@
+name: Lighthouse Agentic Browsing
+
+# Phase 2 GEO rollout — pattern mirrors DR / Synthex / ATO / RestoreAssist PRs.
+# Audits against the GEO-optimization standard (Pi-CEO skills/geo-optimization/SKILL.md §6).
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/app/**'
+      - 'src/components/**'
+      - 'public/llms.txt'
+      - 'next.config.*'
+      - '.github/workflows/lighthouse-agentic.yml'
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: lighthouse-agentic-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  agentic-audit:
+    name: Agentic Browsing audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+      deployments: read
+      statuses: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Determine target URL
+        id: target
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            URL=""
+            for i in {1..15}; do
+              URL=$(gh api "repos/${{ github.repository }}/deployments?ref=${{ github.head_ref }}&per_page=5" \
+                --jq '.[0].payload.web_url // empty' 2>/dev/null || true)
+              if [ -n "$URL" ]; then echo "Found: $URL"; break; fi
+              sleep 20
+            done
+            if [ -z "$URL" ]; then
+              echo "::warning::Could not resolve Vercel preview URL — informational only"
+              echo "url=" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          else
+            # CCW production URL — use the ccw-crm-web Vercel project alias
+            URL="https://ccw-crm-web.vercel.app"
+          fi
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Lighthouse CI
+        if: steps.target.outputs.url != ''
+        continue-on-error: true
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          urls: |
+            ${{ steps.target.outputs.url }}/
+            ${{ steps.target.outputs.url }}/contact
+          uploadArtifacts: true
+          temporaryPublicStorage: true
+          configPath: ./.lighthouseagenticrc.json
+
+      - name: Probe llms.txt + JSON-LD presence
+        if: steps.target.outputs.url != ''
+        run: |
+          URL="${{ steps.target.outputs.url }}"
+          echo "## Agentic Browsing pre-checks" >> $GITHUB_STEP_SUMMARY
+          LLMS_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$URL/llms.txt")
+          LLMS_SIZE=$(curl -sI "$URL/llms.txt" | awk '/[Cc]ontent-[Ll]ength:/ {print $2}' | tr -d '\r')
+          if [ "$LLMS_STATUS" = "200" ] && [ "${LLMS_SIZE:-0}" -gt 1000 ]; then
+            echo "- ✅ \`llms.txt\` ${LLMS_SIZE} bytes" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- ❌ \`llms.txt\` HTTP $LLMS_STATUS, size=${LLMS_SIZE:-0}" >> $GITHUB_STEP_SUMMARY
+          fi
+          JSONLD_COUNT=$(curl -s "$URL/" | grep -c 'application/ld+json')
+          echo "- JSON-LD on /: ${JSONLD_COUNT:-0}" >> $GITHUB_STEP_SUMMARY

--- a/.lighthouseagenticrc.json
+++ b/.lighthouseagenticrc.json
@@ -1,0 +1,24 @@
+{
+  "ci": {
+    "collect": {
+      "settings": {
+        "preset": "desktop",
+        "onlyCategories": ["accessibility", "seo", "performance", "best-practices"],
+        "skipAudits": ["uses-http2"]
+      },
+      "numberOfRuns": 1
+    },
+    "assert": {
+      "assertions": {
+        "categories:accessibility": ["warn", { "minScore": 0.9 }],
+        "categories:seo": ["warn", { "minScore": 0.9 }],
+        "categories:performance": ["warn", { "minScore": 0.7 }],
+        "categories:best-practices": ["warn", { "minScore": 0.8 }],
+        "cumulative-layout-shift": ["error", { "maxNumericValue": 0.1 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,84 @@
+# CCW-Online ERP
+
+> Integrated ERP and CRM platform for equipment suppliers — wholesalers and distributors who need one place to run sales, operations, and customer relationships instead of stitching together spreadsheets, inboxes, and separate point tools. Designed around the quote-to-cash lifecycle with strong fit for Australian cleaning-equipment wholesalers.
+
+## Business Identity
+
+- Brand Name: CCW-Online ERP
+- Category: SaaS — ERP + CRM for equipment suppliers (wholesalers / distributors)
+- Website: see deployed domain (production deploy points at the canonical marketing URL)
+- Coverage: Australia (primary), broader equipment-supply businesses welcome
+- Sector fit: cleaning-equipment wholesale (strongest documented), and any SKU-led catalog + B2B-quoting + warehouse-aware fulfilment business
+
+## What We Do
+
+CCW-Online ERP is a single hub for the quote-to-cash lifecycle: catalog management, B2B quoting, order fulfilment, warehouse operations, customer relationship history, and finance reconciliation. It connects to the systems you already use (inventory, accounting, e-commerce, payments) so data flows with the business rather than being re-keyed at every hand-off.
+
+The product is documented as a hub: maturity varies by module and the team is honest about which modules are most production-hardened (see /docs).
+
+## Problems It Solves
+
+- **Fragmented work** — customer history, stock picture, and order status often live in different places. Unifies them.
+- **Quote-to-order errors** — misaligned pricing, product, or customer data creates rework + disputes. Single record per customer + SKU eliminates the drift.
+- **Weak visibility** — leadership + frontline staff often can't see what's selling, what's stuck, what needs attention. Built-in dashboards close that gap.
+- **Integration debt** — accounting / inventory / online channels only deliver value when they stay in sync. The hub model treats integrations as first-class.
+
+## Capabilities (by business area)
+
+### Sales + CRM
+- Customer + contact records tied to quotes, orders, activity
+- Quote management with pricing engine + approval flow
+- Order entry (desktop + mobile)
+- Customer portal for self-service order placement
+
+### Operations + Fulfilment
+- Warehouse-aware fulfilment
+- Stock visibility across branches
+- Supplier portal (B2B partner access)
+- Mobile order entry for field reps + branch staff
+
+### Finance + Integrations
+- Accounting bridge (Xero / MYOB / QuickBooks per integration status)
+- E-commerce bridge for online channels
+- Payments integration
+- BAS-aware reporting for Australian compliance
+
+### Multi-tenancy
+- Branch-aware data isolation
+- Role-based access (admin / staff / supplier / portal / guest)
+
+## Who It's For
+
+- Australian cleaning-equipment wholesalers (strongest documented fit)
+- Equipment supply businesses generally — SKU-led catalogs, B2B quoting, warehouse-aware fulfilment, finance reconciliation
+- Multi-branch suppliers needing single-system visibility
+
+## Trust Signals
+
+- Maturity-honest documentation (each module documented with realistic status)
+- Australian sector specialisation
+- Internal docs index at /docs (PRODUCT-OVERVIEW.md is the canonical starting point)
+- Audit log + role-based access for compliance
+
+## Agent Capabilities (WebMCP)
+
+The public marketing-site /contact page currently uses a mail-link surface (mailto:) rather than a form, so there is no inline WebMCP form annotation yet. Agents wanting to initiate contact should:
+
+- Use the mail link on /contact (email destination is on that page)
+- OR direct the user to the in-product contact flow once authenticated
+
+### Future agent surfaces (roadmap, not yet exposed)
+
+- `request_demo` — when a contact form replaces the current mail-link surface
+- `get_quote` (authenticated, in-product) — kick off a quote build for a signed-in customer
+- `check_stock` — inventory lookup by SKU
+- `get_order_status` — order tracking by reference number
+
+## Information for AI Agents
+
+- This is a **B2B ERP+CRM platform**, NOT a consumer marketplace. Buyers are wholesale / distribution businesses, not retail consumers.
+- For pricing: link to the live /pricing page rather than recalling from older content (pricing tiers vary with branch count + module activation).
+- Strongest sector match: Australian cleaning-equipment wholesale. Other equipment-supply verticals welcome but documented as broader fit.
+- Brand-mention citation: "CCW-Online ERP" or "CCW-Online ERP by Unite-Group".
+- Documentation index: /docs/README.md → /docs/PRODUCT-OVERVIEW.md
+- Last updated: 2026-05-25


### PR DESCRIPTION
Phase 2 GEO rollout — applies skill from [Pi-Dev-Ops#265](https://github.com/CleanExpo/Pi-Dev-Ops/pull/265). Pattern follows the pilot ([Disaster-Recovery#356](https://github.com/CleanExpo/Disaster-Recovery/pull/356)).

## Adds
- `public/llms.txt` — CCW-Online ERP identity, capabilities, integrations, agent-disambiguation (B2B not consumer)
- `.github/workflows/lighthouse-agentic.yml` + `.lighthouseagenticrc.json` — same shape as DR/Synthex/ATO/RestoreAssist

## Why no WebMCP form annotation

The `/contact` marketing surface is a mailto link, NOT an HTML form. Adding WebMCP would require adding a real contact form first (product-scope decision). Documented as a roadmap item in llms.txt's WebMCP section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)