### PR TITLE
feat: company settings save via authenticated org API (UNI-2111)

### DIFF
--- a/src/app/(dashboard)/settings/company/page.tsx
+++ b/src/app/(dashboard)/settings/company/page.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   Select,
@@ -62,6 +61,9 @@ export default function CompanySettingsPage() {
       try {
         const company = await settingsApi.getCompany();
         setCompanyName(company.name);
+        setTradingName(company.trading_name ?? '');
+        setAbn(company.abn ?? '');
+        setAcn(company.acn ?? '');
       } catch {
         // Use defaults if not available
       } finally {
@@ -76,8 +78,18 @@ export default function CompanySettingsPage() {
     setIsLoading(true);
 
     try {
-      const updated = await settingsApi.updateCompany({ name: companyName });
+      const updated = await settingsApi.updateCompany({
+        name: companyName,
+        trading_name: tradingName || null,
+        abn: abn || null,
+        acn: acn || null,
+      });
+
+      // Reload from API response to confirm persisted values
       setCompanyName(updated.name);
+      setTradingName(updated.trading_name ?? '');
+      setAbn(updated.abn ?? '');
+      setAcn(updated.acn ?? '');
 
       toast({
         title: 'Company Updated',

--- a/src/app/api/settings/company/route.ts
+++ b/src/app/api/settings/company/route.ts
@@ -1,0 +1,60 @@
+/**
+ * UNI-2111: Company settings endpoint — org-authenticated GET + PUT.
+ *
+ * Auth pattern mirrors POS routes merged in UNI-2107:
+ *   1. requireAuthScope  → 401 if no valid JWT
+ *   2. getWorkspaceIdForUser → 403 if user has no workspace row
+ *   3. workspaceId from DB used as the store key (never from request)
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuthScope } from '@/lib/auth/data-scope';
+import { getWorkspaceIdForUser } from '@/lib/auth/workspace-scope';
+import { getCompanySettings, saveCompanySettings } from '@/lib/settings/company-store';
+
+export async function GET(request: NextRequest) {
+  const scope = await requireAuthScope(request);
+  if (!scope) {
+    return NextResponse.json({ detail: 'Not authenticated' }, { status: 401 });
+  }
+
+  const workspaceId = await getWorkspaceIdForUser(scope.userId);
+  if (!workspaceId) {
+    return NextResponse.json({ detail: 'No workspace found for this user' }, { status: 403 });
+  }
+
+  const settings = getCompanySettings(workspaceId);
+  return NextResponse.json(settings);
+}
+
+export async function PUT(request: NextRequest) {
+  const scope = await requireAuthScope(request);
+  if (!scope) {
+    return NextResponse.json({ detail: 'Not authenticated' }, { status: 401 });
+  }
+
+  const workspaceId = await getWorkspaceIdForUser(scope.userId);
+  if (!workspaceId) {
+    return NextResponse.json({ detail: 'No workspace found for this user' }, { status: 403 });
+  }
+
+  const body = (await request.json()) as {
+    name?: unknown;
+    trading_name?: unknown;
+    abn?: unknown;
+    acn?: unknown;
+  };
+
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+  if (!name) {
+    return NextResponse.json({ detail: 'name is required' }, { status: 400 });
+  }
+
+  const updated = saveCompanySettings(workspaceId, {
+    name,
+    trading_name: typeof body.trading_name === 'string' ? body.trading_name.trim() || null : null,
+    abn: typeof body.abn === 'string' ? body.abn.trim() || null : null,
+    acn: typeof body.acn === 'string' ? body.acn.trim() || null : null,
+  });
+
+  return NextResponse.json(updated);
+}

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -26,10 +26,16 @@ export interface CompanySettings {
   name: string;
   slug: string;
   is_active: boolean;
+  trading_name: string | null;
+  abn: string | null;
+  acn: string | null;
 }
 
 export interface UpdateCompanyRequest {
   name: string;
+  trading_name?: string | null;
+  abn?: string | null;
+  acn?: string | null;
 }
 
 export const settingsApi = {
@@ -42,7 +48,7 @@ export const settingsApi = {
   changePassword: (data: ChangePasswordRequest): Promise<{ message: string }> =>
     apiClient.post<{ message: string }>('/api/auth/change-password', data),
 
-  // Company settings
+  // Company settings (UNI-2111: org-authenticated via /api/settings/company)
   getCompany: (): Promise<CompanySettings> =>
     apiClient.get<CompanySettings>('/api/settings/company'),
 

--- a/src/lib/settings/__tests__/company-settings-route.test.ts
+++ b/src/lib/settings/__tests__/company-settings-route.test.ts
@@ -1,0 +1,232 @@
+/**
+ * UNI-2111: Company settings route handler tests.
+ *
+ * Tests:
+ *   1. GET returns saved values after PUT (save persists, reload returns saved values).
+ *   2. Unauthenticated requests → 401 for both GET and PUT.
+ *   3. Authenticated user with no workspace → 403.
+ *   4. Cross-workspace isolation: workspace B cannot read workspace A's settings.
+ *   5. Missing/invalid name in PUT → 400.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { _resetAllCompanySettings, getCompanySettings } from '../company-store';
+
+// Mock auth modules before importing route handlers
+vi.mock('@/lib/auth/data-scope', () => ({
+  requireAuthScope: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/workspace-scope', () => ({
+  getWorkspaceIdForUser: vi.fn(),
+}));
+
+import { requireAuthScope } from '@/lib/auth/data-scope';
+import { getWorkspaceIdForUser } from '@/lib/auth/workspace-scope';
+import { GET, PUT } from '@/app/api/settings/company/route';
+
+type MockAuthScope = { userId: string; role: 'owner' | 'admin' | 'member' | 'billing'; isAdmin: boolean } | null;
+
+function setAuth(scope: MockAuthScope, workspaceId: string | null = 'ws-default') {
+  vi.mocked(requireAuthScope).mockResolvedValue(scope);
+  vi.mocked(getWorkspaceIdForUser).mockResolvedValue(scope ? workspaceId : null);
+}
+
+function makeGetRequest(): Request {
+  return new Request('http://localhost/api/settings/company', { method: 'GET' });
+}
+
+function makePutRequest(body: unknown): Request {
+  return new Request('http://localhost/api/settings/company', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Unauthenticated → 401
+// ---------------------------------------------------------------------------
+
+describe('company settings route: unauthenticated requests → 401', () => {
+  beforeEach(() => {
+    _resetAllCompanySettings();
+    setAuth(null);
+  });
+
+  it('GET /api/settings/company → 401', async () => {
+    const res = await GET(makeGetRequest() as never);
+    expect(res.status).toBe(401);
+    const body = await res.json() as { detail: string };
+    expect(body.detail).toMatch(/not authenticated/i);
+  });
+
+  it('PUT /api/settings/company → 401', async () => {
+    const res = await PUT(makePutRequest({ name: 'New Name' }) as never);
+    expect(res.status).toBe(401);
+    const body = await res.json() as { detail: string };
+    expect(body.detail).toMatch(/not authenticated/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Authenticated but no workspace → 403
+// ---------------------------------------------------------------------------
+
+describe('company settings route: authenticated but no workspace → 403', () => {
+  beforeEach(() => {
+    _resetAllCompanySettings();
+    setAuth({ userId: 'orphan-user', role: 'owner', isAdmin: false }, null);
+  });
+
+  it('GET /api/settings/company → 403', async () => {
+    const res = await GET(makeGetRequest() as never);
+    expect(res.status).toBe(403);
+    const body = await res.json() as { detail: string };
+    expect(body.detail).toMatch(/no workspace/i);
+  });
+
+  it('PUT /api/settings/company → 403', async () => {
+    const res = await PUT(makePutRequest({ name: 'New Name' }) as never);
+    expect(res.status).toBe(403);
+    const body = await res.json() as { detail: string };
+    expect(body.detail).toMatch(/no workspace/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Save persists + reload returns saved values
+// ---------------------------------------------------------------------------
+
+describe('company settings route: save persists and reload returns saved values', () => {
+  const WORKSPACE = 'ws-acme-corp';
+
+  beforeEach(() => {
+    _resetAllCompanySettings();
+    setAuth({ userId: 'user-acme', role: 'owner', isAdmin: false }, WORKSPACE);
+  });
+
+  it('GET returns the default seeded company name', async () => {
+    const res = await GET(makeGetRequest() as never);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { name: string };
+    expect(typeof body.name).toBe('string');
+    expect(body.name.length).toBeGreaterThan(0);
+  });
+
+  it('PUT saves name and GET returns the updated value', async () => {
+    const putRes = await PUT(makePutRequest({ name: 'Acme Corp Pty Ltd' }) as never);
+    expect(putRes.status).toBe(200);
+    const putBody = await putRes.json() as { name: string; slug: string };
+    expect(putBody.name).toBe('Acme Corp Pty Ltd');
+    expect(putBody.slug).toBe('acme-corp-pty-ltd');
+
+    // GET now returns the saved value
+    const getRes = await GET(makeGetRequest() as never);
+    expect(getRes.status).toBe(200);
+    const getBody = await getRes.json() as { name: string };
+    expect(getBody.name).toBe('Acme Corp Pty Ltd');
+  });
+
+  it('PUT saves trading_name, abn, acn and GET returns them', async () => {
+    const putRes = await PUT(
+      makePutRequest({
+        name: 'Acme Corp Pty Ltd',
+        trading_name: 'Acme Corp',
+        abn: '51 824 753 556',
+        acn: '123 456 789',
+      }) as never
+    );
+    expect(putRes.status).toBe(200);
+    const putBody = await putRes.json() as {
+      name: string;
+      trading_name: string | null;
+      abn: string | null;
+      acn: string | null;
+    };
+    expect(putBody.trading_name).toBe('Acme Corp');
+    expect(putBody.abn).toBe('51 824 753 556');
+    expect(putBody.acn).toBe('123 456 789');
+
+    // GET returns the same values
+    const getRes = await GET(makeGetRequest() as never);
+    const getBody = await getRes.json() as {
+      trading_name: string | null;
+      abn: string | null;
+      acn: string | null;
+    };
+    expect(getBody.trading_name).toBe('Acme Corp');
+    expect(getBody.abn).toBe('51 824 753 556');
+    expect(getBody.acn).toBe('123 456 789');
+  });
+
+  it('PUT with missing name → 400', async () => {
+    const res = await PUT(makePutRequest({ name: '' }) as never);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { detail: string };
+    expect(body.detail).toMatch(/name is required/i);
+  });
+
+  it('PUT with no name field → 400', async () => {
+    const res = await PUT(makePutRequest({ trading_name: 'No Name' }) as never);
+    expect(res.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-workspace isolation (spoofed / foreign org rejected)
+// ---------------------------------------------------------------------------
+
+describe('company settings route: cross-workspace isolation', () => {
+  const WORKSPACE_A = 'ws-org-a';
+  const WORKSPACE_B = 'ws-org-b';
+
+  beforeEach(() => {
+    _resetAllCompanySettings();
+  });
+
+  it('workspace B cannot read workspace A settings via GET', async () => {
+    // Seed workspace A with a distinctive name
+    setAuth({ userId: 'user-a', role: 'owner', isAdmin: false }, WORKSPACE_A);
+    await PUT(makePutRequest({ name: 'Org A Secret Name' }) as never);
+
+    // Workspace B authenticates and reads — must NOT see Org A's name
+    setAuth({ userId: 'user-b', role: 'owner', isAdmin: false }, WORKSPACE_B);
+    const res = await GET(makeGetRequest() as never);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { name: string };
+    expect(body.name).not.toBe('Org A Secret Name');
+  });
+
+  it('workspace B PUT does not overwrite workspace A settings', async () => {
+    // Workspace A writes its name
+    setAuth({ userId: 'user-a', role: 'owner', isAdmin: false }, WORKSPACE_A);
+    await PUT(makePutRequest({ name: 'Org A Original' }) as never);
+
+    // Workspace B writes its own name
+    setAuth({ userId: 'user-b', role: 'owner', isAdmin: false }, WORKSPACE_B);
+    await PUT(makePutRequest({ name: 'Org B Name' }) as never);
+
+    // Workspace A reads — still sees its original value
+    setAuth({ userId: 'user-a', role: 'owner', isAdmin: false }, WORKSPACE_A);
+    const res = await GET(makeGetRequest() as never);
+    const body = await res.json() as { name: string };
+    expect(body.name).toBe('Org A Original');
+  });
+
+  it('workspaceId cannot be spoofed via request body', async () => {
+    // Workspace A saves a value
+    setAuth({ userId: 'user-a', role: 'owner', isAdmin: false }, WORKSPACE_A);
+    await PUT(makePutRequest({ name: 'Real Org A Name' }) as never);
+
+    // Workspace B attempts to inject workspace A's id into the body — must be ignored.
+    // The route uses getWorkspaceIdForUser(scope.userId) from DB, not body values.
+    setAuth({ userId: 'user-b', role: 'owner', isAdmin: false }, WORKSPACE_B);
+    const attackBody = { name: 'Attacker', workspaceId: WORKSPACE_A, id: WORKSPACE_A };
+    await PUT(makePutRequest(attackBody) as never);
+
+    // Workspace A still has original value in the store
+    const storeA = getCompanySettings(WORKSPACE_A);
+    expect(storeA.name).toBe('Real Org A Name');
+  });
+});

--- a/src/lib/settings/company-store.ts
+++ b/src/lib/settings/company-store.ts
@@ -1,0 +1,100 @@
+/**
+ * UNI-2111: Per-workspace company settings store (in-memory, same pattern as POS mock-store).
+ *
+ * Workspace isolation is enforced by the route handler: workspaceId MUST come from the
+ * authenticated user's DB record, never from the request body or query string.
+ */
+
+export type CompanySettings = {
+  id: string;
+  workspaceId: string;
+  name: string;
+  slug: string;
+  is_active: boolean;
+  trading_name: string | null;
+  abn: string | null;
+  acn: string | null;
+};
+
+export type UpdateCompanySettingsInput = {
+  name: string;
+  trading_name?: string | null;
+  abn?: string | null;
+  acn?: string | null;
+};
+
+type SettingsMap = Map<string, CompanySettings>;
+
+const STORE_KEY = '__ccwCompanySettingsByWorkspace__';
+
+function getStoreMap(): SettingsMap {
+  const g = globalThis as typeof globalThis & { [STORE_KEY]?: SettingsMap };
+  if (!g[STORE_KEY]) {
+    g[STORE_KEY] = new Map<string, CompanySettings>();
+  }
+  return g[STORE_KEY] as SettingsMap;
+}
+
+function seedSettings(workspaceId: string): CompanySettings {
+  return {
+    id: workspaceId,
+    workspaceId,
+    name: 'CCW Equipment Supplies',
+    slug: 'ccw-equipment-supplies',
+    is_active: true,
+    trading_name: null,
+    abn: null,
+    acn: null,
+  };
+}
+
+/**
+ * Returns the company settings for a workspace, seeding defaults on first access.
+ *
+ * Route handlers MUST supply a workspaceId resolved from the authenticated user's
+ * DB record — never a caller-supplied value.
+ */
+export function getCompanySettings(workspaceId: string): CompanySettings {
+  const map = getStoreMap();
+  if (!map.has(workspaceId)) {
+    map.set(workspaceId, seedSettings(workspaceId));
+  }
+  return map.get(workspaceId) as CompanySettings;
+}
+
+/**
+ * Persists updated company settings for a workspace.
+ * Returns the saved record.
+ */
+export function saveCompanySettings(
+  workspaceId: string,
+  updates: UpdateCompanySettingsInput
+): CompanySettings {
+  const current = getCompanySettings(workspaceId);
+  const slug = updates.name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+
+  const updated: CompanySettings = {
+    ...current,
+    name: updates.name,
+    slug,
+    trading_name: updates.trading_name !== undefined ? updates.trading_name ?? null : current.trading_name,
+    abn: updates.abn !== undefined ? updates.abn ?? null : current.abn,
+    acn: updates.acn !== undefined ? updates.acn ?? null : current.acn,
+  };
+
+  getStoreMap().set(workspaceId, updated);
+  return updated;
+}
+
+/** Reset a workspace's company settings (test helper). */
+export function _resetCompanySettingsForWorkspace(workspaceId: string): void {
+  getStoreMap().delete(workspaceId);
+}
+
+/** Clear all company settings stores (test helper). */
+export function _resetAllCompanySettings(): void {
+  getStoreMap().clear();
+}


### PR DESCRIPTION
## Summary

- Adds GET /api/settings/company and PUT /api/settings/company route handlers using the requireAuthScope + getWorkspaceIdForUser pattern established in UNI-2107 (PR #199)
- Adds src/lib/settings/company-store.ts -- per-workspace in-memory settings store (name, slug, trading_name, abn, acn); the workspaceId key is always resolved from the authenticated user DB record, never from the request body
- Extends CompanySettings and UpdateCompanyRequest API types to include trading_name, abn, and acn
- Wires the company settings frontend to send all four fields on save and reload state from the API response (previously only name was sent, and the backend endpoint was missing)

## Auth shape (canonical - mirrors UNI-2107 POS routes)

GET  /api/settings/company
PUT  /api/settings/company   { name, trading_name?, abn?, acn? }

401  Not authenticated        (no valid JWT)
403  No workspace found       (user has no workspace row)
400  name is required         (empty/missing name on PUT)
200  CompanySettings object

## Test evidence

- src/lib/settings/__tests__/company-settings-route.test.ts (12 tests) 17ms PASSED
- src/lib/pos/__tests__/pos-route-auth.test.ts (19 tests) 19ms PASSED
- Total: 31 tests passed

Tests cover:
- GET returns default seeded name
- PUT saves name and fields, GET returns saved values (save persists and reload)
- Unauthenticated GET and PUT return 401
- Authenticated user with no workspace GET and PUT return 403
- Cross-workspace isolation: workspace B cannot read workspace A settings
- PUT by workspace B does not overwrite workspace A settings
- Spoofed workspaceId in request body is ignored (route uses DB-resolved value)
- Empty/missing name returns 400

## TypeCheck

No new TS errors in changed files. Pre-existing reorder-settings implicit-any error in prisma transaction callback is unrelated and pre-dates this branch.

Generated with [Claude Code](https://claude.com/claude-code)