### PR TITLE
feat: inventory transfer cancel endpoint + UI (UNI-2112)

### DIFF
--- a/src/app/(dashboard)/inventory/transfers/[id]/page.tsx
+++ b/src/app/(dashboard)/inventory/transfers/[id]/page.tsx
@@ -9,6 +9,7 @@ import { ArrowLeft, ArrowRight, Package, User, Calendar, Clock, CheckCircle } fr
 import { useToast } from "@/hooks/use-toast";
 import type { StockTransfer } from "@/types/inventory";
 import { apiClient } from "@/lib/api/client";
+import { inventoryApi } from "@/lib/api/inventory";
 import { TransferStatusBadge } from "@/components/inventory/TransferStatusBadge";
 import { format } from "date-fns";
 
@@ -103,16 +104,32 @@ export default function TransferDetailPage() {
   };
 
   const handleCancelTransfer = async () => {
-    if (!transfer || transfer.status !== "pending") return;
+    if (!transfer) return;
+
+    if (transfer.status === "completed") {
+      toast({
+        variant: "destructive",
+        title: "Cannot cancel",
+        description: "Completed transfers cannot be cancelled.",
+      });
+      return;
+    }
+
+    if (transfer.status === "cancelled") {
+      toast({
+        variant: "destructive",
+        title: "Already cancelled",
+        description: "This transfer has already been cancelled.",
+      });
+      return;
+    }
 
     try {
-      await apiClient.post(`/api/inventory/transfers/${transferId}/status`, {
-        status: "cancelled",
-      });
+      await inventoryApi.cancelTransfer(transferId);
 
       toast({
-        title: "Success",
-        description: "Transfer cancelled",
+        title: "Transfer cancelled",
+        description: "The transfer has been cancelled successfully.",
       });
 
       // Reload transfer
@@ -330,7 +347,7 @@ export default function TransferDetailPage() {
         </CardHeader>
         <CardContent>
           <div className="flex gap-2">
-            {transfer.status === "pending" && (
+            {(transfer.status === "pending" || transfer.status === "in_transit") && (
               <>
                 <Button onClick={handleMarkInTransit}>
                   Mark as In Transit

--- a/src/app/(dashboard)/inventory/transfers/page.tsx
+++ b/src/app/(dashboard)/inventory/transfers/page.tsx
@@ -150,20 +150,39 @@ export default function TransfersPage() {
 
   // Cancel transfer
   const handleCancelTransfer = async (transfer: StockTransfer) => {
-    if (transfer.status !== "pending") {
+    if (transfer.status === "completed") {
       toast({
         variant: "destructive",
-        title: "Error",
-        description: "Only pending transfers can be cancelled",
+        title: "Cannot cancel",
+        description: "Completed transfers cannot be cancelled.",
       });
       return;
     }
 
-    // TODO: Implement cancel endpoint
-    toast({
-      title: "Not Implemented",
-      description: "Cancel transfer functionality coming soon",
-    });
+    if (transfer.status === "cancelled") {
+      toast({
+        variant: "destructive",
+        title: "Already cancelled",
+        description: "This transfer has already been cancelled.",
+      });
+      return;
+    }
+
+    try {
+      await inventoryApi.cancelTransfer(transfer.id);
+      toast({
+        title: "Transfer cancelled",
+        description: `Transfer for ${transfer.product_name || "product"} has been cancelled.`,
+      });
+      await loadTransfers();
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : "Failed to cancel transfer";
+      toast({
+        variant: "destructive",
+        title: "Error",
+        description: message,
+      });
+    }
   };
 
   // Format location for display

--- a/src/app/api/inventory/transfers/[id]/cancel/route.ts
+++ b/src/app/api/inventory/transfers/[id]/cancel/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuthScope } from '@/lib/auth/data-scope';
+import { getWorkspaceMemberUserIds } from '@/lib/auth/workspace-scope';
+import { cancelTransfer } from '@/lib/db/transfer-cancel-service';
+
+/**
+ * POST /api/inventory/transfers/:id/cancel
+ *
+ * Cancel a pending or in-transit stock transfer and roll back any stock movement.
+ *
+ * Rollback rules (enforced in transfer-cancel-service):
+ *  - pending    → set cancelled; no stock adjustment (stock never moved)
+ *  - in_transit → restore stock to fromLocation, decrement toLocation, set cancelled
+ *  - completed  → 409 rejected; stock already moved, create a reverse transfer instead
+ *  - cancelled  → 409 rejected (idempotency guard)
+ *
+ * Org scoping mirrors neighbouring endpoints: workspace member user-id guard on
+ * the owning product — identical to GET /api/inventory/transfers/:id.
+ */
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  try {
+    const scope = await requireAuthScope(request);
+    if (!scope) {
+      return NextResponse.json({ detail: 'Not authenticated' }, { status: 401 });
+    }
+
+    const { id } = await context.params;
+    const workspaceUserIds = await getWorkspaceMemberUserIds(scope.userId);
+
+    const result = await cancelTransfer({ id, workspaceUserIds });
+
+    if (!result.ok) {
+      return NextResponse.json({ detail: result.detail }, { status: result.status });
+    }
+
+    const { transfer } = result;
+    return NextResponse.json({
+      id: transfer.id,
+      status: transfer.status,
+      product_id: transfer.productId,
+      product_name: transfer.productName,
+      product_sku: transfer.productSku,
+      from_location: transfer.fromLocation,
+      to_location: transfer.toLocation,
+      quantity: transfer.quantity,
+      reason: transfer.reason ?? undefined,
+      notes: transfer.notes ?? undefined,
+      updated_at: transfer.updatedAt.toISOString(),
+    });
+  } catch (e) {
+    console.error('[POST /api/inventory/transfers/:id/cancel]', e);
+    return NextResponse.json(
+      { detail: e instanceof Error ? e.message : String(e) },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/api/inventory.ts
+++ b/src/lib/api/inventory.ts
@@ -200,6 +200,13 @@ export const inventoryApi = {
   },
 
   /**
+   * Cancel a stock transfer (pending or in_transit only).
+   * POST /api/inventory/transfers/:id/cancel
+   */
+  async cancelTransfer(id: string): Promise<StockTransfer> {
+    return apiClient.post<StockTransfer>(`/api/inventory/transfers/${id}/cancel`, {});
+  },
+  /**
    * Reserve stock
    * POST /api/inventory/reserve
    */

--- a/src/lib/db/transfer-cancel-service.test.ts
+++ b/src/lib/db/transfer-cancel-service.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Unit tests for transfer-cancel-service
+ * Uses relative imports (vitest has no @/ alias configured).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---- Prisma mock helpers ----
+const mockFindFirst = vi.fn();
+const mockUpdateMany = vi.fn();
+const mockUpdate = vi.fn();
+const mockSyncProductStockTotal = vi.fn();
+
+// We hold a reference to the $transaction mock so we can reset it in beforeEach
+const mockTransaction = vi.fn();
+
+vi.mock('./prisma', () => ({
+  prisma: {
+    stockTransfer: { findFirst: mockFindFirst },
+    $transaction: mockTransaction,
+  },
+}));
+
+vi.mock('./inventory-location-transfer', () => ({
+  syncProductStockTotal: mockSyncProductStockTotal,
+}));
+
+// ---- Module under test ----
+const { cancelTransfer } = await import('./transfer-cancel-service');
+
+// Helper: build the fake TX object used inside the transaction callback
+function makeTx() {
+  return {
+    productLocationStock: { updateMany: mockUpdateMany },
+    stockTransfer: { update: mockUpdate },
+  };
+}
+
+// Default $transaction: passes callback a fake tx and returns its result
+function defaultTxImpl(cb: (tx: ReturnType<typeof makeTx>) => Promise<unknown>) {
+  return cb(makeTx());
+}
+
+const WS_USERS = ['user-abc'];
+
+describe('cancelTransfer service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTransaction.mockImplementation(defaultTxImpl);
+  });
+
+  // ---- 404 ----
+  it('returns 404 when the transfer is not found (org scope miss)', async () => {
+    mockFindFirst.mockResolvedValue(null);
+
+    const result = await cancelTransfer({ id: 'no-such', workspaceUserIds: WS_USERS });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(404);
+      expect(result.detail).toMatch(/not found/i);
+    }
+  });
+
+  // ---- 409: completed ----
+  it('returns 409 for a "completed" transfer and does not touch stock', async () => {
+    mockFindFirst.mockResolvedValue({
+      id: 'tf-done', status: 'completed', productId: 'p1',
+      fromLocation: 'brisbane', toLocation: 'sydney', quantity: 10,
+    });
+
+    const result = await cancelTransfer({ id: 'tf-done', workspaceUserIds: WS_USERS });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(409);
+      expect(result.detail).toMatch(/completed/i);
+    }
+    // No stock mutations — transaction is never entered
+    expect(mockTransaction).not.toHaveBeenCalled();
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+  });
+
+  // ---- 409: already cancelled ----
+  it('returns 409 for an already "cancelled" transfer and does not touch stock', async () => {
+    mockFindFirst.mockResolvedValue({
+      id: 'tf-cx', status: 'cancelled', productId: 'p1',
+      fromLocation: 'brisbane', toLocation: 'sydney', quantity: 5,
+    });
+
+    const result = await cancelTransfer({ id: 'tf-cx', workspaceUserIds: WS_USERS });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(409);
+      expect(result.detail).toMatch(/already cancelled/i);
+    }
+    expect(mockTransaction).not.toHaveBeenCalled();
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+  });
+
+  // ---- pending: cancel without stock rollback ----
+  it('cancels a "pending" transfer: sets status=cancelled, does NOT adjust stock', async () => {
+    mockFindFirst.mockResolvedValue({
+      id: 'tf-pend', status: 'pending', productId: 'p2',
+      fromLocation: 'sydney', toLocation: 'melbourne', quantity: 8,
+    });
+
+    mockUpdate.mockResolvedValue({
+      id: 'tf-pend', status: 'cancelled', productId: 'p2',
+      fromLocation: 'sydney', toLocation: 'melbourne', quantity: 8,
+      reason: null, notes: null,
+      updatedAt: new Date('2026-06-11T00:00:00Z'),
+      product: { name: 'Widget', sku: 'WGT-001' },
+    });
+
+    const result = await cancelTransfer({ id: 'tf-pend', workspaceUserIds: WS_USERS });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.transfer.status).toBe('cancelled');
+      expect(result.transfer.id).toBe('tf-pend');
+    }
+
+    // Pending: stock was never moved — no location updates
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+    expect(mockSyncProductStockTotal).not.toHaveBeenCalled();
+
+    // Only the StockTransfer record is set to cancelled
+    expect(mockUpdate).toHaveBeenCalledOnce();
+    expect(mockUpdate.mock.calls[0][0]).toMatchObject({
+      where: { id: 'tf-pend' },
+      data: { status: 'cancelled' },
+    });
+  });
+
+  // ---- in_transit: cancel WITH stock rollback ----
+  it('cancels an "in_transit" transfer: restores fromLocation, decrements toLocation', async () => {
+    mockFindFirst.mockResolvedValue({
+      id: 'tf-tr', status: 'in_transit', productId: 'p3',
+      fromLocation: 'brisbane', toLocation: 'sydney', quantity: 20,
+    });
+
+    mockUpdateMany.mockResolvedValue({ count: 1 });
+    mockUpdate.mockResolvedValue({
+      id: 'tf-tr', status: 'cancelled', productId: 'p3',
+      fromLocation: 'brisbane', toLocation: 'sydney', quantity: 20,
+      reason: null, notes: null,
+      updatedAt: new Date('2026-06-11T00:00:00Z'),
+      product: { name: 'Gadget', sku: 'GDG-002' },
+    });
+
+    const result = await cancelTransfer({ id: 'tf-tr', workspaceUserIds: WS_USERS });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.transfer.status).toBe('cancelled');
+    }
+
+    // Exactly two stock mutations: restore source, undo destination
+    expect(mockUpdateMany).toHaveBeenCalledTimes(2);
+
+    type UpdateManyArg = {
+      where: { productId: string; location: string };
+      data: { quantity: { increment?: number; decrement?: number } };
+    };
+    const [fromCall, toCall] = mockUpdateMany.mock.calls as [UpdateManyArg[], UpdateManyArg[]][number][];
+
+    // fromLocation (brisbane) incremented — stock restored
+    expect(fromCall[0]).toMatchObject({
+      where: { productId: 'p3', location: 'brisbane' },
+      data: { quantity: { increment: 20 } },
+    });
+
+    // toLocation (sydney) decremented — move undone
+    expect(toCall[0]).toMatchObject({
+      where: { productId: 'p3', location: 'sydney' },
+      data: { quantity: { decrement: 20 } },
+    });
+
+    // Product stock total must be re-synced after in_transit rollback
+    expect(mockSyncProductStockTotal).toHaveBeenCalledOnce();
+    expect(mockSyncProductStockTotal).toHaveBeenCalledWith(expect.anything(), 'p3');
+  });
+
+  // ---- org scoping ----
+  it('enforces org scoping: workspaceUserIds passed to findFirst', async () => {
+    mockFindFirst.mockResolvedValue(null);
+
+    await cancelTransfer({ id: 'tf-org', workspaceUserIds: ['u1', 'u2'] });
+
+    expect(mockFindFirst).toHaveBeenCalledOnce();
+    const arg = mockFindFirst.mock.calls[0][0] as {
+      where: { id: string; product: { ownerUserId: { in: string[] } } };
+    };
+    expect(arg.where.id).toBe('tf-org');
+    expect(arg.where.product.ownerUserId.in).toEqual(['u1', 'u2']);
+  });
+});

--- a/src/lib/db/transfer-cancel-service.ts
+++ b/src/lib/db/transfer-cancel-service.ts
@@ -1,0 +1,116 @@
+import type { Prisma } from '@prisma/client';
+import { prisma } from './prisma';
+import { syncProductStockTotal } from './inventory-location-transfer';
+
+export interface CancelTransferOptions {
+  /** Transfer id to cancel */
+  id: string;
+  /** All workspace member user ids for org scoping */
+  workspaceUserIds: string[];
+}
+
+export type CancelTransferResult =
+  | { ok: true; transfer: CancelledTransferRow }
+  | { ok: false; status: 404 | 409; detail: string };
+
+export interface CancelledTransferRow {
+  id: string;
+  status: string;
+  productId: string;
+  productName: string;
+  productSku: string;
+  fromLocation: string;
+  toLocation: string;
+  quantity: number;
+  reason: string | null;
+  notes: string | null;
+  updatedAt: Date;
+}
+
+/**
+ * Cancel a pending or in_transit stock transfer.
+ *
+ * Rollback rules:
+ *  - completed  → 409 (stock already moved; create a reverse transfer instead)
+ *  - cancelled  → 409 (idempotency guard)
+ *  - pending    → set status = 'cancelled'; NO stock adjustment (stock not yet moved)
+ *  - in_transit → restore quantity to fromLocation, decrement toLocation, set status = 'cancelled'
+ *
+ * Org scoping is enforced by filtering on product.ownerUserId ∈ workspaceUserIds.
+ */
+export async function cancelTransfer(
+  opts: CancelTransferOptions,
+): Promise<CancelTransferResult> {
+  const { id, workspaceUserIds } = opts;
+
+  const transfer = await prisma.stockTransfer.findFirst({
+    where: {
+      id,
+      product: { ownerUserId: { in: workspaceUserIds } },
+    },
+    select: {
+      id: true,
+      status: true,
+      productId: true,
+      fromLocation: true,
+      toLocation: true,
+      quantity: true,
+    },
+  });
+
+  if (!transfer) {
+    return { ok: false, status: 404, detail: 'Transfer not found' };
+  }
+
+  if (transfer.status === 'completed') {
+    return {
+      ok: false,
+      status: 409,
+      detail:
+        'Cannot cancel a completed transfer. Stock has already been moved. Create a reverse transfer if needed.',
+    };
+  }
+
+  if (transfer.status === 'cancelled') {
+    return { ok: false, status: 409, detail: 'Transfer is already cancelled.' };
+  }
+
+  const cancelled = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+    if (transfer.status === 'in_transit') {
+      // Stock was moved when the transfer went in_transit: restore it
+      await tx.productLocationStock.updateMany({
+        where: { productId: transfer.productId, location: transfer.fromLocation },
+        data: { quantity: { increment: transfer.quantity } },
+      });
+      await tx.productLocationStock.updateMany({
+        where: { productId: transfer.productId, location: transfer.toLocation },
+        data: { quantity: { decrement: transfer.quantity } },
+      });
+      await syncProductStockTotal(tx, transfer.productId);
+    }
+    // For pending: stock was not moved — no stock adjustment needed
+
+    return tx.stockTransfer.update({
+      where: { id: transfer.id },
+      data: { status: 'cancelled' },
+      include: { product: { select: { name: true, sku: true } } },
+    });
+  });
+
+  return {
+    ok: true,
+    transfer: {
+      id: cancelled.id,
+      status: cancelled.status,
+      productId: cancelled.productId,
+      productName: cancelled.product.name,
+      productSku: cancelled.product.sku,
+      fromLocation: cancelled.fromLocation,
+      toLocation: cancelled.toLocation,
+      quantity: cancelled.quantity,
+      reason: cancelled.reason,
+      notes: cancelled.notes,
+      updatedAt: cancelled.updatedAt,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- **New endpoint**: `POST /api/inventory/transfers/:id/cancel` — atomic cancel with stock rollback
- **New service**: `src/lib/db/transfer-cancel-service.ts` — decoupled cancel logic (testable without route mocking)
- **UI (list page)**: replaces the `// TODO: Implement cancel endpoint` + "Not Implemented" toast with a real `inventoryApi.cancelTransfer()` call; shows success/error toasts consistent with neighbouring actions
- **UI (detail page)**: `handleCancelTransfer` wired to `/cancel` endpoint instead of the `/status` stub; allows cancel from `pending` or `in_transit`; button guard updated to match

## Rollback rules implemented

| Transfer status | Cancel result |
|---|---|
| `pending` | Set `cancelled`; **no stock adjustment** (stock was never moved) |
| `in_transit` | Restore `fromLocation` qty (increment), decrement `toLocation` qty, sync product total; set `cancelled` |
| `completed` | **409 rejected** — stock settled; caller should create a reverse transfer |
| `cancelled` | **409 rejected** — idempotency guard |

Org scoping: identical to neighbouring endpoints — `product.ownerUserId ∈ workspaceUserIds`.

## Test evidence

```
Test Files  6 passed (6)
Tests       63 passed (63)   ← 57 pre-existing + 6 new

cancelTransfer service
  ✓ returns 404 when the transfer is not found (org scope miss)
  ✓ returns 409 for a "completed" transfer and does not touch stock
  ✓ returns 409 for an already "cancelled" transfer and does not touch stock
  ✓ cancels a "pending" transfer: sets status=cancelled, does NOT adjust stock
  ✓ cancels an "in_transit" transfer: restores fromLocation, decrements toLocation
  ✓ enforces org scoping: workspaceUserIds passed to findFirst
```

TypeScript: no new errors introduced (pre-existing codebase-wide `@prisma/client` generation gap affects 33+ files including the adjacent `inventory-location-transfer.ts` — same pattern used here).

## Test plan

- [ ] Cancel a pending transfer → confirm status = `cancelled`, stock unchanged
- [ ] Cancel an in_transit transfer → confirm stock restored at source, decremented at destination
- [ ] Attempt to cancel a completed transfer → confirm 409 response shown in UI
- [ ] Attempt to cancel an already-cancelled transfer → confirm 409 guard
- [ ] Cancel button hidden on completed/cancelled transfers in list view
- [ ] Cancel from detail page works for pending and in_transit

Closes UNI-2112

🤖 Generated with [Claude Code](https://claude.com/claude-code)