### PR TITLE
fix: service portal uses authenticated customer context (UNI-2115)

### DIFF
--- a/src/app/(portal)/portal/service/page.tsx
+++ b/src/app/(portal)/portal/service/page.tsx
@@ -9,6 +9,9 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
 import { apiClient } from '@/lib/api/client';
+// UNI-2115: customer identity is always derived from the authenticated session,
+// never from a hardcoded or caller-supplied value.
+import { usePortalCustomer } from '@/hooks/use-portal-customer';
 
 type RequestType = 'warranty_claim' | 'service_booking' | 'general_inquiry';
 
@@ -29,6 +32,10 @@ const REQUEST_TYPE_LABELS: Record<RequestType, string> = {
 
 export default function PortalServicePage() {
   const { toast } = useToast();
+  // UNI-2115: Load customer context from the session. The customer_id is
+  // resolved server-side by /api/portal/customer-context — it is never read
+  // from a prop, URL param, or hardcoded literal.
+  const { customer } = usePortalCustomer();
   const [requestType, setRequestType] = useState<RequestType>('warranty_claim');
   const [orderNumber, setOrderNumber] = useState('');
   const [sku, setSku] = useState('');
@@ -76,6 +83,11 @@ export default function PortalServicePage() {
         <h1 className="text-2xl font-bold text-slate-900">Service Requests</h1>
         <p className="mt-0.5 text-sm text-slate-500">
           Lodge warranty claims, book a service, or ask a general question.
+          {customer && (
+            <span className="ml-1 text-slate-400">
+              — Account: <span className="font-medium text-slate-600">{customer.company_name}</span>
+            </span>
+          )}
         </p>
       </div>
 

--- a/src/app/api/portal/customer-context/route.ts
+++ b/src/app/api/portal/customer-context/route.ts
@@ -1,0 +1,50 @@
+/**
+ * UNI-2115: GET /api/portal/customer-context
+ *
+ * Returns the Customer record that belongs to the authenticated portal user.
+ * The customer is resolved server-side from the JWT — the client never
+ * supplies a customer_id.
+ *
+ * Used by the usePortalCustomer() hook so portal pages can display account
+ * info without any client-side hardcoding.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { resolvePortalCustomer } from '@/lib/portal/customer-context';
+import { prisma } from '@/lib/db/prisma';
+
+export async function GET(request: NextRequest) {
+  const ctx = await resolvePortalCustomer(request);
+  if (!ctx) {
+    const { requireAuthScope } = await import('@/lib/auth/data-scope');
+    const scope = await requireAuthScope(request);
+    if (!scope) {
+      return NextResponse.json({ detail: 'Not authenticated' }, { status: 401 });
+    }
+    return NextResponse.json(
+      { detail: 'No customer account found for this session' },
+      { status: 403 }
+    );
+  }
+
+  const customer = await prisma.customer.findUnique({
+    where: { id: ctx.customerId },
+    select: {
+      id: true,
+      companyName: true,
+      contactName: true,
+      email: true,
+    },
+  });
+
+  if (!customer) {
+    return NextResponse.json({ detail: 'Customer record not found' }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    customer_id: customer.id,
+    company_name: customer.companyName,
+    contact_name: customer.contactName,
+    email: customer.email,
+  });
+}

--- a/src/app/api/portal/service-requests/route.ts
+++ b/src/app/api/portal/service-requests/route.ts
@@ -1,0 +1,100 @@
+/**
+ * UNI-2115: Portal service-request endpoints.
+ *
+ * Security model (same shape as UNI-2107 / requireAuthScope):
+ * 1. Verify the access JWT → identify the user.
+ * 2. Resolve the Customer record server-side from the JWT email.
+ * 3. NEVER accept a customer_id from the request body / query string.
+ *    Any body field named `customer_id` that does NOT match the session
+ *    customer triggers a 403.
+ *
+ * GET  /api/portal/service-requests  → list requests for the session customer
+ * POST /api/portal/service-requests  → create a new request for the session customer
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { resolvePortalCustomer, customerIdMatchesSession } from '@/lib/portal/customer-context';
+import {
+  getRequestsForCustomer,
+  createRequest,
+  type PortalRequestType,
+} from '@/lib/portal/service-request-store';
+
+const VALID_REQUEST_TYPES = new Set<PortalRequestType>([
+  'warranty_claim',
+  'service_booking',
+  'general_inquiry',
+]);
+
+export async function GET(request: NextRequest) {
+  const ctx = await resolvePortalCustomer(request);
+  if (!ctx) {
+    // Distinguish: null because unauthenticated vs. no matching customer.
+    // resolvePortalCustomer returns null for both; we re-check the JWT here
+    // to give the right status code.
+    const { requireAuthScope } = await import('@/lib/auth/data-scope');
+    const scope = await requireAuthScope(request);
+    if (!scope) {
+      return NextResponse.json({ detail: 'Not authenticated' }, { status: 401 });
+    }
+    return NextResponse.json({ detail: 'No customer account found for this session' }, { status: 403 });
+  }
+
+  const requests = getRequestsForCustomer(ctx.customerId);
+  return NextResponse.json({ requests, total: requests.length });
+}
+
+export async function POST(request: NextRequest) {
+  const ctx = await resolvePortalCustomer(request);
+  if (!ctx) {
+    const { requireAuthScope } = await import('@/lib/auth/data-scope');
+    const scope = await requireAuthScope(request);
+    if (!scope) {
+      return NextResponse.json({ detail: 'Not authenticated' }, { status: 401 });
+    }
+    return NextResponse.json({ detail: 'No customer account found for this session' }, { status: 403 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return NextResponse.json({ detail: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  // UNI-2115 spoof-rejection: if the caller includes a customer_id claim in
+  // the body it must match the session-resolved customer. Mismatch → 403.
+  if (body.customer_id !== undefined && body.customer_id !== null) {
+    if (!customerIdMatchesSession(ctx, String(body.customer_id))) {
+      return NextResponse.json(
+        { detail: 'Forbidden: customer_id does not match authenticated session' },
+        { status: 403 }
+      );
+    }
+  }
+
+  const rawType = String(body.request_type ?? '');
+  if (!VALID_REQUEST_TYPES.has(rawType as PortalRequestType)) {
+    return NextResponse.json(
+      {
+        detail: `Invalid request_type. Must be one of: ${[...VALID_REQUEST_TYPES].join(', ')}`,
+      },
+      { status: 400 }
+    );
+  }
+
+  const description = String(body.description ?? '').trim();
+  if (!description) {
+    return NextResponse.json({ detail: 'description is required' }, { status: 400 });
+  }
+
+  const created = createRequest(ctx.customerId, {
+    request_type: rawType as PortalRequestType,
+    description,
+    order_id: body.order_id ? String(body.order_id) : null,
+    product_sku: body.product_sku ? String(body.product_sku) : null,
+    preferred_contact: String(body.preferred_contact ?? 'email'),
+  });
+
+  return NextResponse.json(created, { status: 201 });
+}

--- a/src/hooks/use-portal-customer.ts
+++ b/src/hooks/use-portal-customer.ts
@@ -1,0 +1,52 @@
+/**
+ * UNI-2115: Hook to load the portal customer context from the authenticated session.
+ *
+ * Calls GET /api/portal/customer-context which returns the customer id and name
+ * resolved server-side from the JWT. The hook is used by portal pages to show
+ * account info and confirm the correct customer identity — it never reads a
+ * customer_id from local state or component props.
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+import { apiClient } from '@/lib/api/client';
+
+export interface PortalCustomer {
+  customer_id: string;
+  company_name: string;
+  contact_name: string | null;
+  email: string;
+}
+
+export function usePortalCustomer(): {
+  customer: PortalCustomer | null;
+  loading: boolean;
+  error: string | null;
+} {
+  const [customer, setCustomer] = useState<PortalCustomer | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    apiClient
+      .get<PortalCustomer>('/api/portal/customer-context')
+      .then((data) => {
+        if (!cancelled) setCustomer(data);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load customer context');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { customer, loading, error };
+}

--- a/src/lib/portal/__tests__/portal-service-requests.test.ts
+++ b/src/lib/portal/__tests__/portal-service-requests.test.ts
@@ -1,0 +1,263 @@
+/**
+ * UNI-2115: Portal service-request route handler tests.
+ *
+ * Proves:
+ * 1. Unauthenticated requests → 401.
+ * 2. Authenticated but no matching customer account → 403.
+ * 3. Authenticated with a valid customer → can POST and GET their own requests.
+ * 4. SPOOF REJECTION: a request whose body carries a customer_id that does NOT
+ *    match the session-resolved customer → 403. This is the regression guard
+ *    required by UNI-2115.
+ * 5. Two different customers are isolated from each other.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { _resetAllPortalStores } from '../service-request-store';
+
+// ─── Mock auth + DB dependencies ─────────────────────────────────────────────
+
+vi.mock('@/lib/auth/data-scope', () => ({
+  requireAuthScope: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/request-token', () => ({
+  getAuthClaimsFromRequest: vi.fn(),
+}));
+
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    customer: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+import { requireAuthScope } from '@/lib/auth/data-scope';
+import { getAuthClaimsFromRequest } from '@/lib/auth/request-token';
+import { prisma } from '@/lib/db/prisma';
+import { GET, POST } from '@/app/api/portal/service-requests/route';
+
+// ─── Type helpers ─────────────────────────────────────────────────────────────
+
+type MockScope = { userId: string; role: 'owner' | 'admin' | 'member' | 'billing'; isAdmin: boolean } | null;
+
+const CUSTOMER_A = { id: 'cust-alpha-uuid', email: 'alice@example.com' };
+const CUSTOMER_B = { id: 'cust-beta-uuid', email: 'bob@example.com' };
+
+function setSession(
+  scope: MockScope,
+  email: string | null = null,
+  customerId: string | null = null
+) {
+  vi.mocked(requireAuthScope).mockResolvedValue(scope);
+  vi.mocked(getAuthClaimsFromRequest).mockResolvedValue(
+    scope && email
+      ? { sub: scope.userId, email, is_admin: false, role: scope.role }
+      : null
+  );
+  vi.mocked(prisma.customer.findFirst).mockResolvedValue(
+    customerId ? ({ id: customerId } as never) : null
+  );
+}
+
+function makeGet(): Request {
+  return new Request('http://localhost/api/portal/service-requests', { method: 'GET' });
+}
+
+function makePost(body: unknown): Request {
+  return new Request('http://localhost/api/portal/service-requests', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('Portal service-requests: unauthenticated → 401', () => {
+  beforeEach(() => {
+    _resetAllPortalStores();
+    setSession(null);
+  });
+
+  it('GET returns 401 when no JWT', async () => {
+    const res = await GET(makeGet() as never);
+    expect(res.status).toBe(401);
+  });
+
+  it('POST returns 401 when no JWT', async () => {
+    const res = await POST(
+      makePost({ request_type: 'warranty_claim', description: 'broken unit' }) as never
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('Portal service-requests: authenticated but no customer account → 403', () => {
+  beforeEach(() => {
+    _resetAllPortalStores();
+    // Auth is fine but no Customer row matches the email.
+    setSession(
+      { userId: 'user-no-cust', role: 'member', isAdmin: false },
+      'stranger@example.com',
+      null // no matching customer
+    );
+  });
+
+  it('GET returns 403 when no customer found for email', async () => {
+    const res = await GET(makeGet() as never);
+    expect(res.status).toBe(403);
+  });
+
+  it('POST returns 403 when no customer found for email', async () => {
+    const res = await POST(
+      makePost({ request_type: 'general_inquiry', description: 'help' }) as never
+    );
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('Portal service-requests: happy path', () => {
+  beforeEach(() => {
+    _resetAllPortalStores();
+    setSession(
+      { userId: 'user-alice', role: 'member', isAdmin: false },
+      CUSTOMER_A.email,
+      CUSTOMER_A.id
+    );
+  });
+
+  it('POST creates a request and returns 201 with a reference number', async () => {
+    const res = await POST(
+      makePost({
+        request_type: 'warranty_claim',
+        description: 'The motor seized after 3 months.',
+        order_id: 'ORD-2026-0001',
+        product_sku: 'TM-PRO-570',
+        preferred_contact: 'email',
+      }) as never
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json() as {
+      request_id: string;
+      customer_id: string;
+      reference_number: string;
+      status: string;
+    };
+    expect(body.customer_id).toBe(CUSTOMER_A.id);
+    expect(body.reference_number).toMatch(/^SR-\d{4}-\d{4}$/);
+    expect(body.status).toBe('submitted');
+  });
+
+  it('GET lists created requests for the session customer', async () => {
+    // Create one first
+    await POST(
+      makePost({ request_type: 'general_inquiry', description: 'Any spare parts?' }) as never
+    );
+
+    const res = await GET(makeGet() as never);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { requests: Array<{ customer_id: string }>; total: number };
+    expect(body.total).toBe(1);
+    expect(body.requests[0].customer_id).toBe(CUSTOMER_A.id);
+  });
+
+  it('POST returns 400 when description is missing', async () => {
+    const res = await POST(
+      makePost({ request_type: 'general_inquiry', description: '   ' }) as never
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('POST returns 400 when request_type is invalid', async () => {
+    const res = await POST(
+      makePost({ request_type: 'hack_the_planet', description: 'valid text' }) as never
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── UNI-2115 primary acceptance criterion: spoof rejection ──────────────────
+
+describe('UNI-2115 spoof rejection: forged customer_id in body → 403', () => {
+  beforeEach(() => {
+    _resetAllPortalStores();
+    // Session resolves to CUSTOMER_A
+    setSession(
+      { userId: 'user-alice', role: 'member', isAdmin: false },
+      CUSTOMER_A.email,
+      CUSTOMER_A.id
+    );
+  });
+
+  it('POST with body.customer_id = session customer is accepted (200-class)', async () => {
+    // Attacker who knows their own id sends it explicitly — should be fine.
+    const res = await POST(
+      makePost({
+        customer_id: CUSTOMER_A.id, // matches session → OK
+        request_type: 'general_inquiry',
+        description: 'Correct claim',
+      }) as never
+    );
+    expect(res.status).toBe(201);
+  });
+
+  it('POST with body.customer_id = a DIFFERENT customer is rejected with 403', async () => {
+    // Core regression test for UNI-2115: a caller supplies a forged
+    // customer_id belonging to a different customer in the body.
+    // The backend must detect the mismatch and refuse.
+    const res = await POST(
+      makePost({
+        customer_id: CUSTOMER_B.id, // FORGED — does NOT match session
+        request_type: 'warranty_claim',
+        description: 'Spoofed request attempting to act as another customer',
+      }) as never
+    );
+    expect(res.status).toBe(403);
+    const body = await res.json() as { detail: string };
+    expect(body.detail).toContain('customer_id');
+  });
+
+  it('POST with body.customer_id = arbitrary string is rejected with 403', async () => {
+    const res = await POST(
+      makePost({
+        customer_id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        request_type: 'service_booking',
+        description: 'Injected arbitrary customer id',
+      }) as never
+    );
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─── Customer isolation ───────────────────────────────────────────────────────
+
+describe('Portal service-requests: customers are isolated from each other', () => {
+  beforeEach(() => {
+    _resetAllPortalStores();
+  });
+
+  it('CUSTOMER_A cannot read CUSTOMER_B requests via GET', async () => {
+    // CUSTOMER_B creates a request
+    setSession(
+      { userId: 'user-bob', role: 'member', isAdmin: false },
+      CUSTOMER_B.email,
+      CUSTOMER_B.id
+    );
+    await POST(
+      makePost({ request_type: 'general_inquiry', description: 'Bob only' }) as never
+    );
+
+    // CUSTOMER_A now requests their list — must not see Bob's entry
+    setSession(
+      { userId: 'user-alice', role: 'member', isAdmin: false },
+      CUSTOMER_A.email,
+      CUSTOMER_A.id
+    );
+    const res = await GET(makeGet() as never);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { requests: unknown[]; total: number };
+    expect(body.total).toBe(0);
+    expect(body.requests).toHaveLength(0);
+  });
+});

--- a/src/lib/portal/customer-context.ts
+++ b/src/lib/portal/customer-context.ts
@@ -1,0 +1,73 @@
+/**
+ * UNI-2115: Portal customer-context resolution.
+ *
+ * Resolves the Customer record that belongs to the authenticated portal user.
+ * The customer is looked up server-side by matching the JWT email against the
+ * Customer.email column — the caller never trusts a client-supplied customer_id.
+ *
+ * Pattern mirrors requireAuthScope (UNI-2107): call from any /api/portal/* route
+ * handler after verifying the JWT. The resolved customer_id can then be used to
+ * scope all data operations.
+ */
+
+import { prisma } from '@/lib/db/prisma';
+import { requireAuthScope } from '@/lib/auth/data-scope';
+import type { NextRequest } from 'next/server';
+
+export type PortalCustomerContext = {
+  /** The JWT subject (AppUser.id). */
+  userId: string;
+  /** The authenticated user's email (from JWT claims). */
+  email: string;
+  /** The Customer row whose email matches the authenticated user's email. */
+  customerId: string;
+};
+
+/**
+ * Resolve the portal customer for the current request.
+ *
+ * Returns null when:
+ * - The request carries no valid JWT (→ 401)
+ * - No Customer row matches the session email (→ 403)
+ *
+ * Never accepts a customer_id from the request body / query string.
+ */
+export async function resolvePortalCustomer(
+  request: NextRequest
+): Promise<PortalCustomerContext | null> {
+  const scope = await requireAuthScope(request);
+  if (!scope) return null;
+
+  // The JWT claims carry the user's email via the `email` field baked in at
+  // login (see jwt-tokens.ts). Re-derive it from the raw token so we stay
+  // consistent with the existing token shape.
+  const { getAuthClaimsFromRequest } = await import('@/lib/auth/request-token');
+  const claims = await getAuthClaimsFromRequest(request);
+  if (!claims?.email) return null;
+
+  const customer = await prisma.customer.findFirst({
+    where: { email: claims.email.toLowerCase(), isActive: true },
+    select: { id: true },
+  });
+
+  if (!customer) return null;
+
+  return {
+    userId: scope.userId,
+    email: claims.email.toLowerCase(),
+    customerId: customer.id,
+  };
+}
+
+/**
+ * Verify that `claimedCustomerId` matches the session-resolved customer.
+ *
+ * Returns false (→ 403 Forbidden) when the claimed id doesn't match.
+ * This guards against a caller constructing a body with an arbitrary customer_id.
+ */
+export function customerIdMatchesSession(
+  ctx: PortalCustomerContext,
+  claimedCustomerId: string
+): boolean {
+  return ctx.customerId === claimedCustomerId;
+}

--- a/src/lib/portal/service-request-store.ts
+++ b/src/lib/portal/service-request-store.ts
@@ -1,0 +1,80 @@
+/**
+ * UNI-2115: In-memory store for portal service requests.
+ *
+ * Scoped by customerId — each customer sees only their own requests.
+ * Mirrors the POS mock-store pattern from UNI-2107.
+ *
+ * In production this would be replaced by a Prisma `ServiceRequest` table;
+ * for now an in-memory map is sufficient and keeps the PR focused on the
+ * auth / customer-context layer.
+ */
+
+import { randomUUID } from 'crypto';
+
+export type PortalRequestType = 'warranty_claim' | 'service_booking' | 'general_inquiry';
+
+export interface PortalServiceRequest {
+  request_id: string;
+  customer_id: string;
+  reference_number: string;
+  request_type: PortalRequestType;
+  description: string;
+  order_id: string | null;
+  product_sku: string | null;
+  preferred_contact: string;
+  status: string;
+  created_at: string;
+}
+
+interface CustomerStore {
+  requests: PortalServiceRequest[];
+  sequence: number;
+}
+
+/** Map<customerId, CustomerStore> */
+const stores = new Map<string, CustomerStore>();
+
+function getStore(customerId: string): CustomerStore {
+  if (!stores.has(customerId)) {
+    stores.set(customerId, { requests: [], sequence: 0 });
+  }
+  return stores.get(customerId)!;
+}
+
+export function getRequestsForCustomer(customerId: string): PortalServiceRequest[] {
+  return getStore(customerId).requests.slice();
+}
+
+export function createRequest(
+  customerId: string,
+  input: {
+    request_type: PortalRequestType;
+    description: string;
+    order_id: string | null;
+    product_sku: string | null;
+    preferred_contact: string;
+  }
+): PortalServiceRequest {
+  const store = getStore(customerId);
+  store.sequence += 1;
+  const ref = `SR-${new Date().getFullYear()}-${String(store.sequence).padStart(4, '0')}`;
+  const req: PortalServiceRequest = {
+    request_id: randomUUID(),
+    customer_id: customerId,
+    reference_number: ref,
+    request_type: input.request_type,
+    description: input.description,
+    order_id: input.order_id,
+    product_sku: input.product_sku,
+    preferred_contact: input.preferred_contact,
+    status: 'submitted',
+    created_at: new Date().toISOString(),
+  };
+  store.requests.unshift(req);
+  return req;
+}
+
+/** Test helper — wipes all stores so tests are isolated. */
+export function _resetAllPortalStores(): void {
+  stores.clear();
+}


### PR DESCRIPTION
## Summary

- **Backend**: `resolvePortalCustomer()` in `src/lib/portal/customer-context.ts` derives the Customer record server-side from the JWT email — the client never supplies a `customer_id` that is trusted.
- **Spoof rejection**: `POST /api/portal/service-requests` checks any body-supplied `customer_id` against the session-resolved customer and returns **403** on mismatch — an attacker cannot act as a different customer by forging the field.
- **Frontend**: `usePortalCustomer` hook (via `GET /api/portal/customer-context`) gives the service page the account name derived from the session; no literal customer ID anywhere in client code.
- **Tests**: 12 vitest tests in `src/lib/portal/__tests__/portal-service-requests.test.ts`; all 113 project tests pass.

## Spoof Test Evidence

Three explicit spoof-rejection tests in the `UNI-2115 spoof rejection` suite:

| Test | Result |
|------|--------|
| `POST` with `customer_id` = **own id** (matches session) | ✅ 201 Accepted |
| `POST` with `customer_id` = **different customer** | 🚫 403 Forbidden |
| `POST` with `customer_id` = **arbitrary UUID** | 🚫 403 Forbidden |

Test output:
```
✓ UNI-2115 spoof rejection: forged customer_id in body → 403 > POST with body.customer_id = session customer is accepted (200-class)
✓ UNI-2115 spoof rejection: forged customer_id in body → 403 > POST with body.customer_id = a DIFFERENT customer is rejected with 403
✓ UNI-2115 spoof rejection: forged customer_id in body → 403 > POST with body.customer_id = arbitrary string is rejected with 403

Test Files  1 passed (1)
Tests       12 passed (12)
```

## Test Plan

- [x] `npx vitest run src/lib/portal/__tests__/portal-service-requests.test.ts` — 12/12 pass
- [x] `npx vitest run` — 113/113 pass (no regressions)
- [x] TypeScript: 0 new errors introduced (219 pre-existing Prisma-generate errors unchanged)
- [ ] Manual: log in to portal, submit a service request, confirm reference number appears
- [ ] Manual: confirm another customer's session cannot see the first customer's requests

## Scope Note

UNI-2114 (portal orders/tracking pages) runs concurrently and consumes the customer-context layer added here. This PR does **not** touch orders/tracking pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)