### PR TITLE
fix(ci): Deepsec workspace + project-id for weekly scan (RA-5660)

### DIFF
--- a/.deepsec/deepsec.config.ts
+++ b/.deepsec/deepsec.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "deepsec/config";
+
+export default defineConfig({
+  projects: [
+    { id: "CCW-CRM", root: ".." },
+    // <deepsec:projects-insert-above>
+  ],
+});

--- a/.deepsec/package.json
+++ b/.deepsec/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "deepsec-workspace",
+  "version": "0.1.0",
+  "private": true,
+  "description": "deepsec scanning workspace",
+  "type": "module",
+  "workspaces": [],
+  "packageManager": "pnpm@9.15.4",
+  "dependencies": {
+    "deepsec": "^2.0.12"
+  }
+}

--- a/.github/workflows/deepsec-weekly.yml
+++ b/.github/workflows/deepsec-weekly.yml
@@ -14,11 +14,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: |
+          cd .deepsec
+          npm install
       - name: Run Deepsec
-        run: npx -y deepsec scan
+        run: |
+          cd .deepsec
+          npx deepsec scan --project-id CCW-CRM
       - name: Open issue on findings
         if: failure()
         run: |
+          # Ensure labels exist
+          gh label create "security" --color "d73a4a" --description "Security related" 2>/dev/null || true
+          gh label create "deepsec" --color "7057ff" --description "Deepsec scan" 2>/dev/null || true
+          gh label create "weekly-scan" --color "008672" --description "Weekly automated scan" 2>/dev/null || true
           gh issue create \
             --title "[deepsec] Weekly scan findings $(date +%Y-%m-%d)" \
             --label "security,deepsec,weekly-scan" \


### PR DESCRIPTION
## Summary
The `Deepsec weekly security scan` workflow has failed on every run since at least 2026-06-01 (runs 26763285112, 27144469331) with:

> No --project-id specified and no projects found in deepsec.config.ts.

Root cause: the workflow ran bare `npx -y deepsec scan` at the repo root — there is no deepsec workspace in this repo and no project id was passed. The identical workflow in CleanExpo/unite-group passes because it runs inside a `.deepsec/` workspace with a project id.

## Changes
- Add `.deepsec/` workspace (mirrored from unite-group's known-good setup): `deepsec.config.ts` with a `projects[]` entry (`id: CCW-CRM, root: ..`) and `package.json` pinning `deepsec ^2.0.12`.
- Workflow now sets up Node 20, runs `npm install` in `.deepsec`, and invokes the scan with the CCW-CRM project id.
- Ensure the `security` / `deepsec` / `weekly-scan` labels exist before the on-failure issue creation (it errors when labels are missing — also copied from unite-group).

## Verification
- Workflow YAML and config mirror unite-group's passing workflow 1:1 apart from the project id.
- To prove live after merge: Actions → Deepsec weekly security scan → Run workflow (`workflow_dispatch` is enabled). Getting past config resolution closes the RA-5660 failure mode; any remaining failure would be real findings — that is the workflow doing its job.

## Linear
Fixes the root cause of RA-5660 ([WorkOrder] ccw-crm — ci_failing, high).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
