### PR TITLE
feat(for Rana): WorkspaceSettings persistence + missing migrations

### DIFF
--- a/prisma/migrations/20260611100000_add_reconciliation_match_audit/migration.sql
+++ b/prisma/migrations/20260611100000_add_reconciliation_match_audit/migration.sql
@@ -1,0 +1,24 @@
+-- Migration: add_reconciliation_match_audit
+-- Context: ReconciliationMatchAudit model was added to schema.prisma in PR #206
+-- but the corresponding migration file was never created.
+-- This migration creates the missing table.
+
+CREATE TABLE IF NOT EXISTS "reconciliation_match_audit" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "matched_by_user_id" UUID NOT NULL,
+  "bank_feed_id" UUID NOT NULL,
+  "pos_transaction_id" UUID NOT NULL,
+  "outcome" TEXT NOT NULL,
+  "failure_reason" TEXT,
+  "matched_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "reconciliation_match_audit_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "reconciliation_match_audit_matched_by_user_id_idx"
+  ON "reconciliation_match_audit"("matched_by_user_id");
+
+CREATE INDEX IF NOT EXISTS "reconciliation_match_audit_bank_feed_id_idx"
+  ON "reconciliation_match_audit"("bank_feed_id");
+
+CREATE INDEX IF NOT EXISTS "reconciliation_match_audit_pos_transaction_id_idx"
+  ON "reconciliation_match_audit"("pos_transaction_id");

--- a/prisma/migrations/20260611110000_add_workspace_settings/migration.sql
+++ b/prisma/migrations/20260611110000_add_workspace_settings/migration.sql
@@ -1,0 +1,20 @@
+-- Migration: add_workspace_settings
+-- Context: Replaces the in-memory company-store (PR #202 / UNI-2111) with a
+-- persistent DB table so company settings survive server restarts.
+
+CREATE TABLE IF NOT EXISTS "workspace_settings" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "workspace_id" UUID NOT NULL,
+  "name" TEXT NOT NULL DEFAULT 'My Company',
+  "slug" TEXT NOT NULL DEFAULT 'my-company',
+  "trading_name" TEXT,
+  "abn" TEXT,
+  "acn" TEXT,
+  "is_active" BOOLEAN NOT NULL DEFAULT true,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "workspace_settings_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "workspace_settings_workspace_id_key"
+  ON "workspace_settings"("workspace_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -955,6 +955,23 @@ model AgentRun {
   @@map("agent_runs")
 }
 
+/// Per-workspace company identity (name, trading name, ABN, ACN).
+/// Replaces the in-memory company-store seeded by UNI-2111 (PR #202).
+model WorkspaceSettings {
+  id          String   @id @default(uuid()) @db.Uuid
+  workspaceId String   @unique @map("workspace_id") @db.Uuid
+  name        String   @default("My Company")
+  slug        String   @default("my-company")
+  tradingName String?  @map("trading_name")
+  abn         String?
+  acn         String?
+  isActive    Boolean  @default(true) @map("is_active")
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+
+  @@map("workspace_settings")
+}
+
 /// OAuth tokens for Xero accounting (one row per workspace).
 model WorkspaceXeroConnection {
   id                String    @id @default(uuid()) @db.Uuid

--- a/src/app/api/settings/company/route.ts
+++ b/src/app/api/settings/company/route.ts
@@ -5,6 +5,10 @@
  *   1. requireAuthScope  → 401 if no valid JWT
  *   2. getWorkspaceIdForUser → 403 if user has no workspace row
  *   3. workspaceId from DB used as the store key (never from request)
+ *
+ * Persistence: getCompanySettings / saveCompanySettings in company-store.ts
+ * use Prisma when DATABASE_URL is available, falling back to in-memory when
+ * not (CI without a DB, unit tests with vi.mock on @/lib/db/prisma).
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAuthScope } from '@/lib/auth/data-scope';
@@ -22,7 +26,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ detail: 'No workspace found for this user' }, { status: 403 });
   }
 
-  const settings = getCompanySettings(workspaceId);
+  const settings = await getCompanySettings(workspaceId);
   return NextResponse.json(settings);
 }
 
@@ -49,7 +53,7 @@ export async function PUT(request: NextRequest) {
     return NextResponse.json({ detail: 'name is required' }, { status: 400 });
   }
 
-  const updated = saveCompanySettings(workspaceId, {
+  const updated = await saveCompanySettings(workspaceId, {
     name,
     trading_name: typeof body.trading_name === 'string' ? body.trading_name.trim() || null : null,
     abn: typeof body.abn === 'string' ? body.abn.trim() || null : null,

--- a/src/lib/settings/__tests__/company-settings-route.test.ts
+++ b/src/lib/settings/__tests__/company-settings-route.test.ts
@@ -7,10 +7,35 @@
  *   3. Authenticated user with no workspace → 403.
  *   4. Cross-workspace isolation: workspace B cannot read workspace A's settings.
  *   5. Missing/invalid name in PUT → 400.
+ *
+ * DB isolation: hasDatabaseConfig is mocked to return false so all store
+ * operations use the in-memory fallback — no DATABASE_URL required in tests.
+ * This is the same pattern used by bulk-reconcile-route.test.ts for Prisma routes.
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { _resetAllCompanySettings, getCompanySettings } from '../company-store';
+
+// Force in-memory path — no real DB needed in unit tests.
+// Must mock BOTH database-env (so hasDatabaseConfig returns false) AND
+// @/lib/db/prisma (so the PrismaClient import does not fail when
+// prisma generate has not run, e.g. in CI without DATABASE_URL).
+vi.mock('@/lib/db/database-env', () => ({
+  hasDatabaseConfig: vi.fn().mockReturnValue(false),
+  getDatabaseConnectionString: vi.fn().mockReturnValue(''),
+  getPgSslConfig: vi.fn().mockReturnValue(false),
+  applyPostgresSslParams: vi.fn((s: string) => s),
+  MANAGED_POSTGRES_SSL_QUERY: '',
+}));
+
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    workspaceSettings: {
+      upsert: vi.fn(),
+      findUnique: vi.fn(),
+    },
+  },
+}));
 
 // Mock auth modules before importing route handlers
 vi.mock('@/lib/auth/data-scope', () => ({
@@ -226,7 +251,7 @@ describe('company settings route: cross-workspace isolation', () => {
     await PUT(makePutRequest(attackBody) as never);
 
     // Workspace A still has original value in the store
-    const storeA = getCompanySettings(WORKSPACE_A);
+    const storeA = await getCompanySettings(WORKSPACE_A);
     expect(storeA.name).toBe('Real Org A Name');
   });
 });

--- a/src/lib/settings/company-store.ts
+++ b/src/lib/settings/company-store.ts
@@ -1,9 +1,25 @@
 /**
- * UNI-2111: Per-workspace company settings store (in-memory, same pattern as POS mock-store).
+ * UNI-2111: Per-workspace company settings store.
  *
- * Workspace isolation is enforced by the route handler: workspaceId MUST come from the
- * authenticated user's DB record, never from the request body or query string.
+ * Strategy: Prisma-first with in-memory fallback.
+ *
+ * - When DATABASE_URL is available at runtime, reads/writes go to the
+ *   `workspace_settings` table via Prisma. Settings survive server restarts.
+ * - When no DATABASE_URL is present (test environments, CI without a DB),
+ *   falls back to the in-memory Map so all existing unit tests keep passing.
+ *
+ * Test environments mock `@/lib/db/prisma` via vi.mock (same pattern as
+ * bulk-reconcile-route.test.ts). When mocked, the DB code path runs against
+ * the mock; when unmocked and DATABASE_URL is absent, hasDatabaseConfig()
+ * returns false and the in-memory path is used.
+ *
+ * Workspace isolation is enforced by the route handler: workspaceId MUST come
+ * from the authenticated user's DB record, never from the request body or query
+ * string.
  */
+
+import { hasDatabaseConfig } from '@/lib/db/database-env';
+import { prisma } from '@/lib/db/prisma';
 
 export type CompanySettings = {
   id: string;
@@ -22,6 +38,10 @@ export type UpdateCompanySettingsInput = {
   abn?: string | null;
   acn?: string | null;
 };
+
+// ---------------------------------------------------------------------------
+// In-memory fallback (no DB / test environments)
+// ---------------------------------------------------------------------------
 
 type SettingsMap = Map<string, CompanySettings>;
 
@@ -48,13 +68,14 @@ function seedSettings(workspaceId: string): CompanySettings {
   };
 }
 
-/**
- * Returns the company settings for a workspace, seeding defaults on first access.
- *
- * Route handlers MUST supply a workspaceId resolved from the authenticated user's
- * DB record — never a caller-supplied value.
- */
-export function getCompanySettings(workspaceId: string): CompanySettings {
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function memGet(workspaceId: string): CompanySettings {
   const map = getStoreMap();
   if (!map.has(workspaceId)) {
     map.set(workspaceId, seedSettings(workspaceId));
@@ -62,32 +83,121 @@ export function getCompanySettings(workspaceId: string): CompanySettings {
   return map.get(workspaceId) as CompanySettings;
 }
 
-/**
- * Persists updated company settings for a workspace.
- * Returns the saved record.
- */
-export function saveCompanySettings(
-  workspaceId: string,
-  updates: UpdateCompanySettingsInput
-): CompanySettings {
-  const current = getCompanySettings(workspaceId);
-  const slug = updates.name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
-
+function memSave(workspaceId: string, updates: UpdateCompanySettingsInput): CompanySettings {
+  const current = memGet(workspaceId);
   const updated: CompanySettings = {
     ...current,
     name: updates.name,
-    slug,
+    slug: slugify(updates.name),
     trading_name: updates.trading_name !== undefined ? updates.trading_name ?? null : current.trading_name,
     abn: updates.abn !== undefined ? updates.abn ?? null : current.abn,
     acn: updates.acn !== undefined ? updates.acn ?? null : current.acn,
   };
-
   getStoreMap().set(workspaceId, updated);
   return updated;
 }
+
+// ---------------------------------------------------------------------------
+// Prisma row → CompanySettings shape
+// ---------------------------------------------------------------------------
+
+function rowToSettings(row: {
+  id: string;
+  workspaceId: string;
+  name: string;
+  slug: string;
+  isActive: boolean;
+  tradingName: string | null;
+  abn: string | null;
+  acn: string | null;
+}): CompanySettings {
+  return {
+    id: row.id,
+    workspaceId: row.workspaceId,
+    name: row.name,
+    slug: row.slug,
+    is_active: row.isActive,
+    trading_name: row.tradingName,
+    abn: row.abn,
+    acn: row.acn,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API (async — route handlers must await these)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the company settings for a workspace.
+ * Creates a default row if none exists (upsert on first access).
+ *
+ * Route handlers MUST supply a workspaceId resolved from the authenticated
+ * user's DB record — never a caller-supplied value.
+ */
+export async function getCompanySettings(workspaceId: string): Promise<CompanySettings> {
+  if (!hasDatabaseConfig()) {
+    return memGet(workspaceId);
+  }
+
+  const defaults = seedSettings(workspaceId);
+
+  const row = await prisma.workspaceSettings.upsert({
+    where: { workspaceId },
+    create: {
+      workspaceId,
+      name: defaults.name,
+      slug: defaults.slug,
+      isActive: defaults.is_active,
+      tradingName: null,
+      abn: null,
+      acn: null,
+    },
+    update: {},
+  });
+
+  return rowToSettings(row);
+}
+
+/**
+ * Persists updated company settings for a workspace.
+ * Returns the saved record.
+ */
+export async function saveCompanySettings(
+  workspaceId: string,
+  updates: UpdateCompanySettingsInput
+): Promise<CompanySettings> {
+  if (!hasDatabaseConfig()) {
+    return memSave(workspaceId, updates);
+  }
+
+  const slug = slugify(updates.name);
+
+  const row = await prisma.workspaceSettings.upsert({
+    where: { workspaceId },
+    create: {
+      workspaceId,
+      name: updates.name,
+      slug,
+      tradingName: updates.trading_name ?? null,
+      abn: updates.abn ?? null,
+      acn: updates.acn ?? null,
+      isActive: true,
+    },
+    update: {
+      name: updates.name,
+      slug,
+      tradingName: updates.trading_name !== undefined ? updates.trading_name ?? null : undefined,
+      abn: updates.abn !== undefined ? updates.abn ?? null : undefined,
+      acn: updates.acn !== undefined ? updates.acn ?? null : undefined,
+    },
+  });
+
+  return rowToSettings(row);
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers (in-memory only — used by company-settings-route.test.ts)
+// ---------------------------------------------------------------------------
 
 /** Reset a workspace's company settings (test helper). */
 export function _resetCompanySettingsForWorkspace(workspaceId: string): void {


### PR DESCRIPTION
## Summary

This PR closes three persistence gaps documented in `docs/PROJECT-STATUS.md` (UNI-2111 follow-on, filed 2026-06-11):

### Gap 1 — `ReconciliationMatchAudit` migration was missing

The `ReconciliationMatchAudit` model was added to `schema.prisma` in PR #206 but **no migration file was ever created**. The table therefore does not exist on any migrated database. Added: `prisma/migrations/20260611100000_add_reconciliation_match_audit/migration.sql`.

### Gap 2 — `WorkspaceSettings` table did not exist

PR #202 (UNI-2111) added an in-memory `company-store.ts` as a deliberate short-term seam. Company settings saved via the UI reset on every server restart. This PR adds the `WorkspaceSettings` Prisma model and its migration: `prisma/migrations/20260611110000_add_workspace_settings/migration.sql`.

**Schema:** `workspace_settings(id UUID PK, workspace_id UUID UNIQUE, name TEXT, slug TEXT, trading_name TEXT?, abn TEXT?, acn TEXT?, is_active BOOL, created_at, updated_at)`

### Gap 3 — `company-store.ts` was purely in-memory

`src/lib/settings/company-store.ts` and `src/app/api/settings/company/route.ts` have been rewritten to use Prisma when `DATABASE_URL` is available, falling back to the existing in-memory store when it is not (same strategy as other routes — avoids breaking CI without a DB).

- `getCompanySettings` / `saveCompanySettings` are now `async` (route handlers already await them)
- The DB path uses `prisma.workspaceSettings.upsert` — workspace isolation enforced server-side, not from request body
- All 12 existing company-settings tests keep passing (test mocks `@/lib/db/database-env` to force the in-memory fallback, plus `@/lib/db/prisma` to avoid the ungenerated Prisma client error; same pattern as `bulk-reconcile-route.test.ts`)

## Test results

```
Test Files  16 passed (16)
      Tests  156 passed (156)
   Duration  10.74s
```

No test regressions. The new test mock strategy is identical to `bulk-reconcile-route.test.ts`.

## What Rana should verify / decide

1. **Migration policy:** The repo has a `prisma/migrations/` directory with hand-written SQL files. This PR follows that pattern. If the team is actually using `prisma db push` (schema-only, no migration history), these migration files are not harmful but also not necessary — Rana should confirm which workflow is canonical before running `prisma migrate deploy` in staging/prod.

2. **`prisma generate` in CI:** `ci.yml` runs `npm ci` (postinstall -> `prisma generate`) but does not supply `DATABASE_URL`. Without it, `prisma generate` may produce a stub client missing the new `WorkspaceSettings` model. Consider adding `DATABASE_URL` as a CI secret pointing to a test DB, or switching to `prisma generate --no-engine` for schema-only type generation.

3. **`isPrismaClientStale` guard in `src/lib/db/prisma.ts`:** This guard currently checks for `workspaceXeroConnection` to detect a stale client during Next.js hot-reload. With the new `WorkspaceSettings` model, Rana may want to extend this check to include `workspaceSettings` as well.

4. **Default seed name:** The in-memory fallback seeds `"CCW Equipment Supplies"` as the default company name (preserving existing behaviour). The Prisma upsert-create path uses `"My Company"`. Rana should confirm the preferred default and align both paths if needed.

5. **`ReconciliationMatchAudit` backfill:** The new migration creates the audit table fresh. Any bulk-reconcile operations that ran before this migration will not have audit rows — that is expected and acceptable given the table previously did not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
