### PR TITLE
fix: salvage secret-scan placeholder skip + restore .githooks/.gitleaks.toml (closes #151, #153 remnants)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# pre-commit — block commits containing secrets via gitleaks.
+#
+# Setup (run once per clone):  git config core.hooksPath .githooks
+# Bypass (emergency only):      git commit --no-verify
+#
+# Install gitleaks if missing:  brew install gitleaks
+
+set -euo pipefail
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "⚠️  gitleaks not installed — install with:  brew install gitleaks"
+  echo "    Skipping secret scan; commit allowed but unprotected."
+  exit 0
+fi
+
+# Scan only staged content (fast, no false positives from history).
+if ! gitleaks protect --staged --redact --no-banner; then
+  echo ""
+  echo "❌ gitleaks detected potential secret(s) in staged changes."
+  echo "   Remove the secret, then re-stage. Use 'git commit --no-verify' only as a last resort."
+  exit 1
+fi

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,66 @@
+# Custom gitleaks rules for Unite-Group portfolio.
+# Extends gitleaks' built-in defaults — see https://github.com/gitleaks/gitleaks
+# Defaults already catch GitHub PATs (ghp_*), Stripe keys, AWS keys, etc.
+
+title = "Unite-Group secrets policy"
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "anthropic-api-key"
+description = "Anthropic API key (sk-ant-api*-...)"
+regex = '''sk-ant-api[0-9]{2,3}-[A-Za-z0-9_\-]{20,}'''
+keywords = ["sk-ant-api"]
+
+[[rules]]
+id = "linear-api-key"
+description = "Linear API key (lin_api_...)"
+regex = '''lin_api_[A-Za-z0-9]{20,}'''
+keywords = ["lin_api_"]
+
+[[rules]]
+id = "composio-api-key"
+description = "Composio API key (ak_...)"
+regex = '''\bak_[A-Za-z0-9_\-]{20,}\b'''
+keywords = ["ak_"]
+
+[[rules]]
+id = "openai-api-key"
+description = "OpenAI API key (sk-... or sk-proj-...)"
+regex = '''sk-(proj-)?[A-Za-z0-9_\-]{40,}'''
+keywords = ["sk-proj-", "sk-"]
+
+[[rules]]
+id = "perplexity-api-key"
+description = "Perplexity API key (pplx-...)"
+regex = '''pplx-[A-Za-z0-9]{40,}'''
+keywords = ["pplx-"]
+
+[[rules]]
+id = "supabase-service-role-key"
+description = "Supabase service role JWT"
+regex = '''eyJ[A-Za-z0-9_\-]{20,}\.eyJ[A-Za-z0-9_\-]{20,}\.[A-Za-z0-9_\-]{20,}'''
+keywords = ["eyJ"]
+
+[[rules]]
+id = "papercut-api-key"
+description = "Paperclip API key (pcp_...)"
+regex = '''\bpcp_[A-Za-z0-9_\-]{20,}\b'''
+keywords = ["pcp_"]
+
+[allowlist]
+description = "Allowlist for known-safe placeholders and lockfile hashes"
+paths = [
+  '''package-lock\.json''',
+  '''pnpm-lock\.yaml''',
+  '''yarn\.lock''',
+  '''\.env\.example''',
+  '''\.env\.template''',
+  '''\.env\.sample''',
+]
+regexes = [
+  '''sk-ant-api[0-9]{2,3}-FAKE''',
+  '''sk-ant-api[0-9]{2,3}-(YOUR|REPLACE|EXAMPLE|XXX|DUMMY)''',
+  '''lin_api_(YOUR|REPLACE|EXAMPLE|XXX)''',
+]

--- a/scripts/ci/scan-secrets.js
+++ b/scripts/ci/scan-secrets.js
@@ -37,7 +37,7 @@ function scan(dir) {
     if (!EXTS.includes(path.extname(e.name))) return;
     const lines = fs.readFileSync(full, 'utf8').split('\n');
     lines.forEach((line, i) => {
-      if (/process\.env\.|example|placeholder|<.*>|xxx/i.test(line)) return;
+      if (/process\.env\.|example|placeholder|<.*>|xxx|your[_\-]/i.test(line)) return;
       PATTERNS.forEach(({ name, re }) => {
         if (re.test(line)) {
           console.error(`  ❌ ${name}: ${rel}:${i + 1}`);


### PR DESCRIPTION
﻿## Summary

Salvages the remaining unreleased pieces from stale PRs #151 and #153, rebuilt cleanly against current main.

- scripts/ci/scan-secrets.js (from PR #151): Adds `your[_-]` to the placeholder-skip regex. Main currently has `example|placeholder|<.*>|xxx` — this extends it to also skip your_key, your-api-key, etc., preventing false positives on documentation and .env.example files that use that convention.
- .githooks/pre-commit (from PR #153): Restored. This file was dropped from main by an old direct push and returned 404. It runs `gitleaks protect --staged` on every commit, soft-failing gracefully if gitleaks is not installed.
- .gitleaks.toml (from PR #153): Restored. Extends gitleaks defaults with Unite-Group-specific rules (Anthropic, Linear, Composio, OpenAI, Perplexity, Supabase, Papercut) plus an allowlist covering lockfiles and .env.example paths.

**Deliberately excluded:** .npmrc from PR #153 — already present on main.

## Hooks wiring note

package.json has **no prepare script or core.hooksPath configuration**. The .githooks/pre-commit hook is inert until each developer runs once per clone:

```sh
git config core.hooksPath .githooks
```

This is documented in the hook file header. No prepare script was added here — add one explicitly if the team wants automatic wiring on npm install.

## Evidence

### Scanner output (node scripts/ci/scan-secrets.js on this branch)

```
Scanning for hardcoded secrets...

No hardcoded secrets found
```

Exit code: 0. No false positives introduced.

### Original PRs credited

- PR #151 — secret-scanner placeholder skip
- PR #153 — .githooks/pre-commit + .gitleaks.toml restore

Both original PRs left open per instructions — this PR closes only the missing pieces.

Generated with Claude Code (https://claude.com/claude-code)
