### PR TITLE
feat: POS reconciliation bulk match with audit + partial failures (UNI-2113)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -633,6 +633,26 @@ model BankFeedTransaction {
   @@map("bank_feed_transactions")
 }
 
+/// Immutable audit trail for every POS reconciliation bulk-match operation.
+/// One row per pair matched (or attempted) in a bulk run.
+model ReconciliationMatchAudit {
+  id               String   @id @default(uuid()) @db.Uuid
+  /// The user who triggered the bulk-match
+  matchedByUserId  String   @map("matched_by_user_id") @db.Uuid
+  bankFeedId       String   @map("bank_feed_id") @db.Uuid
+  posTransactionId String   @map("pos_transaction_id") @db.Uuid
+  /// "matched" | "failed"
+  outcome          String
+  /// populated when outcome="failed"
+  failureReason    String?  @map("failure_reason")
+  matchedAt        DateTime @default(now()) @map("matched_at")
+
+  @@index([matchedByUserId])
+  @@index([bankFeedId])
+  @@index([posTransactionId])
+  @@map("reconciliation_match_audit")
+}
+
 model ContactSubmission {
   id        String   @id @default(uuid()) @db.Uuid
   name      String

--- a/src/app/(dashboard)/dashboard/operations/pos/reconciliation/components/BulkActionsPanel.tsx
+++ b/src/app/(dashboard)/dashboard/operations/pos/reconciliation/components/BulkActionsPanel.tsx
@@ -1,5 +1,23 @@
 'use client';
 
+/**
+ * BulkActionsPanel — UNI-2113
+ *
+ * Provides two bulk-match modes:
+ *
+ * 1. Auto-Match: for each selected bank-feed, find a POS transaction whose
+ *    amount matches within $0.10 tolerance, then call POST /api/bank-feeds/bulk-reconcile.
+ *
+ * 2. Manual Bulk Match: user explicitly selects N bank-feed IDs AND N POS
+ *    transaction IDs (passed in via props from the parent page), pairs them
+ *    positionally (index 0 ↔ index 0, etc.), then submits to the same endpoint.
+ *    The response itemises any partial failures so the user knows exactly
+ *    which pairs did not reconcile.
+ *
+ * Both paths call the same endpoint which enforces auth/workspace scoping and
+ * writes an immutable audit record for every pair (success or failure).
+ */
+
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -13,23 +31,37 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
-import { CheckSquare, XSquare, Zap } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { CheckSquare, XSquare, Zap, Link } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
-import { bulkReconcile } from '@/lib/api/pos';
+import { bulkReconcile, type ReconcileMatch } from '@/lib/api/pos';
+
+// ── Failure detail returned by the endpoint ─────────────────────────────────
+
+interface MatchFailure {
+  bank_feed_id: string;
+  pos_transaction_id: string;
+  reason: string;
+}
+
+// ── Props ────────────────────────────────────────────────────────────────────
 
 interface BulkActionsPanelProps {
+  /** Currently selected bank-feed IDs (for auto-match mode). */
   selectedItems: Set<string>;
   onClearSelection: () => void;
   onSuccess: () => void;
-  bankFeedData: Array<{
-    id: string;
-    amount: number;
-  }>;
-  posTransactionData: Array<{
-    id: string;
-    amount: number;
-  }>;
+  bankFeedData: Array<{ id: string; amount: number }>;
+  posTransactionData: Array<{ id: string; amount: number }>;
+  /**
+   * Explicit pairs provided by the parent page for manual bulk-match mode.
+   * When present the "Manual Bulk Match" button is enabled and submits these
+   * exact pairs rather than deriving them from selectedItems.
+   */
+  manualPairs?: ReconcileMatch[];
 }
+
+// ── Component ────────────────────────────────────────────────────────────────
 
 export function BulkActionsPanel({
   selectedItems,
@@ -37,82 +69,101 @@ export function BulkActionsPanel({
   onSuccess,
   bankFeedData,
   posTransactionData,
+  manualPairs,
 }: BulkActionsPanelProps) {
   const { toast } = useToast();
   const [isLoading, setIsLoading] = useState(false);
   const [showAutoMatchDialog, setShowAutoMatchDialog] = useState(false);
-  const [showReconcileDialog, setShowReconcileDialog] = useState(false);
+  const [showManualMatchDialog, setShowManualMatchDialog] = useState(false);
+
+  // ── Partial-failure result state ─────────────────────────────────────────
+  const [partialFailures, setPartialFailures] = useState<MatchFailure[]>([]);
+  const [showFailuresDialog, setShowFailuresDialog] = useState(false);
 
   const selectedCount = selectedItems.size;
+  const manualPairCount = manualPairs?.length ?? 0;
 
-  const handleAutoMatch = async () => {
+  // ── Submit helper ────────────────────────────────────────────────────────
+
+  async function submitMatches(matches: ReconcileMatch[], mode: 'auto' | 'manual') {
     setIsLoading(true);
     try {
-      // Find potential matches for selected bank feeds
-      const matches: Array<{ bank_feed_id: string; pos_transaction_id: string }> = [];
-
-      selectedItems.forEach((bankFeedId) => {
-        const bankFeed = bankFeedData.find((bf) => bf.id === bankFeedId);
-        if (!bankFeed) return;
-
-        // Find POS transaction with matching amount (within $0.10)
-        const potentialMatch = posTransactionData.find(
-          (pos) => Math.abs(pos.amount - Math.abs(bankFeed.amount)) <= 0.1
-        );
-
-        if (potentialMatch) {
-          matches.push({
-            bank_feed_id: bankFeedId,
-            pos_transaction_id: potentialMatch.id,
-          });
-        }
-      });
-
-      if (matches.length === 0) {
-        toast({
-          title: 'No Matches Found',
-          description: 'Could not find any matching POS transactions for the selected items.',
-          variant: 'destructive',
-        });
-        setShowAutoMatchDialog(false);
-        return;
-      }
-
-      // Bulk reconcile
       const result = await bulkReconcile(matches);
 
-      toast({
-        title: 'Auto-Match Complete',
-        description: `Successfully matched ${result.matched_count} of ${selectedCount} transactions. ${result.failed_count} failed.`,
-      });
+      // Surface partial failures explicitly
+      const failures = (result as typeof result & { failures?: MatchFailure[] }).failures ?? [];
 
-      onClearSelection();
-      onSuccess();
-      setShowAutoMatchDialog(false);
+      if (result.failed_count > 0 && failures.length > 0) {
+        setPartialFailures(failures);
+        setShowFailuresDialog(true);
+        toast({
+          title: `${mode === 'auto' ? 'Auto-Match' : 'Manual Match'} — partial success`,
+          description: `${result.matched_count} succeeded, ${result.failed_count} failed. See details below.`,
+          variant: 'destructive',
+        });
+      } else {
+        toast({
+          title: `${mode === 'auto' ? 'Auto-Match' : 'Manual Match'} Complete`,
+          description: `Successfully matched ${result.matched_count} transaction${result.matched_count === 1 ? '' : 's'}.`,
+        });
+        onClearSelection();
+        onSuccess();
+      }
     } catch (error: unknown) {
       toast({
         title: 'Error',
-        description: error instanceof Error ? error.message : 'Failed to auto-match transactions',
+        description: error instanceof Error ? error.message : 'Failed to process matches',
         variant: 'destructive',
       });
     } finally {
       setIsLoading(false);
+      setShowAutoMatchDialog(false);
+      setShowManualMatchDialog(false);
     }
-  };
+  }
 
-  const handleBulkReconcile = async () => {
-    // For manual bulk reconcile, we need user to have already paired them
-    // This is just a placeholder - in real implementation, user would select pairs
-    toast({
-      title: 'Not Implemented',
-      description:
-        'Manual bulk reconcile requires pre-paired transactions. Use auto-match instead.',
-      variant: 'destructive',
+  // ── Auto-match handler ───────────────────────────────────────────────────
+
+  async function handleAutoMatch() {
+    const matches: ReconcileMatch[] = [];
+
+    selectedItems.forEach((bankFeedId) => {
+      const bankFeed = bankFeedData.find((bf) => bf.id === bankFeedId);
+      if (!bankFeed) return;
+
+      // Find POS transaction with matching amount within $0.10 tolerance
+      const potentialMatch = posTransactionData.find(
+        (pos) => Math.abs(pos.amount - Math.abs(bankFeed.amount)) <= 0.1
+      );
+
+      if (potentialMatch) {
+        matches.push({ bank_feed_id: bankFeedId, pos_transaction_id: potentialMatch.id });
+      }
     });
-    setShowReconcileDialog(false);
-  };
 
-  if (selectedCount === 0) {
+    if (matches.length === 0) {
+      toast({
+        title: 'No Matches Found',
+        description: 'Could not find any POS transactions within $0.10 of the selected bank feeds.',
+        variant: 'destructive',
+      });
+      setShowAutoMatchDialog(false);
+      return;
+    }
+
+    await submitMatches(matches, 'auto');
+  }
+
+  // ── Manual bulk-match handler ────────────────────────────────────────────
+
+  async function handleManualMatch() {
+    if (!manualPairs || manualPairs.length === 0) return;
+    await submitMatches(manualPairs, 'manual');
+  }
+
+  // ── Render guard ─────────────────────────────────────────────────────────
+
+  if (selectedCount === 0 && manualPairCount === 0) {
     return null;
   }
 
@@ -125,21 +176,45 @@ export function BulkActionsPanel({
               <div className="flex items-center gap-2">
                 <CheckSquare className="text-primary h-5 w-5" />
                 <span className="font-medium">
-                  {selectedCount} {selectedCount === 1 ? 'item' : 'items'} selected
+                  {selectedCount > 0 && (
+                    <>
+                      {selectedCount} bank feed{selectedCount === 1 ? '' : 's'} selected
+                    </>
+                  )}
+                  {selectedCount > 0 && manualPairCount > 0 && ' · '}
+                  {manualPairCount > 0 && (
+                    <>
+                      {manualPairCount} manual pair{manualPairCount === 1 ? '' : 's'} ready
+                    </>
+                  )}
                 </span>
               </div>
             </div>
 
             <div className="flex items-center gap-2">
-              <Button
-                variant="default"
-                size="sm"
-                onClick={() => setShowAutoMatchDialog(true)}
-                disabled={isLoading}
-              >
-                <Zap className="mr-2 h-4 w-4" />
-                Auto-Match Selected
-              </Button>
+              {selectedCount > 0 && (
+                <Button
+                  variant="default"
+                  size="sm"
+                  onClick={() => setShowAutoMatchDialog(true)}
+                  disabled={isLoading}
+                >
+                  <Zap className="mr-2 h-4 w-4" />
+                  Auto-Match Selected
+                </Button>
+              )}
+
+              {manualPairCount > 0 && (
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => setShowManualMatchDialog(true)}
+                  disabled={isLoading}
+                >
+                  <Link className="mr-2 h-4 w-4" />
+                  Bulk Match ({manualPairCount} pairs)
+                </Button>
+              )}
 
               <Button variant="outline" size="sm" onClick={onClearSelection} disabled={isLoading}>
                 <XSquare className="mr-2 h-4 w-4" />
@@ -150,7 +225,7 @@ export function BulkActionsPanel({
         </CardContent>
       </Card>
 
-      {/* Auto-Match Confirmation Dialog */}
+      {/* ── Auto-Match Confirmation ──────────────────────────────────────── */}
       <AlertDialog open={showAutoMatchDialog} onOpenChange={setShowAutoMatchDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>
@@ -161,32 +236,74 @@ export function BulkActionsPanel({
               tolerance).
               <br />
               <br />
-              Matches found will be automatically reconciled. Continue?
+              Matches that pass validation will be reconciled. Any failures will be listed without
+              affecting the successful matches.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel disabled={isLoading}>Cancel</AlertDialogCancel>
             <AlertDialogAction onClick={handleAutoMatch} disabled={isLoading}>
-              {isLoading ? 'Processing...' : 'Auto-Match'}
+              {isLoading ? 'Processing…' : 'Auto-Match'}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
 
-      {/* Bulk Reconcile Confirmation Dialog */}
-      <AlertDialog open={showReconcileDialog} onOpenChange={setShowReconcileDialog}>
+      {/* ── Manual Bulk-Match Confirmation ──────────────────────────────── */}
+      <AlertDialog open={showManualMatchDialog} onOpenChange={setShowManualMatchDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Bulk Reconcile?</AlertDialogTitle>
+            <AlertDialogTitle>Bulk Match {manualPairCount} Pairs?</AlertDialogTitle>
             <AlertDialogDescription>
-              This will reconcile {selectedCount} selected transaction
-              {selectedCount === 1 ? '' : 's'}. This action cannot be undone.
+              This will reconcile {manualPairCount} explicitly paired bank feed → POS transaction
+              {manualPairCount === 1 ? '' : 's'}. Pairs that fail validation are reported without
+              blocking the successful ones.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel disabled={isLoading}>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={handleBulkReconcile} disabled={isLoading}>
-              {isLoading ? 'Processing...' : 'Reconcile'}
+            <AlertDialogAction onClick={handleManualMatch} disabled={isLoading}>
+              {isLoading ? 'Processing…' : 'Confirm Match'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* ── Partial-Failure Report ───────────────────────────────────────── */}
+      <AlertDialog open={showFailuresDialog} onOpenChange={setShowFailuresDialog}>
+        <AlertDialogContent className="max-w-lg">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Some Matches Failed</AlertDialogTitle>
+            <AlertDialogDescription asChild>
+              <div>
+                <p className="mb-3">
+                  The following {partialFailures.length} pair
+                  {partialFailures.length === 1 ? '' : 's'} could not be reconciled. All other
+                  pairs succeeded.
+                </p>
+                <ul className="space-y-2 text-sm">
+                  {partialFailures.map((f, i) => (
+                    <li key={i} className="rounded border p-2">
+                      <div className="flex items-center gap-2">
+                        <Badge variant="destructive">Failed</Badge>
+                        <span className="font-mono text-xs truncate">{f.bank_feed_id}</span>
+                      </div>
+                      <p className="mt-1 text-muted-foreground">{f.reason}</p>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogAction
+              onClick={() => {
+                setShowFailuresDialog(false);
+                onClearSelection();
+                onSuccess();
+              }}
+            >
+              Dismiss
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/app/api/bank-feeds/bulk-reconcile/route.ts
+++ b/src/app/api/bank-feeds/bulk-reconcile/route.ts
@@ -1,73 +1,231 @@
+/**
+ * POST /api/bank-feeds/bulk-reconcile
+ *
+ * Bulk match N bank-feed transactions to N POS transactions.
+ *
+ * UNI-2113 requirements:
+ * (a) Audit trail — one ReconciliationMatchAudit row per pair (success or failure).
+ * (b) Partial failures — if some pairs fail validation the rest still succeed.
+ *     The 200 response itemises every failure with its reason.
+ * (c) Auth/workspace scoping — requireAuthScope → getWorkspaceIdForUser → 401/403.
+ *
+ * Request body:
+ *   { "matches": [{ "bank_feed_id": "…", "pos_transaction_id": "…" }] }
+ *
+ * Response 200:
+ *   {
+ *     "success": boolean,        // true only when failed_count === 0
+ *     "matched_count": number,
+ *     "failed_count": number,
+ *     "failures": [{ "bank_feed_id": "…", "pos_transaction_id": "…", "reason": "…" }],
+ *     "errors": string[]         // legacy alias kept for backwards compat
+ *   }
+ */
+
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db/prisma';
 import { requireAuthScope } from '@/lib/auth/data-scope';
+import { getWorkspaceIdForUser } from '@/lib/auth/workspace-scope';
+
+interface MatchPair {
+  bank_feed_id?: string;
+  pos_transaction_id?: string;
+}
+
+interface FailureDetail {
+  bank_feed_id: string;
+  pos_transaction_id: string;
+  reason: string;
+}
 
 export async function POST(request: NextRequest) {
-  try {
-    const scope = await requireAuthScope(request);
-    if (!scope) {
-      return NextResponse.json({ detail: 'Not authenticated' }, { status: 401 });
-    }
-
-    const body = (await request.json()) as {
-      matches?: Array<{ bank_feed_id?: string; pos_transaction_id?: string }>;
-    };
-
-    const matches = Array.isArray(body.matches) ? body.matches : [];
-    if (matches.length === 0) {
-      return NextResponse.json({ detail: 'matches array is required' }, { status: 400 });
-    }
-
-    let matched = 0;
-    let failed = 0;
-    const errors: string[] = [];
-
-    for (const match of matches) {
-      const feedId = String(match.bank_feed_id ?? '');
-      const posId = String(match.pos_transaction_id ?? '');
-      if (!feedId || !posId) {
-        failed += 1;
-        errors.push('Missing bank_feed_id or pos_transaction_id');
-        continue;
-      }
-
-      try {
-        const feed = await prisma.bankFeedTransaction.findFirst({
-          where: { id: feedId, bankAccount: { ownerUserId: scope.userId } },
-        });
-        const pos = await prisma.posTransaction.findFirst({
-          where: { id: posId, ownerUserId: scope.userId },
-        });
-        if (!feed || !pos) {
-          failed += 1;
-          errors.push('Feed line or POS transaction not found');
-          continue;
-        }
-
-        await prisma.$transaction([
-          prisma.bankFeedTransaction.update({
-            where: { id: feedId },
-            data: { reconciled: true, matchedPosTxId: posId },
-          }),
-          prisma.posTransaction.update({
-            where: { id: posId },
-            data: { reconciliationStatus: 'reconciled' },
-          }),
-        ]);
-        matched += 1;
-      } catch (error) {
-        failed += 1;
-        errors.push(error instanceof Error ? error.message : String(error));
-      }
-    }
-
-    return NextResponse.json({
-      success: failed === 0,
-      matched_count: matched,
-      failed_count: failed,
-      errors,
-    });
-  } catch (error) {
-    return NextResponse.json({ detail: String(error) }, { status: 500 });
+  // ── Auth gate ──────────────────────────────────────────────────────────────
+  const scope = await requireAuthScope(request);
+  if (!scope) {
+    return NextResponse.json({ detail: 'Not authenticated' }, { status: 401 });
   }
+
+  const workspaceId = await getWorkspaceIdForUser(scope.userId);
+  if (!workspaceId) {
+    return NextResponse.json({ detail: 'No workspace found for this user' }, { status: 403 });
+  }
+
+  // ── Input validation ───────────────────────────────────────────────────────
+  let body: { matches?: MatchPair[] };
+  try {
+    body = (await request.json()) as { matches?: MatchPair[] };
+  } catch {
+    return NextResponse.json({ detail: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const matches = Array.isArray(body.matches) ? body.matches : [];
+  if (matches.length === 0) {
+    return NextResponse.json(
+      { detail: 'matches array is required and must be non-empty' },
+      { status: 400 }
+    );
+  }
+
+  // ── Per-pair processing with partial-failure semantics ─────────────────────
+  let matchedCount = 0;
+  let failedCount = 0;
+  const failures: FailureDetail[] = [];
+  const errors: string[] = []; // backwards-compat field
+
+  for (const pair of matches) {
+    const feedId = String(pair.bank_feed_id ?? '').trim();
+    const posId = String(pair.pos_transaction_id ?? '').trim();
+
+    // Validate IDs present
+    if (!feedId || !posId) {
+      const reason = 'Missing bank_feed_id or pos_transaction_id';
+      failures.push({ bank_feed_id: feedId, pos_transaction_id: posId, reason });
+      errors.push(reason);
+      failedCount += 1;
+
+      // Audit the failure (no DB rows to update, but record intent)
+      await prisma.reconciliationMatchAudit.create({
+        data: {
+          matchedByUserId: scope.userId,
+          bankFeedId: feedId || '00000000-0000-0000-0000-000000000000',
+          posTransactionId: posId || '00000000-0000-0000-0000-000000000000',
+          outcome: 'failed',
+          failureReason: reason,
+        },
+      });
+      continue;
+    }
+
+    // Validate ownership: bank feed must belong to this user's workspace,
+    // POS transaction must be owned by this user.
+    const [feed, pos] = await Promise.all([
+      prisma.bankFeedTransaction.findFirst({
+        where: { id: feedId, bankAccount: { ownerUserId: scope.userId } },
+      }),
+      prisma.posTransaction.findFirst({
+        where: { id: posId, ownerUserId: scope.userId },
+      }),
+    ]);
+
+    if (!feed) {
+      const reason = `Bank feed transaction not found or not accessible: ${feedId}`;
+      failures.push({ bank_feed_id: feedId, pos_transaction_id: posId, reason });
+      errors.push(reason);
+      failedCount += 1;
+      await prisma.reconciliationMatchAudit.create({
+        data: {
+          matchedByUserId: scope.userId,
+          bankFeedId: feedId,
+          posTransactionId: posId,
+          outcome: 'failed',
+          failureReason: reason,
+        },
+      });
+      continue;
+    }
+
+    if (!pos) {
+      const reason = `POS transaction not found or not accessible: ${posId}`;
+      failures.push({ bank_feed_id: feedId, pos_transaction_id: posId, reason });
+      errors.push(reason);
+      failedCount += 1;
+      await prisma.reconciliationMatchAudit.create({
+        data: {
+          matchedByUserId: scope.userId,
+          bankFeedId: feedId,
+          posTransactionId: posId,
+          outcome: 'failed',
+          failureReason: reason,
+        },
+      });
+      continue;
+    }
+
+    // Guard: skip already-reconciled pairs
+    if (feed.reconciled) {
+      const reason = `Bank feed transaction already reconciled: ${feedId}`;
+      failures.push({ bank_feed_id: feedId, pos_transaction_id: posId, reason });
+      errors.push(reason);
+      failedCount += 1;
+      await prisma.reconciliationMatchAudit.create({
+        data: {
+          matchedByUserId: scope.userId,
+          bankFeedId: feedId,
+          posTransactionId: posId,
+          outcome: 'failed',
+          failureReason: reason,
+        },
+      });
+      continue;
+    }
+
+    if (pos.reconciliationStatus === 'reconciled') {
+      const reason = `POS transaction already reconciled: ${posId}`;
+      failures.push({ bank_feed_id: feedId, pos_transaction_id: posId, reason });
+      errors.push(reason);
+      failedCount += 1;
+      await prisma.reconciliationMatchAudit.create({
+        data: {
+          matchedByUserId: scope.userId,
+          bankFeedId: feedId,
+          posTransactionId: posId,
+          outcome: 'failed',
+          failureReason: reason,
+        },
+      });
+      continue;
+    }
+
+    // Attempt the match inside a DB transaction; catch per-pair errors
+    try {
+      await prisma.$transaction([
+        prisma.bankFeedTransaction.update({
+          where: { id: feedId },
+          data: { reconciled: true, matchedPosTxId: posId },
+        }),
+        prisma.posTransaction.update({
+          where: { id: posId },
+          data: { reconciliationStatus: 'reconciled' },
+        }),
+        // Audit record — the single source of truth for "who matched what, when"
+        prisma.reconciliationMatchAudit.create({
+          data: {
+            matchedByUserId: scope.userId,
+            bankFeedId: feedId,
+            posTransactionId: posId,
+            outcome: 'matched',
+          },
+        }),
+      ]);
+      matchedCount += 1;
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      failures.push({ bank_feed_id: feedId, pos_transaction_id: posId, reason });
+      errors.push(reason);
+      failedCount += 1;
+
+      // Best-effort audit of the failure
+      try {
+        await prisma.reconciliationMatchAudit.create({
+          data: {
+            matchedByUserId: scope.userId,
+            bankFeedId: feedId,
+            posTransactionId: posId,
+            outcome: 'failed',
+            failureReason: reason,
+          },
+        });
+      } catch {
+        // If even the audit write fails we still return the correct counts
+      }
+    }
+  }
+
+  return NextResponse.json({
+    success: failedCount === 0,
+    matched_count: matchedCount,
+    failed_count: failedCount,
+    failures,
+    errors, // backwards compat
+  });
 }

--- a/src/lib/api/pos.ts
+++ b/src/lib/api/pos.ts
@@ -64,10 +64,19 @@ export interface ReconcileMatch {
   pos_transaction_id: string;
 }
 
+export interface BulkReconcileFailure {
+  bank_feed_id: string;
+  pos_transaction_id: string;
+  reason: string;
+}
+
 export interface BulkReconcileResult {
   success: boolean;
   matched_count: number;
   failed_count: number;
+  /** Itemised per-pair failure details (UNI-2113). */
+  failures: BulkReconcileFailure[];
+  /** Legacy flat error strings kept for backwards compat. */
   errors: string[];
 }
 

--- a/src/lib/pos/__tests__/bulk-reconcile-route.test.ts
+++ b/src/lib/pos/__tests__/bulk-reconcile-route.test.ts
@@ -1,0 +1,435 @@
+/**
+ * UNI-2113: POST /api/bank-feeds/bulk-reconcile
+ *
+ * Tests cover:
+ * - 401 when unauthenticated
+ * - 403 when authenticated but no workspace
+ * - 400 when matches array is empty / missing
+ * - Successful full-batch match (all pairs succeed)
+ * - Partial failure: 3 of 10 pairs fail, 7 succeed — response itemises all 3 failures
+ * - Already-reconciled guard: bank feed already reconciled → failure detail
+ * - Already-reconciled guard: POS already reconciled → failure detail
+ * - Missing IDs in pair → failure detail
+ * - Cross-workspace isolation: cannot reconcile another user's records
+ * - Audit trail: ReconciliationMatchAudit rows written for successes and failures
+ */
+
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+import { POST } from '@/app/api/bank-feeds/bulk-reconcile/route';
+
+// ── Mock auth ──────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/auth/data-scope', () => ({
+  requireAuthScope: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/workspace-scope', () => ({
+  getWorkspaceIdForUser: vi.fn(),
+}));
+
+// ── Mock Prisma ────────────────────────────────────────────────────────────
+
+const mockBankFeedFindFirst = vi.fn();
+const mockPosFindFirst = vi.fn();
+const mockBankFeedUpdate = vi.fn();
+const mockPosUpdate = vi.fn();
+const mockAuditCreate = vi.fn();
+const mockTransaction = vi.fn();
+
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    bankFeedTransaction: {
+      findFirst: (...args: unknown[]) => mockBankFeedFindFirst(...args),
+      update: (...args: unknown[]) => mockBankFeedUpdate(...args),
+    },
+    posTransaction: {
+      findFirst: (...args: unknown[]) => mockPosFindFirst(...args),
+      update: (...args: unknown[]) => mockPosUpdate(...args),
+    },
+    reconciliationMatchAudit: {
+      create: (...args: unknown[]) => mockAuditCreate(...args),
+    },
+    $transaction: (...args: unknown[]) => mockTransaction(...args),
+  },
+}));
+
+// ── Imports (after mocks) ──────────────────────────────────────────────────
+
+import { requireAuthScope } from '@/lib/auth/data-scope';
+import { getWorkspaceIdForUser } from '@/lib/auth/workspace-scope';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const AUTH_USER_ID = 'user-alice';
+const WORKSPACE_ID = 'ws-alice';
+
+function setAuth(userId: string | null = AUTH_USER_ID, workspaceId: string | null = WORKSPACE_ID) {
+  (requireAuthScope as Mock).mockResolvedValue(
+    userId ? { userId, role: 'owner', isAdmin: false } : null
+  );
+  (getWorkspaceIdForUser as Mock).mockResolvedValue(workspaceId);
+}
+
+function makeRequest(body: unknown): Request {
+  return new Request('http://localhost/api/bank-feeds/bulk-reconcile', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+/** Returns a mock bank feed record (unreconciled). */
+function mockFeed(id: string) {
+  return { id, reconciled: false, matchedPosTxId: null, bankAccountId: 'acc-1' };
+}
+
+/** Returns a mock POS transaction record (unreconciled). */
+function mockPos(id: string) {
+  return { id, reconciliationStatus: 'pending', ownerUserId: AUTH_USER_ID, amount: 100 };
+}
+
+/**
+ * Sets up mockBankFeedFindFirst and mockPosFindFirst to return valid records
+ * for the given IDs (ownership check passes).
+ */
+function mockOwned(feedIds: string[], posIds: string[]) {
+  mockBankFeedFindFirst.mockImplementation(({ where }: { where: { id: string } }) => {
+    return feedIds.includes(where.id) ? mockFeed(where.id) : null;
+  });
+  mockPosFindFirst.mockImplementation(({ where }: { where: { id: string } }) => {
+    return posIds.includes(where.id) ? mockPos(where.id) : null;
+  });
+}
+
+/** Sets up $transaction to execute all writes atomically (no real DB). */
+function mockTransactionSuccess() {
+  mockTransaction.mockImplementation(async (ops: unknown[]) => {
+    for (const op of ops) {
+      await (op as Promise<unknown>);
+    }
+    return undefined;
+  });
+}
+
+// ── Test suite ─────────────────────────────────────────────────────────────
+
+describe('POST /api/bank-feeds/bulk-reconcile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBankFeedUpdate.mockResolvedValue({});
+    mockPosUpdate.mockResolvedValue({});
+    mockAuditCreate.mockResolvedValue({});
+    mockTransactionSuccess();
+  });
+
+  // ── Auth ──────────────────────────────────────────────────────────────────
+
+  it('returns 401 when not authenticated', async () => {
+    setAuth(null);
+    const res = await POST(makeRequest({ matches: [{ bank_feed_id: 'f1', pos_transaction_id: 'p1' }] }) as never);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when authenticated but no workspace', async () => {
+    setAuth(AUTH_USER_ID, null);
+    const res = await POST(makeRequest({ matches: [{ bank_feed_id: 'f1', pos_transaction_id: 'p1' }] }) as never);
+    expect(res.status).toBe(403);
+  });
+
+  // ── Validation ────────────────────────────────────────────────────────────
+
+  it('returns 400 when matches is empty array', async () => {
+    setAuth();
+    const res = await POST(makeRequest({ matches: [] }) as never);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when matches is missing', async () => {
+    setAuth();
+    const res = await POST(makeRequest({}) as never);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when body is not valid JSON', async () => {
+    setAuth();
+    const res = await POST(
+      new Request('http://localhost/api/bank-feeds/bulk-reconcile', {
+        method: 'POST',
+        body: 'not-json',
+      }) as never
+    );
+    expect(res.status).toBe(400);
+  });
+
+  // ── Full success ──────────────────────────────────────────────────────────
+
+  it('matches all 3 pairs when all are valid → success=true, matched_count=3, failed_count=0', async () => {
+    setAuth();
+    mockOwned(['f1', 'f2', 'f3'], ['p1', 'p2', 'p3']);
+
+    const res = await POST(
+      makeRequest({
+        matches: [
+          { bank_feed_id: 'f1', pos_transaction_id: 'p1' },
+          { bank_feed_id: 'f2', pos_transaction_id: 'p2' },
+          { bank_feed_id: 'f3', pos_transaction_id: 'p3' },
+        ],
+      }) as never
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      success: boolean;
+      matched_count: number;
+      failed_count: number;
+      failures: unknown[];
+    };
+    expect(body.success).toBe(true);
+    expect(body.matched_count).toBe(3);
+    expect(body.failed_count).toBe(0);
+    expect(body.failures).toHaveLength(0);
+  });
+
+  // ── Partial failure: core UNI-2113 acceptance criterion ──────────────────
+
+  it('partial failure: 3 of 10 pairs fail — 7 succeed, response itemises 3 failures', async () => {
+    setAuth();
+
+    // IDs f1–f7 and p1–p7 are accessible; f8–f10 and p8–p10 are NOT (simulate ownership fail)
+    const goodFeedIds = ['f1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7'];
+    const goodPosIds  = ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7'];
+    mockOwned(goodFeedIds, goodPosIds);
+
+    const matches = [
+      ...goodFeedIds.map((f, i) => ({ bank_feed_id: f, pos_transaction_id: goodPosIds[i] })),
+      { bank_feed_id: 'f8', pos_transaction_id: 'p8' },  // not found
+      { bank_feed_id: 'f9', pos_transaction_id: 'p9' },  // not found
+      { bank_feed_id: 'f10', pos_transaction_id: 'p10' }, // not found
+    ];
+
+    const res = await POST(makeRequest({ matches }) as never);
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      success: boolean;
+      matched_count: number;
+      failed_count: number;
+      failures: Array<{ bank_feed_id: string; pos_transaction_id: string; reason: string }>;
+      errors: string[];
+    };
+
+    // Exactly 7 successes
+    expect(body.matched_count).toBe(7);
+    // Exactly 3 failures
+    expect(body.failed_count).toBe(3);
+    expect(body.success).toBe(false);
+
+    // Failures array itemises each failed pair
+    expect(body.failures).toHaveLength(3);
+    const failedFeedIds = body.failures.map((f) => f.bank_feed_id);
+    expect(failedFeedIds).toContain('f8');
+    expect(failedFeedIds).toContain('f9');
+    expect(failedFeedIds).toContain('f10');
+
+    // Each failure has a human-readable reason
+    body.failures.forEach((f) => {
+      expect(typeof f.reason).toBe('string');
+      expect(f.reason.length).toBeGreaterThan(0);
+    });
+
+    // Backwards-compat errors array also has 3 entries
+    expect(body.errors).toHaveLength(3);
+  });
+
+  // ── Already-reconciled guards ─────────────────────────────────────────────
+
+  it('fails pair when bank feed is already reconciled', async () => {
+    setAuth();
+    // Feed is already reconciled
+    mockBankFeedFindFirst.mockResolvedValue({ id: 'f1', reconciled: true, matchedPosTxId: 'p-old' });
+    mockPosFindFirst.mockResolvedValue(mockPos('p1'));
+
+    const res = await POST(
+      makeRequest({ matches: [{ bank_feed_id: 'f1', pos_transaction_id: 'p1' }] }) as never
+    );
+    const body = await res.json() as {
+      matched_count: number;
+      failed_count: number;
+      failures: Array<{ reason: string }>;
+    };
+    expect(body.matched_count).toBe(0);
+    expect(body.failed_count).toBe(1);
+    expect(body.failures[0].reason).toMatch(/already reconciled/i);
+  });
+
+  it('fails pair when POS transaction is already reconciled', async () => {
+    setAuth();
+    mockBankFeedFindFirst.mockResolvedValue(mockFeed('f1'));
+    mockPosFindFirst.mockResolvedValue({ ...mockPos('p1'), reconciliationStatus: 'reconciled' });
+
+    const res = await POST(
+      makeRequest({ matches: [{ bank_feed_id: 'f1', pos_transaction_id: 'p1' }] }) as never
+    );
+    const body = await res.json() as {
+      matched_count: number;
+      failed_count: number;
+      failures: Array<{ reason: string }>;
+    };
+    expect(body.matched_count).toBe(0);
+    expect(body.failed_count).toBe(1);
+    expect(body.failures[0].reason).toMatch(/already reconciled/i);
+  });
+
+  // ── Missing IDs ───────────────────────────────────────────────────────────
+
+  it('fails pair when bank_feed_id is missing', async () => {
+    setAuth();
+    const res = await POST(
+      makeRequest({ matches: [{ pos_transaction_id: 'p1' }] }) as never
+    );
+    const body = await res.json() as { failed_count: number; failures: Array<{ reason: string }> };
+    expect(body.failed_count).toBe(1);
+    expect(body.failures[0].reason).toMatch(/missing/i);
+  });
+
+  it('fails pair when pos_transaction_id is missing', async () => {
+    setAuth();
+    const res = await POST(
+      makeRequest({ matches: [{ bank_feed_id: 'f1' }] }) as never
+    );
+    const body = await res.json() as { failed_count: number; failures: Array<{ reason: string }> };
+    expect(body.failed_count).toBe(1);
+    expect(body.failures[0].reason).toMatch(/missing/i);
+  });
+
+  // ── Cross-workspace isolation ─────────────────────────────────────────────
+
+  it('fails pair when bank feed belongs to a different user', async () => {
+    setAuth();
+    // Feed not found (ownership filter rejects it)
+    mockBankFeedFindFirst.mockResolvedValue(null);
+    mockPosFindFirst.mockResolvedValue(mockPos('p1'));
+
+    const res = await POST(
+      makeRequest({ matches: [{ bank_feed_id: 'other-user-feed', pos_transaction_id: 'p1' }] }) as never
+    );
+    const body = await res.json() as { matched_count: number; failed_count: number; failures: Array<{ reason: string }> };
+    expect(body.matched_count).toBe(0);
+    expect(body.failed_count).toBe(1);
+    expect(body.failures[0].reason).toMatch(/not found/i);
+  });
+
+  it('fails pair when POS transaction belongs to a different user', async () => {
+    setAuth();
+    mockBankFeedFindFirst.mockResolvedValue(mockFeed('f1'));
+    mockPosFindFirst.mockResolvedValue(null); // POS ownership check fails
+
+    const res = await POST(
+      makeRequest({ matches: [{ bank_feed_id: 'f1', pos_transaction_id: 'other-user-pos' }] }) as never
+    );
+    const body = await res.json() as { matched_count: number; failed_count: number; failures: Array<{ reason: string }> };
+    expect(body.matched_count).toBe(0);
+    expect(body.failed_count).toBe(1);
+    expect(body.failures[0].reason).toMatch(/not found/i);
+  });
+
+  // ── Audit trail ───────────────────────────────────────────────────────────
+
+  it('writes one audit record per successful match', async () => {
+    setAuth();
+    mockOwned(['f1', 'f2'], ['p1', 'p2']);
+
+    await POST(
+      makeRequest({
+        matches: [
+          { bank_feed_id: 'f1', pos_transaction_id: 'p1' },
+          { bank_feed_id: 'f2', pos_transaction_id: 'p2' },
+        ],
+      }) as never
+    );
+
+    // $transaction is called once per successful pair
+    expect(mockTransaction).toHaveBeenCalledTimes(2);
+
+    // Each $transaction call includes the audit create as the 3rd operation
+    const firstCallOps: unknown[] = mockTransaction.mock.calls[0][0];
+    expect(Array.isArray(firstCallOps)).toBe(true);
+    expect(firstCallOps).toHaveLength(3); // update feed, update pos, create audit
+  });
+
+  it('writes a failure audit record when ownership check fails', async () => {
+    setAuth();
+    mockBankFeedFindFirst.mockResolvedValue(null);
+    mockPosFindFirst.mockResolvedValue(null);
+
+    await POST(
+      makeRequest({ matches: [{ bank_feed_id: 'bad-feed', pos_transaction_id: 'bad-pos' }] }) as never
+    );
+
+    // Audit create called with outcome='failed'
+    expect(mockAuditCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          outcome: 'failed',
+          matchedByUserId: AUTH_USER_ID,
+        }),
+      })
+    );
+  });
+
+  it('audit record for success includes matchedByUserId, bankFeedId, posTransactionId', async () => {
+    setAuth();
+    mockOwned(['f1'], ['p1']);
+
+    // Capture the ops passed to $transaction
+    mockTransaction.mockImplementation(async (ops: unknown[]) => {
+      for (const op of ops) await (op as Promise<unknown>);
+    });
+
+    await POST(
+      makeRequest({ matches: [{ bank_feed_id: 'f1', pos_transaction_id: 'p1' }] }) as never
+    );
+
+    expect(mockAuditCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          matchedByUserId: AUTH_USER_ID,
+          bankFeedId: 'f1',
+          posTransactionId: 'p1',
+          outcome: 'matched',
+        }),
+      })
+    );
+  });
+
+  // ── DB error in transaction → partial failure ─────────────────────────────
+
+  it('handles $transaction throwing for one pair: that pair fails, others succeed', async () => {
+    setAuth();
+    mockOwned(['f1', 'f2', 'f3'], ['p1', 'p2', 'p3']);
+
+    // Second call to $transaction throws
+    let txCallCount = 0;
+    mockTransaction.mockImplementation(async (ops: unknown[]) => {
+      txCallCount++;
+      if (txCallCount === 2) throw new Error('DB deadlock');
+      for (const op of ops) await (op as Promise<unknown>);
+    });
+
+    const res = await POST(
+      makeRequest({
+        matches: [
+          { bank_feed_id: 'f1', pos_transaction_id: 'p1' },
+          { bank_feed_id: 'f2', pos_transaction_id: 'p2' },
+          { bank_feed_id: 'f3', pos_transaction_id: 'p3' },
+        ],
+      }) as never
+    );
+    const body = await res.json() as {
+      matched_count: number;
+      failed_count: number;
+      failures: Array<{ reason: string }>;
+    };
+    expect(body.matched_count).toBe(2);
+    expect(body.failed_count).toBe(1);
+    expect(body.failures[0].reason).toMatch(/DB deadlock/i);
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the `Not Implemented` placeholder in `BulkActionsPanel` with two real bulk-match flows: auto-match (amount tolerance ±$0.10) and manual bulk-match (explicit caller-supplied pairs)
- Rebuilds `POST /api/bank-feeds/bulk-reconcile` with full auth/workspace scoping, per-pair validation, partial-failure semantics, and an immutable audit trail
- Adds `ReconciliationMatchAudit` Prisma model — one row per pair attempted, recording `matchedByUserId`, `bankFeedId`, `posTransactionId`, `outcome`, and `failureReason`

## Endpoint shape

```
POST /api/bank-feeds/bulk-reconcile
Body: { "matches": [{ "bank_feed_id": "…", "pos_transaction_id": "…" }] }

200 {
  "success": boolean,
  "matched_count": number,
  "failed_count": number,
  "failures": [{ "bank_feed_id": "…", "pos_transaction_id": "…", "reason": "…" }],
  "errors": string[]   // backwards compat flat list
}
401 — unauthenticated
403 — no workspace
400 — empty/missing matches array
```

## Partial-failure semantics

Each pair is processed independently. A pair fails when:
- `bank_feed_id` or `pos_transaction_id` is absent
- The bank feed or POS transaction is not found / not owned by this user
- The bank feed is already `reconciled: true`
- The POS transaction is already `reconciliationStatus: 'reconciled'`
- The DB transaction throws (e.g. deadlock)

Failing pairs do **not** roll back successful pairs. The response itemises every failure with `bank_feed_id`, `pos_transaction_id`, and `reason`.

## Audit mechanism

Every pair — success or failure — gets a `ReconciliationMatchAudit` row written atomically inside the same `prisma.$transaction` (for successes) or as a best-effort separate write (for failures). Fields: `matchedByUserId`, `bankFeedId`, `posTransactionId`, `outcome` (`"matched"` or `"failed"`), `failureReason`.

## Auth/workspace scoping

Identical to the merged POS routes (UNI-2107): `requireAuthScope` → `getWorkspaceIdForUser` → 401/403. Bank feeds are scoped via `bankAccount.ownerUserId`, POS transactions via `ownerUserId`.

## Test evidence

```
vitest run src/lib/pos/__tests__/bulk-reconcile-route.test.ts
17 tests passed

vitest run (full suite)
156 tests passed (16 test files)
```

Tests cover: 401/403/400, full success, partial failure 3-of-10 (core acceptance criterion), already-reconciled guards, missing IDs, cross-workspace isolation, audit row contents, DB transaction error -> per-pair failure.

## Test plan

- [ ] Confirm CI green
- [ ] Verify `ReconciliationMatchAudit` table exists after `prisma migrate dev`
- [ ] Test auto-match with 2+ bank feeds selected
- [ ] Test manual bulk-match with `manualPairs` prop populated
- [ ] Confirm partial-failure dialog surfaces failures without blocking successes
- [ ] Check audit rows written to DB after a mixed-success batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
