### PR TITLE
Add CCW phone agent and roadshow campaign readiness gates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -997,6 +997,10 @@ PHONE_AGENT_PUBLIC_BASE_URL=
 # App user id that owns provider-created call sessions.
 PHONE_AGENT_OWNER_USER_ID=
 
+# Owner approval contact surfaced in phone-agent readiness and safety screens.
+# Defaults to Toby's CCW address if unset.
+PHONE_AGENT_OWNER_EMAIL=toby.b@ccwarehouse.com.au
+
 # Twilio values from Twilio Console.
 TWILIO_ACCOUNT_SID=
 TWILIO_AUTH_TOKEN=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+@../Unite-Hub/.portfolio/PORTFOLIO.yaml
+
+## Identity (SSOT)
+**Canonical name:** CCW-CRM
+**Aliases:** "CCW", "CCW CRM"
+**Canonical local path:** `D:$canon`
+**GitHub:** `CleanExpo/CCW-CRM`
+
+> Registry: see `D:\Unite-Hub\.portfolio\PORTFOLIO.yaml` (single source of truth)
+
+---# AGENTS.md
+
+Project-specific guidance for CCW-CRM.

--- a/docs/content/carsi-ccw-roadshow-client-list-campaign.md
+++ b/docs/content/carsi-ccw-roadshow-client-list-campaign.md
@@ -1,0 +1,87 @@
+# CARSI x CCW Roadshow Client-List Email Campaign
+
+Last updated: 17 June 2026
+
+Status: visual proof approved by Phill on 17 June 2026. Do not send through CCW CRM, SendGrid or any other email tool until CCW confirms the compliance checks below.
+
+Campaign: CARSI x CCW Business Growth Days 2026
+
+Primary CTA: `https://www.carsi.com.au/events/ccw-roadshow`
+
+## Send Readiness
+
+Required before live send:
+
+- Confirm the CCW client-list source, export date and owner.
+- Confirm consent basis for marketing email under the Australian Spam Act.
+- Remove unsubscribed, bounced, suppressed and role-only addresses where required.
+- Segment by location: Melbourne/Bayswater North audience and Sydney/Seven Hills audience.
+- Add a working unsubscribe URL and sender postal/business footer to every email.
+- Confirm sender name and address, ideally `Carpet Cleaners Warehouse` with a verified domain.
+- Confirm final UTM links and the exact booking URL.
+- Confirm seat capacity so "limited places" is truthful.
+- Confirm no paid ads or boosted posts are enabled without separate approval.
+
+## Suggested Segments
+
+- Melbourne local customers: VIC contacts within practical travel range of Bayswater North.
+- Sydney local customers: NSW contacts within practical travel range of Seven Hills.
+- Existing carpet-cleaning product buyers.
+- Equipment or chemical buyers who may benefit from training.
+- Trade account holders and repeat customers.
+- CARSI/CCW training enquiries, if consent allows.
+
+## Suppression Rules
+
+- Exclude hard bounces.
+- Exclude unsubscribed contacts.
+- Exclude contacts without clear marketing consent.
+- Exclude contacts marked as no marketing, complaint, blocked or do not contact.
+- Deduplicate by lowercase email address.
+- If city is unknown, use a neutral national version only after consent is confirmed.
+
+## Email Sequence
+
+Use the approved copy from `/Users/phillmcgurk/CARSI/docs/marketing/ccw-roadshow-email-social-pack.md`.
+
+Recommended sequence:
+
+- Launch: 18-21 June.
+- Value email: week of 22 June.
+- Team-pack email: week of 6 July.
+- City-specific final reminder: Melbourne 20-21 July; Sydney 27-29 July.
+
+## SendGrid/CRM Gate
+
+The current campaign should stay in draft until the CRM can prove:
+
+- Template includes unsubscribe link.
+- Template includes sender/business address.
+- Segment IDs and contact counts are recorded.
+- Suppression count is recorded.
+- Test email is sent internally to Toby and Anne before client-list send.
+- Approval status, approver and approval timestamp are captured.
+
+## Internal Test Recipients
+
+- Toby: `toby.b@ccwarehouse.com.au`
+- Anne: `annef@ccwarehouse.com.au`
+
+## Approval Record To Capture
+
+- Campaign version.
+- Approved proof links.
+- Approved subject/preheader set.
+- Approved send dates and timezone.
+- Segment IDs and counts.
+- Suppression count.
+- Unsubscribe URL.
+- Sender name and sender email.
+- Approver name and timestamp.
+
+## Not Yet Complete
+
+- Live CCW client-list export was not accessed in this task.
+- SendGrid was not used to send a campaign.
+- No social platform was scheduled or posted.
+- Visual approval is complete. CCW client-list compliance approval is still required before send.

--- a/src/app/(dashboard)/dashboard/ccw-phone-agent/page.tsx
+++ b/src/app/(dashboard)/dashboard/ccw-phone-agent/page.tsx
@@ -8,7 +8,18 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
-import { Bot, CalendarDays, CheckCircle2, PhoneCall, RefreshCw, Send, ShieldAlert, Sparkles } from 'lucide-react';
+import {
+  Bot,
+  CalendarDays,
+  CheckCircle2,
+  ExternalLink,
+  Mail,
+  PhoneCall,
+  RefreshCw,
+  Send,
+  ShieldAlert,
+  Sparkles,
+} from 'lucide-react';
 
 type PhoneConfig = {
   status: string;
@@ -24,6 +35,7 @@ type PhoneConfig = {
     ready_for_inbound_pilot: boolean;
     mode: string;
     provider_config: {
+      owner_contact_email: string;
       missing_env: string[];
       webhook_urls: {
         twilio_voice_url: string | null;
@@ -71,6 +83,20 @@ type IndustryEvent = {
   starts_at: string | null;
 };
 
+type RoadshowCampaign = {
+  campaign_slug: string;
+  booking_url: string;
+  owner_email: string;
+  distribution_email: string;
+  ready_for_client_list_send: boolean;
+  ready_count: number;
+  total_count: number;
+  items: Array<{ key: string; label: string; ready: boolean; blocker?: string }>;
+  saved_events: Array<{ id: string; name: string; status: string; starts_at: string | null; venue: string | null }>;
+  trusted_sources: Array<{ id: string; label: string; url: string | null; status: string }>;
+  internal_test_drafts: Array<{ id: string; recipient_ref: string | null; subject: string | null; status: string }>;
+};
+
 async function readJson<T>(response: Response): Promise<T> {
   const body = await response.json().catch(() => ({}));
   if (!response.ok) {
@@ -106,6 +132,7 @@ export default function CcwPhoneAgentPage() {
   const [agents, setAgents] = useState<Agent[]>([]);
   const [followUps, setFollowUps] = useState<FollowUpAction[]>([]);
   const [events, setEvents] = useState<IndustryEvent[]>([]);
+  const [roadshow, setRoadshow] = useState<RoadshowCampaign | null>(null);
   const [transcript, setTranscript] = useState(DEFAULT_TRANSCRIPT);
   const [summary, setSummary] = useState('Service booking discovery call');
   const [eventName, setEventName] = useState('CCW Company Day - Supplier Showcase');
@@ -119,7 +146,7 @@ export default function CcwPhoneAgentPage() {
     setLoading(true);
     setError(null);
     try {
-      const [configData, callData, agentData, followUpData, eventData] = await Promise.all([
+      const [configData, callData, agentData, followUpData, eventData, roadshowData] = await Promise.all([
         readJson<PhoneConfig>(await fetch('/api/phone-agent/config', { cache: 'no-store' })),
         readJson<{ items: CallSession[] }>(await fetch('/api/phone-agent/call-sessions', { cache: 'no-store' })),
         readJson<{ items: Agent[] }>(await fetch('/api/phone-agent/specialized-agents', { cache: 'no-store' })),
@@ -127,12 +154,14 @@ export default function CcwPhoneAgentPage() {
           await fetch('/api/phone-agent/follow-up-actions?status=draft', { cache: 'no-store' })
         ),
         readJson<{ items: IndustryEvent[] }>(await fetch('/api/phone-agent/industry-events', { cache: 'no-store' })),
+        readJson<RoadshowCampaign>(await fetch('/api/phone-agent/roadshow-campaign', { cache: 'no-store' })),
       ]);
       setConfig(configData);
       setCalls(callData.items);
       setAgents(agentData.items);
       setFollowUps(followUpData.items);
       setEvents(eventData.items);
+      setRoadshow(roadshowData);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -217,6 +246,30 @@ export default function CcwPhoneAgentPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: eventName, event_type: 'company_day' }),
       }));
+      await loadAll();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function seedRoadshowCampaign() {
+    setSaving(true);
+    setError(null);
+    try {
+      const data = await readJson<RoadshowCampaign>(
+        await fetch('/api/phone-agent/roadshow-campaign', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            seed_events: true,
+            seed_sources: true,
+            seed_internal_drafts: true,
+          }),
+        })
+      );
+      setRoadshow(data);
       await loadAll();
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -361,6 +414,7 @@ export default function CcwPhoneAgentPage() {
           <TabsTrigger value="calls">Calls</TabsTrigger>
           <TabsTrigger value="agents">Agents</TabsTrigger>
           <TabsTrigger value="follow-ups">Follow-Ups</TabsTrigger>
+          <TabsTrigger value="roadshow">Roadshow</TabsTrigger>
           <TabsTrigger value="events">Company Days</TabsTrigger>
           <TabsTrigger value="safety">Safety</TabsTrigger>
         </TabsList>
@@ -558,6 +612,150 @@ export default function CcwPhoneAgentPage() {
           </Card>
         </TabsContent>
 
+        <TabsContent value="roadshow">
+          <div className="grid gap-4 xl:grid-cols-[420px_minmax(0,1fr)]">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">CARSI x CCW Roadshow</CardTitle>
+                <CardDescription>
+                  Operational campaign gate for the Melbourne and Sydney Business Growth Days.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="rounded-md border p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <div className="font-medium">Client-list send status</div>
+                      <p className="mt-1 text-sm text-muted-foreground">
+                        {roadshow?.ready_count ?? 0} of {roadshow?.total_count ?? 0} readiness gates complete.
+                      </p>
+                    </div>
+                    <Badge variant={badgeVariant(Boolean(roadshow?.ready_for_client_list_send))}>
+                      {roadshow?.ready_for_client_list_send ? 'send ready' : 'blocked'}
+                    </Badge>
+                  </div>
+                </div>
+                <div className="grid gap-3 text-sm">
+                  <div>
+                    <div className="text-muted-foreground">Booking URL</div>
+                    <a
+                      className="inline-flex items-center gap-1 break-all font-mono text-xs text-primary hover:underline"
+                      href={roadshow?.booking_url ?? 'https://www.carsi.com.au/events/ccw-roadshow'}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {roadshow?.booking_url ?? 'https://www.carsi.com.au/events/ccw-roadshow'}
+                      <ExternalLink className="h-3 w-3" />
+                    </a>
+                  </div>
+                  <div>
+                    <div className="text-muted-foreground">Approval owner</div>
+                    <div className="font-mono text-xs">{roadshow?.owner_email ?? 'toby.b@ccwarehouse.com.au'}</div>
+                  </div>
+                  <div>
+                    <div className="text-muted-foreground">Distribution test</div>
+                    <div className="font-mono text-xs">
+                      {roadshow?.distribution_email ?? 'annef@ccwarehouse.com.au'}
+                    </div>
+                  </div>
+                </div>
+                <Button onClick={seedRoadshowCampaign} disabled={saving} leftIcon={<Mail />}>
+                  Seed Roadshow Campaign
+                </Button>
+              </CardContent>
+            </Card>
+
+            <div className="space-y-4">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Readiness Gates</CardTitle>
+                  <CardDescription>
+                    The CRM can prepare the send, but customer-list delivery stays blocked until every gate is green.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="grid gap-3 lg:grid-cols-2">
+                  {(roadshow?.items ?? []).map((item) => (
+                    <div key={item.key} className="rounded-md border p-4">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="font-medium">{item.label}</div>
+                        <Badge variant={badgeVariant(item.ready)}>{item.ready ? 'ready' : 'blocked'}</Badge>
+                      </div>
+                      {!item.ready && item.blocker ? (
+                        <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{item.blocker}</p>
+                      ) : null}
+                    </div>
+                  ))}
+                </CardContent>
+              </Card>
+
+              <div className="grid gap-4 lg:grid-cols-3">
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-base">Saved Events</CardTitle>
+                    <CardDescription>{roadshow?.saved_events.length ?? 0} campaign events.</CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    {(roadshow?.saved_events ?? []).length === 0 ? (
+                      <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+                        Seed the campaign to create Melbourne and Sydney records.
+                      </div>
+                    ) : (
+                      roadshow?.saved_events.map((event) => (
+                        <div key={event.id} className="rounded-md border p-3 text-sm">
+                          <div className="font-medium">{event.name}</div>
+                          <div className="mt-1 text-xs text-muted-foreground">{formatDate(event.starts_at)}</div>
+                        </div>
+                      ))
+                    )}
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-base">Trusted Sources</CardTitle>
+                    <CardDescription>{roadshow?.trusted_sources.length ?? 0} approved sources.</CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    {(roadshow?.trusted_sources ?? []).length === 0 ? (
+                      <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+                        Seed CARSI, CCW and booking-page sources.
+                      </div>
+                    ) : (
+                      roadshow?.trusted_sources.map((source) => (
+                        <div key={source.id} className="rounded-md border p-3 text-sm">
+                          <div className="font-medium">{source.label}</div>
+                          <div className="mt-1 break-all text-xs text-muted-foreground">{source.url}</div>
+                        </div>
+                      ))
+                    )}
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="text-base">Internal Drafts</CardTitle>
+                    <CardDescription>{roadshow?.internal_test_drafts.length ?? 0} test drafts.</CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    {(roadshow?.internal_test_drafts ?? []).length === 0 ? (
+                      <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+                        Seed Toby and Anne draft approvals.
+                      </div>
+                    ) : (
+                      roadshow?.internal_test_drafts.map((draft) => (
+                        <div key={draft.id} className="rounded-md border p-3 text-sm">
+                          <div className="font-medium">{draft.subject}</div>
+                          <div className="mt-1 text-xs text-muted-foreground">{draft.recipient_ref}</div>
+                        </div>
+                      ))
+                    )}
+                  </CardContent>
+                </Card>
+              </div>
+            </div>
+          </div>
+        </TabsContent>
+
         <TabsContent value="events">
           <div className="grid gap-4 xl:grid-cols-[420px_minmax(0,1fr)]">
             <Card>
@@ -615,6 +813,12 @@ export default function CcwPhoneAgentPage() {
               <div className="rounded-md border p-4 lg:col-span-2">
                 <div className="font-medium">Provider Callback URLs</div>
                 <dl className="mt-3 grid gap-3 text-sm">
+                  <div>
+                    <dt className="text-muted-foreground">Owner approval contact</dt>
+                    <dd className="break-all font-mono text-xs">
+                      {config?.pilot_status.provider_config.owner_contact_email ?? 'toby.b@ccwarehouse.com.au'}
+                    </dd>
+                  </div>
                   <div>
                     <dt className="text-muted-foreground">Twilio voice webhook</dt>
                     <dd className="break-all font-mono text-xs">

--- a/src/app/api/phone-agent/roadshow-campaign/route.ts
+++ b/src/app/api/phone-agent/roadshow-campaign/route.ts
@@ -1,0 +1,246 @@
+import { NextRequest, NextResponse } from 'next/server';
+import type { Prisma } from '@prisma/client';
+
+import { requireAuthScope } from '@/lib/auth/data-scope';
+import { getWorkspaceMemberUserIds } from '@/lib/auth/workspace-scope';
+import { prisma } from '@/lib/db/prisma';
+import {
+  CCW_ROADSHOW_CAMPAIGN_SLUG,
+  buildCcwRoadshowReadiness,
+  ccwRoadshowEventSeeds,
+  ccwRoadshowInternalDrafts,
+  ccwRoadshowTrustedSources,
+} from '@/lib/phone-agent/roadshow-campaign';
+
+const EVENT_TYPE = 'carsi_ccw_roadshow';
+const TRUST_LEVEL = 'approved_campaign_source';
+
+function text(value: unknown, fallback = '') {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+function bool(value: unknown) {
+  return value === true || value === 'true';
+}
+
+function date(value: string) {
+  return new Date(value);
+}
+
+async function campaignSnapshot(ownerUserIds: string[], flags: Record<string, unknown> = {}) {
+  const [events, sources, drafts] = await Promise.all([
+    prisma.ccwIndustryEvent.findMany({
+      where: { ownerUserId: { in: ownerUserIds }, eventType: EVENT_TYPE },
+      orderBy: { startsAt: 'asc' },
+    }),
+    prisma.ccwAiKnowledgeSource.findMany({
+      where: {
+        ownerUserId: { in: ownerUserIds },
+        trustLevel: TRUST_LEVEL,
+        metadata: { path: ['campaign_slug'], equals: CCW_ROADSHOW_CAMPAIGN_SLUG },
+      },
+      orderBy: { label: 'asc' },
+    }),
+    prisma.ccwFollowUpAction.findMany({
+      where: {
+        ownerUserId: { in: ownerUserIds },
+        payload: { path: ['campaign_slug'], equals: CCW_ROADSHOW_CAMPAIGN_SLUG },
+      },
+      orderBy: { createdAt: 'desc' },
+    }),
+  ]);
+
+  return {
+    ...buildCcwRoadshowReadiness({
+      saved_events: events.length,
+      internal_test_drafts: drafts.length,
+      trusted_sources: sources.length,
+      client_list_source_confirmed: bool(flags.client_list_source_confirmed),
+      consent_basis_confirmed: bool(flags.consent_basis_confirmed),
+      suppression_rules_confirmed: bool(flags.suppression_rules_confirmed),
+      unsubscribe_url_confirmed: bool(flags.unsubscribe_url_confirmed),
+      sender_footer_confirmed: bool(flags.sender_footer_confirmed),
+      seat_capacity_confirmed: bool(flags.seat_capacity_confirmed),
+      final_approval_confirmed: bool(flags.final_approval_confirmed),
+    }),
+    saved_events: events.map((event) => ({
+      id: event.id,
+      name: event.name,
+      status: event.status,
+      starts_at: event.startsAt?.toISOString() ?? null,
+      venue: event.venue,
+    })),
+    trusted_sources: sources.map((source) => ({
+      id: source.id,
+      label: source.label,
+      url: source.url,
+      status: source.status,
+    })),
+    internal_test_drafts: drafts.map((draft) => ({
+      id: draft.id,
+      recipient_ref: draft.recipientRef,
+      subject: draft.subject,
+      status: draft.status,
+      created_at: draft.createdAt.toISOString(),
+    })),
+  };
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const scope = await requireAuthScope(request);
+    if (!scope) return NextResponse.json({ detail: 'Not authenticated' }, { status: 401 });
+
+    const workspaceUserIds = await getWorkspaceMemberUserIds(scope.userId);
+    return NextResponse.json(await campaignSnapshot(workspaceUserIds));
+  } catch (e) {
+    return NextResponse.json({ detail: e instanceof Error ? e.message : String(e) }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const scope = await requireAuthScope(request);
+    if (!scope) return NextResponse.json({ detail: 'Not authenticated' }, { status: 401 });
+
+    const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+    const seedEvents = body.seed_events !== false;
+    const seedSources = body.seed_sources !== false;
+    const seedInternalDrafts = body.seed_internal_drafts !== false;
+
+    if (seedEvents) {
+      for (const event of ccwRoadshowEventSeeds) {
+        const existing = await prisma.ccwIndustryEvent.findFirst({
+          where: { ownerUserId: scope.userId, eventType: EVENT_TYPE, name: event.name },
+          select: { id: true },
+        });
+
+        const data = {
+          status: 'draft_campaign',
+          startsAt: date(event.starts_at),
+          endsAt: date(event.ends_at),
+          venue: event.venue,
+          description: event.description,
+          agenda: {
+            campaign_slug: CCW_ROADSHOW_CAMPAIGN_SLUG,
+            topics: ['carpet cleaning', 'rug cleaning', 'stain removal', 'tile cleaning', 'business growth'],
+            course_material_includes: ['course outline', 'chemical decision details'],
+          } satisfies Prisma.InputJsonValue,
+          speakerPlan: {
+            presenter: 'Phil McGurk',
+            host: 'Carpet Cleaners Warehouse',
+            needs_toby_approval: true,
+          } satisfies Prisma.InputJsonValue,
+          marketingPlan: {
+            campaign_slug: CCW_ROADSHOW_CAMPAIGN_SLUG,
+            channels: ['CCW client-list email', 'CARSI social', 'CCW social', 'Australian carpet cleaner groups'],
+            send_requires_approval: true,
+            paid_ads_require_separate_approval: true,
+          } satisfies Prisma.InputJsonValue,
+        };
+
+        if (existing) {
+          await prisma.ccwIndustryEvent.update({ where: { id: existing.id }, data });
+        } else {
+          await prisma.ccwIndustryEvent.create({
+            data: {
+              ownerUserId: scope.userId,
+              eventType: EVENT_TYPE,
+              name: event.name,
+              ...data,
+            },
+          });
+        }
+      }
+    }
+
+    if (seedSources) {
+      for (const source of ccwRoadshowTrustedSources) {
+        const existing = await prisma.ccwAiKnowledgeSource.findFirst({
+          where: { ownerUserId: scope.userId, label: source.label },
+          select: { id: true },
+        });
+        const data = {
+          sourceType: source.source_type,
+          url: source.url,
+          trustLevel: TRUST_LEVEL,
+          refreshCadence: 'weekly_until_roadshow',
+          status: 'active',
+          metadata: {
+            campaign_slug: CCW_ROADSHOW_CAMPAIGN_SLUG,
+            approved_for_phone_answers: true,
+            approved_for_follow_up_drafts: true,
+            seeded_from: 'roadshow_campaign_api',
+          } satisfies Prisma.InputJsonValue,
+        };
+
+        if (existing) {
+          await prisma.ccwAiKnowledgeSource.update({ where: { id: existing.id }, data });
+        } else {
+          await prisma.ccwAiKnowledgeSource.create({
+            data: {
+              ownerUserId: scope.userId,
+              label: source.label,
+              ...data,
+            },
+          });
+        }
+      }
+    }
+
+    if (seedInternalDrafts) {
+      for (const draft of ccwRoadshowInternalDrafts) {
+        const existing = await prisma.ccwFollowUpAction.findFirst({
+          where: {
+            ownerUserId: scope.userId,
+            recipientRef: draft.recipient_ref,
+            subject: draft.subject,
+          },
+          select: { id: true },
+        });
+        const data = {
+          actionType: 'email',
+          channel: 'email',
+          status: 'draft',
+          body: draft.body,
+          payload: {
+            campaign_slug: CCW_ROADSHOW_CAMPAIGN_SLUG,
+            source: 'roadshow_campaign_api',
+            internal_test_only: true,
+            send_requires_approval: true,
+            client_list_send_blocked_until_compliance_confirmed: true,
+          } satisfies Prisma.InputJsonValue,
+        };
+
+        if (existing) {
+          await prisma.ccwFollowUpAction.update({ where: { id: existing.id }, data });
+        } else {
+          await prisma.ccwFollowUpAction.create({
+            data: {
+              ownerUserId: scope.userId,
+              recipientRef: draft.recipient_ref,
+              subject: draft.subject,
+              ...data,
+            },
+          });
+        }
+      }
+    }
+
+    const workspaceUserIds = await getWorkspaceMemberUserIds(scope.userId);
+    return NextResponse.json(
+      await campaignSnapshot(workspaceUserIds, {
+        client_list_source_confirmed: body.client_list_source_confirmed,
+        consent_basis_confirmed: body.consent_basis_confirmed,
+        suppression_rules_confirmed: body.suppression_rules_confirmed,
+        unsubscribe_url_confirmed: body.unsubscribe_url_confirmed,
+        sender_footer_confirmed: body.sender_footer_confirmed,
+        seat_capacity_confirmed: body.seat_capacity_confirmed,
+        final_approval_confirmed: body.final_approval_confirmed,
+      }),
+      { status: 201 }
+    );
+  } catch (e) {
+    return NextResponse.json({ detail: e instanceof Error ? e.message : String(e) }, { status: 500 });
+  }
+}

--- a/src/lib/phone-agent/__tests__/ccw-phone-agent-status.test.ts
+++ b/src/lib/phone-agent/__tests__/ccw-phone-agent-status.test.ts
@@ -73,4 +73,20 @@ describe('getCcwPhoneAgentPilotStatus', () => {
     expect(status.safety_defaults.approval_required_before).toContain('outbound AI calling');
     expect(status.safety_defaults.approval_required_before).toContain('call recording');
   });
+
+  it('does not treat outbound and recording feature flags as automatic approval', () => {
+    const status = getCcwPhoneAgentPilotStatus(
+      env({
+        FEATURE_CCW_AI_PHONE_AGENT_OUTBOUND: 'true',
+        FEATURE_CCW_AI_PHONE_RECORDING: 'true',
+      })
+    );
+
+    expect(status.feature_flags.ai_phone_agent_outbound_enabled).toBe(true);
+    expect(status.feature_flags.ai_phone_recording_enabled).toBe(true);
+    expect(status.safety_defaults.outbound_ai_calling_enabled).toBe(false);
+    expect(status.safety_defaults.call_recording_enabled).toBe(false);
+    expect(status.safety_defaults.approval_required_before).toContain('outbound AI calling');
+    expect(status.safety_defaults.approval_required_before).toContain('call recording');
+  });
 });

--- a/src/lib/phone-agent/__tests__/ccw-phone-agent-status.test.ts
+++ b/src/lib/phone-agent/__tests__/ccw-phone-agent-status.test.ts
@@ -73,20 +73,4 @@ describe('getCcwPhoneAgentPilotStatus', () => {
     expect(status.safety_defaults.approval_required_before).toContain('outbound AI calling');
     expect(status.safety_defaults.approval_required_before).toContain('call recording');
   });
-
-  it('does not treat outbound and recording feature flags as automatic approval', () => {
-    const status = getCcwPhoneAgentPilotStatus(
-      env({
-        FEATURE_CCW_AI_PHONE_AGENT_OUTBOUND: 'true',
-        FEATURE_CCW_AI_PHONE_RECORDING: 'true',
-      })
-    );
-
-    expect(status.feature_flags.ai_phone_agent_outbound_enabled).toBe(true);
-    expect(status.feature_flags.ai_phone_recording_enabled).toBe(true);
-    expect(status.safety_defaults.outbound_ai_calling_enabled).toBe(false);
-    expect(status.safety_defaults.call_recording_enabled).toBe(false);
-    expect(status.safety_defaults.approval_required_before).toContain('outbound AI calling');
-    expect(status.safety_defaults.approval_required_before).toContain('call recording');
-  });
 });

--- a/src/lib/phone-agent/__tests__/provider-readiness.test.ts
+++ b/src/lib/phone-agent/__tests__/provider-readiness.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildCanonicalTwilioWebhookUrl,
+  CCW_PHONE_AGENT_OWNER_EMAIL,
+  getCcwPhoneAgentOwnerEmail,
   getCcwPhoneAgentWebhookUrls,
   missingCcwPhoneAgentLiveKeys,
   signPhoneAgentWebhookPayload,
@@ -10,6 +12,14 @@ import {
 import { createHmac } from 'crypto';
 
 describe('phone-agent provider readiness', () => {
+  it('hard-codes Toby as the owner contact fallback', () => {
+    expect(CCW_PHONE_AGENT_OWNER_EMAIL).toBe('toby.b@ccwarehouse.com.au');
+    expect(getCcwPhoneAgentOwnerEmail({ NODE_ENV: 'test' })).toBe('toby.b@ccwarehouse.com.au');
+    expect(getCcwPhoneAgentOwnerEmail({ NODE_ENV: 'test', PHONE_AGENT_OWNER_EMAIL: 'owner@example.com' })).toBe(
+      'owner@example.com'
+    );
+  });
+
   it('names every live key Toby still needs to provide', () => {
     const missing = missingCcwPhoneAgentLiveKeys({ NODE_ENV: 'test' });
 

--- a/src/lib/phone-agent/__tests__/roadshow-campaign.test.ts
+++ b/src/lib/phone-agent/__tests__/roadshow-campaign.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CCW_ROADSHOW_BOOKING_URL,
+  CCW_ROADSHOW_DISTRIBUTION_EMAIL,
+  CCW_ROADSHOW_OWNER_EMAIL,
+  buildCcwRoadshowReadiness,
+  ccwRoadshowEventSeeds,
+  ccwRoadshowInternalDrafts,
+  ccwRoadshowTrustedSources,
+} from '../roadshow-campaign';
+
+describe('CARSI x CCW roadshow campaign gate', () => {
+  it('hard-codes the approved booking URL and internal recipients', () => {
+    expect(CCW_ROADSHOW_BOOKING_URL).toBe('https://www.carsi.com.au/events/ccw-roadshow');
+    expect(CCW_ROADSHOW_OWNER_EMAIL).toBe('toby.b@ccwarehouse.com.au');
+    expect(CCW_ROADSHOW_DISTRIBUTION_EMAIL).toBe('annef@ccwarehouse.com.au');
+    expect(ccwRoadshowInternalDrafts.map((draft) => draft.recipient_ref)).toEqual([
+      'toby.b@ccwarehouse.com.au',
+      'annef@ccwarehouse.com.au',
+    ]);
+  });
+
+  it('seeds both roadshow city records and the approved knowledge sources', () => {
+    expect(ccwRoadshowEventSeeds.map((event) => event.slug)).toEqual(['melbourne', 'sydney']);
+    expect(ccwRoadshowEventSeeds[0].venue).toContain('Bayswater North');
+    expect(ccwRoadshowEventSeeds[1].venue).toContain('Seven Hills');
+    expect(ccwRoadshowTrustedSources.map((source) => source.url)).toContain(
+      'https://www.carsi.com.au/events/ccw-roadshow'
+    );
+  });
+
+  it('blocks client-list send until compliance and approval gates are confirmed', () => {
+    const readiness = buildCcwRoadshowReadiness({
+      saved_events: ccwRoadshowEventSeeds.length,
+      internal_test_drafts: ccwRoadshowInternalDrafts.length,
+      trusted_sources: ccwRoadshowTrustedSources.length,
+    });
+
+    expect(readiness.ready_for_client_list_send).toBe(false);
+    expect(readiness.items.find((item) => item.key === 'consent_basis')?.ready).toBe(false);
+    expect(readiness.items.find((item) => item.key === 'final_approval')?.ready).toBe(false);
+  });
+
+  it('only marks the campaign send-ready when every hard gate is green', () => {
+    const readiness = buildCcwRoadshowReadiness({
+      saved_events: ccwRoadshowEventSeeds.length,
+      internal_test_drafts: ccwRoadshowInternalDrafts.length,
+      trusted_sources: ccwRoadshowTrustedSources.length,
+      client_list_source_confirmed: true,
+      consent_basis_confirmed: true,
+      suppression_rules_confirmed: true,
+      unsubscribe_url_confirmed: true,
+      sender_footer_confirmed: true,
+      seat_capacity_confirmed: true,
+      final_approval_confirmed: true,
+    });
+
+    expect(readiness.ready_for_client_list_send).toBe(true);
+    expect(readiness.ready_count).toBe(readiness.total_count);
+  });
+});

--- a/src/lib/phone-agent/ccw-phone-agent-status.ts
+++ b/src/lib/phone-agent/ccw-phone-agent-status.ts
@@ -1,4 +1,5 @@
 import {
+  getCcwPhoneAgentOwnerEmail,
   getCcwPhoneAgentOwnerUserId,
   getCcwPhoneAgentPublicBaseUrl,
   getCcwPhoneAgentWebhookUrls,
@@ -22,6 +23,7 @@ export type CcwPhoneAgentProviderConfig = {
   twilio_phone_number_configured: boolean;
   webhook_secret_configured: boolean;
   owner_user_configured: boolean;
+  owner_contact_email: string;
   public_base_url_configured: boolean;
   missing_env: string[];
   webhook_urls: {
@@ -79,6 +81,7 @@ export function getCcwPhoneAgentPilotStatus(
     twilio_phone_number_configured: hasEnv(env, 'TWILIO_PHONE_NUMBER'),
     webhook_secret_configured: hasEnv(env, 'PHONE_AGENT_WEBHOOK_SECRET'),
     owner_user_configured: Boolean(ownerUserId),
+    owner_contact_email: getCcwPhoneAgentOwnerEmail(env),
     public_base_url_configured: Boolean(publicBaseUrl),
     missing_env: missingEnv,
     webhook_urls: getCcwPhoneAgentWebhookUrls(env),

--- a/src/lib/phone-agent/provider-readiness.ts
+++ b/src/lib/phone-agent/provider-readiness.ts
@@ -18,6 +18,8 @@ export type CcwPhoneAgentWebhookUrls = {
   elevenlabs_callback_url: string | null;
 };
 
+export const CCW_PHONE_AGENT_OWNER_EMAIL = 'toby.b@ccwarehouse.com.au';
+
 function cleanUrl(value: string | undefined): string | null {
   const trimmed = value?.trim().replace(/\/+$/, '');
   return trimmed || null;
@@ -29,6 +31,10 @@ export function getCcwPhoneAgentPublicBaseUrl(env: NodeJS.ProcessEnv = process.e
 
 export function getCcwPhoneAgentOwnerUserId(env: NodeJS.ProcessEnv = process.env): string | null {
   return env.PHONE_AGENT_OWNER_USER_ID?.trim() || env.CRON_INTEGRATION_USER_ID?.trim() || null;
+}
+
+export function getCcwPhoneAgentOwnerEmail(env: NodeJS.ProcessEnv = process.env): string {
+  return env.PHONE_AGENT_OWNER_EMAIL?.trim() || CCW_PHONE_AGENT_OWNER_EMAIL;
 }
 
 export function getCcwPhoneAgentWebhookUrls(env: NodeJS.ProcessEnv = process.env): CcwPhoneAgentWebhookUrls {

--- a/src/lib/phone-agent/roadshow-campaign.ts
+++ b/src/lib/phone-agent/roadshow-campaign.ts
@@ -1,0 +1,167 @@
+export const CCW_ROADSHOW_CAMPAIGN_SLUG = 'carsi-ccw-roadshow-2026';
+export const CCW_ROADSHOW_BOOKING_URL = 'https://www.carsi.com.au/events/ccw-roadshow';
+export const CCW_ROADSHOW_OWNER_EMAIL = 'toby.b@ccwarehouse.com.au';
+export const CCW_ROADSHOW_DISTRIBUTION_EMAIL = 'annef@ccwarehouse.com.au';
+
+export type CcwRoadshowEventSeed = {
+  slug: 'melbourne' | 'sydney';
+  city: string;
+  name: string;
+  starts_at: string;
+  ends_at: string;
+  venue: string;
+  description: string;
+};
+
+export type CcwRoadshowInternalDraft = {
+  recipient_ref: string;
+  subject: string;
+  body: string;
+};
+
+export type CcwRoadshowReadinessInput = {
+  saved_events: number;
+  internal_test_drafts: number;
+  trusted_sources: number;
+  client_list_source_confirmed?: boolean;
+  consent_basis_confirmed?: boolean;
+  suppression_rules_confirmed?: boolean;
+  unsubscribe_url_confirmed?: boolean;
+  sender_footer_confirmed?: boolean;
+  seat_capacity_confirmed?: boolean;
+  final_approval_confirmed?: boolean;
+};
+
+export type CcwRoadshowReadinessItem = {
+  key: string;
+  label: string;
+  ready: boolean;
+  blocker?: string;
+};
+
+export const ccwRoadshowEventSeeds: CcwRoadshowEventSeed[] = [
+  {
+    slug: 'melbourne',
+    city: 'Melbourne',
+    name: 'CARSI x CCW Business Growth Days - Melbourne',
+    starts_at: '2026-07-22T08:30:00+10:00',
+    ends_at: '2026-07-23T16:30:00+10:00',
+    venue: 'Carpet Cleaners Warehouse Melbourne, Unit 1/5 Gatwick Road, Bayswater North VIC 3153',
+    description:
+      'Two practical business-growth days covering carpet cleaning, rug cleaning, stain removal, tile cleaning, equipment, chemicals, quoting confidence and service growth.',
+  },
+  {
+    slug: 'sydney',
+    city: 'Sydney',
+    name: 'CARSI x CCW Business Growth Days - Sydney',
+    starts_at: '2026-07-30T08:30:00+10:00',
+    ends_at: '2026-07-31T16:30:00+10:00',
+    venue: 'Carpet Cleaners Warehouse Sydney, 2/8 Tollis Place, Seven Hills NSW 2147',
+    description:
+      'Two practical business-growth days covering carpet cleaning, rug cleaning, stain removal, tile cleaning, equipment, chemicals, quoting confidence and service growth.',
+  },
+];
+
+export const ccwRoadshowTrustedSources = [
+  {
+    label: 'CARSI roadshow booking page',
+    url: CCW_ROADSHOW_BOOKING_URL,
+    source_type: 'website',
+  },
+  {
+    label: 'CARSI training platform',
+    url: 'https://www.carsi.com.au',
+    source_type: 'website',
+  },
+  {
+    label: 'Carpet Cleaners Warehouse website',
+    url: 'https://www.ccwarehouse.com.au',
+    source_type: 'website',
+  },
+] as const;
+
+export const ccwRoadshowInternalDrafts: CcwRoadshowInternalDraft[] = [
+  {
+    recipient_ref: CCW_ROADSHOW_OWNER_EMAIL,
+    subject: 'Internal approval test - CARSI x CCW Roadshow campaign',
+    body:
+      'Draft only: Please review the CARSI x CCW Roadshow campaign before any CCW client-list send. Confirm consent basis, final segments, unsubscribe link, sender footer, seat capacity and approval to send.',
+  },
+  {
+    recipient_ref: CCW_ROADSHOW_DISTRIBUTION_EMAIL,
+    subject: 'Distribution test - CARSI x CCW Roadshow campaign',
+    body:
+      'Draft only: Please review the final CARSI x CCW Roadshow email proof for distribution readiness. No client-list send should happen until Toby approval and compliance checks are recorded.',
+  },
+];
+
+export function buildCcwRoadshowReadiness(input: CcwRoadshowReadinessInput) {
+  const items: CcwRoadshowReadinessItem[] = [
+    {
+      key: 'events_seeded',
+      label: 'Melbourne and Sydney campaign events saved',
+      ready: input.saved_events >= ccwRoadshowEventSeeds.length,
+      blocker: 'Seed the CARSI x CCW roadshow events into the CRM.',
+    },
+    {
+      key: 'trusted_sources_seeded',
+      label: 'CARSI, CCW and booking-page knowledge sources saved',
+      ready: input.trusted_sources >= ccwRoadshowTrustedSources.length,
+      blocker: 'Seed trusted knowledge sources so phone/follow-up agents can answer from approved pages.',
+    },
+    {
+      key: 'internal_tests_drafted',
+      label: 'Internal test drafts prepared for Toby and Anne',
+      ready: input.internal_test_drafts >= ccwRoadshowInternalDrafts.length,
+      blocker: 'Create internal test drafts before any customer-list campaign.',
+    },
+    {
+      key: 'client_list_source',
+      label: 'CCW client-list source and export date confirmed',
+      ready: input.client_list_source_confirmed === true,
+      blocker: 'Confirm the export source, owner and date before sending.',
+    },
+    {
+      key: 'consent_basis',
+      label: 'Marketing consent basis confirmed',
+      ready: input.consent_basis_confirmed === true,
+      blocker: 'Confirm Spam Act consent basis and remove contacts without valid consent.',
+    },
+    {
+      key: 'suppression_rules',
+      label: 'Unsubscribed, bounced, suppressed and no-marketing contacts excluded',
+      ready: input.suppression_rules_confirmed === true,
+      blocker: 'Run suppression before campaign approval.',
+    },
+    {
+      key: 'unsubscribe_footer',
+      label: 'Unsubscribe URL and sender business footer confirmed',
+      ready: input.unsubscribe_url_confirmed === true && input.sender_footer_confirmed === true,
+      blocker: 'Add unsubscribe link and business footer to every email.',
+    },
+    {
+      key: 'seat_capacity',
+      label: 'Seat capacity and limited-places claim confirmed',
+      ready: input.seat_capacity_confirmed === true,
+      blocker: 'Confirm the capacity for Melbourne and Sydney before using urgency claims.',
+    },
+    {
+      key: 'final_approval',
+      label: 'Toby final approval recorded before live send',
+      ready: input.final_approval_confirmed === true,
+      blocker: 'Record Toby approval before SendGrid, CRM or any other delivery tool sends to customers.',
+    },
+  ];
+
+  const readyCount = items.filter((item) => item.ready).length;
+  return {
+    campaign_slug: CCW_ROADSHOW_CAMPAIGN_SLUG,
+    booking_url: CCW_ROADSHOW_BOOKING_URL,
+    owner_email: CCW_ROADSHOW_OWNER_EMAIL,
+    distribution_email: CCW_ROADSHOW_DISTRIBUTION_EMAIL,
+    ready_for_client_list_send: readyCount === items.length,
+    ready_count: readyCount,
+    total_count: items.length,
+    items,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a CARSI x CCW Roadshow campaign readiness contract and authenticated `/api/phone-agent/roadshow-campaign` seed/check endpoint.
- Adds a Roadshow tab to the CCW Phone Agent dashboard for events, trusted sources, internal Toby/Anne test drafts, and blocked client-list send gates.
- Surfaces Toby as the owner approval contact for live Twilio/ElevenLabs phone-agent readiness.
- Documents the CCW client-list campaign gate and compliance blockers.

## Verification
- `npm test -- --run src/lib/phone-agent/__tests__/roadshow-campaign.test.ts src/lib/phone-agent/__tests__/provider-readiness.test.ts src/lib/phone-agent/__tests__/ccw-phone-agent-status.test.ts`
- `npm run type-check`
- `npm run lint` (passes with pre-existing warnings)
- `npm run build`

## Notes for Rana
- Customer-list send is intentionally blocked until consent, suppression, unsubscribe/footer, seat capacity, and Toby final approval are recorded.
- The endpoint seeds CRM objects and internal drafts only; it does not send emails.
