### PR TITLE
Gate CCW roadshow payment readiness

### DIFF
--- a/src/app/(dashboard)/dashboard/ccw-phone-agent/page.tsx
+++ b/src/app/(dashboard)/dashboard/ccw-phone-agent/page.tsx
@@ -87,6 +87,14 @@ type IndustryEvent = {
 type RoadshowCampaign = {
   campaign_slug: string;
   booking_url: string;
+  payment_checkout_url: string | null;
+  payment: {
+    currency: string;
+    single_ticket_price: number;
+    five_pack_price: number;
+    five_pack_quantity: number;
+    checkout_url_ready: boolean;
+  };
   owner_email: string;
   distribution_email: string;
   ready_for_client_list_send: boolean;
@@ -117,12 +125,15 @@ type RoadshowComplianceKey =
   | 'unsubscribe_url_confirmed'
   | 'sender_footer_confirmed'
   | 'seat_capacity_confirmed'
+  | 'payment_pricing_confirmed'
+  | 'payment_checkout_url_confirmed'
   | 'final_approval_confirmed';
 
 type RoadshowComplianceState = Record<RoadshowComplianceKey, boolean> & {
   updated_by: string | null;
   updated_at: string | null;
   notes: string | null;
+  payment_checkout_url: string | null;
 };
 
 const roadshowComplianceControls: Array<{ key: RoadshowComplianceKey; label: string }> = [
@@ -132,6 +143,8 @@ const roadshowComplianceControls: Array<{ key: RoadshowComplianceKey; label: str
   { key: 'unsubscribe_url_confirmed', label: 'Working unsubscribe URL confirmed' },
   { key: 'sender_footer_confirmed', label: 'Sender business footer confirmed' },
   { key: 'seat_capacity_confirmed', label: 'Venue capacity and limited-places claim confirmed' },
+  { key: 'payment_pricing_confirmed', label: '$175 single and $500 five-pack pricing confirmed' },
+  { key: 'payment_checkout_url_confirmed', label: 'Live CARSI/Stripe checkout URL confirmed' },
   { key: 'final_approval_confirmed', label: 'Toby final approval recorded' },
 ];
 
@@ -337,6 +350,20 @@ export default function CcwPhoneAgentPage() {
         compliance_state: {
           ...current.compliance_state,
           notes: value,
+        },
+      };
+    });
+  }
+
+  function updateRoadshowPaymentUrl(value: string) {
+    setRoadshow((current) => {
+      if (!current) return current;
+      return {
+        ...current,
+        payment_checkout_url: value,
+        compliance_state: {
+          ...current.compliance_state,
+          payment_checkout_url: value,
         },
       };
     });
@@ -762,6 +789,42 @@ export default function CcwPhoneAgentPage() {
                       {roadshow?.booking_url ?? 'https://www.carsi.com.au/events/ccw-roadshow'}
                       <ExternalLink className="h-3 w-3" />
                     </a>
+                  </div>
+                  <div className="rounded-md border p-3">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <div className="font-medium">Payment setup</div>
+                        <div className="mt-1 text-xs text-muted-foreground">
+                          {roadshow?.payment.currency ?? 'AUD'} ${roadshow?.payment.single_ticket_price ?? 175} per
+                          person or ${roadshow?.payment.five_pack_price ?? 500} for{' '}
+                          {roadshow?.payment.five_pack_quantity ?? 5}
+                        </div>
+                      </div>
+                      <Badge variant={badgeVariant(Boolean(roadshow?.payment.checkout_url_ready))}>
+                        {roadshow?.payment.checkout_url_ready ? 'payment ready' : 'payment blocked'}
+                      </Badge>
+                    </div>
+                    <div className="mt-3 space-y-2">
+                      <Label htmlFor="roadshow-payment-url">Live checkout URL</Label>
+                      <Input
+                        id="roadshow-payment-url"
+                        value={roadshow?.compliance_state.payment_checkout_url ?? ''}
+                        onChange={(event) => updateRoadshowPaymentUrl(event.target.value)}
+                        placeholder="https://buy.stripe.com/... or https://www.carsi.com.au/..."
+                        disabled={!roadshow || saving}
+                      />
+                      {roadshow?.payment_checkout_url ? (
+                        <a
+                          className="inline-flex items-center gap-1 break-all font-mono text-xs text-primary hover:underline"
+                          href={roadshow.payment_checkout_url}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          {roadshow.payment_checkout_url}
+                          <ExternalLink className="h-3 w-3" />
+                        </a>
+                      ) : null}
+                    </div>
                   </div>
                   <div>
                     <div className="text-muted-foreground">Approval owner</div>

--- a/src/app/api/phone-agent/roadshow-campaign/route.ts
+++ b/src/app/api/phone-agent/roadshow-campaign/route.ts
@@ -19,7 +19,11 @@ import {
 } from '@/lib/integrations/sendgrid-persistence';
 import {
   CCW_ROADSHOW_CAMPAIGN_SLUG,
+  CCW_ROADSHOW_CURRENCY,
+  CCW_ROADSHOW_FIVE_PACK_PRICE,
+  CCW_ROADSHOW_FIVE_PACK_QUANTITY,
   CCW_ROADSHOW_FEATURE_SLUG,
+  CCW_ROADSHOW_SINGLE_TICKET_PRICE,
   buildCcwRoadshowInternalTestEmail,
   buildCcwRoadshowReadiness,
   ccwRoadshowEventSeeds,
@@ -340,6 +344,12 @@ export async function POST(request: NextRequest) {
             campaign_slug: CCW_ROADSHOW_CAMPAIGN_SLUG,
             topics: ['carpet cleaning', 'rug cleaning', 'stain removal', 'tile cleaning', 'business growth'],
             course_material_includes: ['course outline', 'chemical decision details'],
+            pricing: {
+              currency: CCW_ROADSHOW_CURRENCY,
+              single_ticket_price: CCW_ROADSHOW_SINGLE_TICKET_PRICE,
+              five_pack_price: CCW_ROADSHOW_FIVE_PACK_PRICE,
+              five_pack_quantity: CCW_ROADSHOW_FIVE_PACK_QUANTITY,
+            },
           } satisfies Prisma.InputJsonValue,
           speakerPlan: {
             presenter: 'Phil McGurk',
@@ -350,6 +360,7 @@ export async function POST(request: NextRequest) {
             campaign_slug: CCW_ROADSHOW_CAMPAIGN_SLUG,
             channels: ['CCW client-list email', 'CARSI social', 'CCW social', 'Australian carpet cleaner groups'],
             send_requires_approval: true,
+            payment_link_required_before_publish: true,
             paid_ads_require_separate_approval: true,
           } satisfies Prisma.InputJsonValue,
         };

--- a/src/lib/phone-agent/__tests__/roadshow-campaign.test.ts
+++ b/src/lib/phone-agent/__tests__/roadshow-campaign.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import {
   CCW_ROADSHOW_BOOKING_URL,
+  CCW_ROADSHOW_CURRENCY,
   CCW_ROADSHOW_DISTRIBUTION_EMAIL,
+  CCW_ROADSHOW_FIVE_PACK_PRICE,
   CCW_ROADSHOW_OWNER_EMAIL,
+  CCW_ROADSHOW_SINGLE_TICKET_PRICE,
   buildCcwRoadshowInternalTestEmail,
   buildCcwRoadshowReadiness,
   ccwRoadshowEventSeeds,
@@ -11,6 +14,7 @@ import {
   ccwRoadshowTrustedSources,
   defaultCcwRoadshowComplianceState,
   isCcwRoadshowInternalRecipient,
+  isValidCcwRoadshowPaymentUrl,
   normaliseCcwRoadshowComplianceState,
 } from '../roadshow-campaign';
 
@@ -57,6 +61,9 @@ describe('CARSI x CCW roadshow campaign gate', () => {
       unsubscribe_url_confirmed: true,
       sender_footer_confirmed: true,
       seat_capacity_confirmed: true,
+      payment_pricing_confirmed: true,
+      payment_checkout_url_confirmed: true,
+      payment_checkout_url: 'https://buy.stripe.com/test-roadshow',
       final_approval_confirmed: true,
     });
 
@@ -86,6 +93,9 @@ describe('CARSI x CCW roadshow campaign gate', () => {
       unsubscribe_url_confirmed: true,
       sender_footer_confirmed: true,
       seat_capacity_confirmed: true,
+      payment_pricing_confirmed: true,
+      payment_checkout_url_confirmed: false,
+      payment_checkout_url: 'https://buy.stripe.com/test-roadshow',
       final_approval_confirmed: false,
       notes: 'CCW Shopify export checked, suppression count recorded.',
       updated_by: 'user-1',
@@ -93,6 +103,8 @@ describe('CARSI x CCW roadshow campaign gate', () => {
     });
 
     expect(state.client_list_source_confirmed).toBe(true);
+    expect(state.payment_pricing_confirmed).toBe(true);
+    expect(state.payment_checkout_url).toBe('https://buy.stripe.com/test-roadshow');
     expect(state.final_approval_confirmed).toBe(false);
     expect(state.notes).toContain('suppression count');
   });
@@ -110,5 +122,34 @@ describe('CARSI x CCW roadshow campaign gate', () => {
     expect(body).toContain(CCW_ROADSHOW_BOOKING_URL);
     expect(body).toContain('Internal proof only');
     expect(body).toContain('Toby final approval');
+  });
+
+  it('requires a valid CARSI or Stripe payment URL before payment readiness passes', () => {
+    expect(CCW_ROADSHOW_CURRENCY).toBe('AUD');
+    expect(CCW_ROADSHOW_SINGLE_TICKET_PRICE).toBe(175);
+    expect(CCW_ROADSHOW_FIVE_PACK_PRICE).toBe(500);
+    expect(isValidCcwRoadshowPaymentUrl('https://buy.stripe.com/live-link')).toBe(true);
+    expect(isValidCcwRoadshowPaymentUrl('https://www.carsi.com.au/events/ccw-roadshow')).toBe(true);
+    expect(isValidCcwRoadshowPaymentUrl('http://buy.stripe.com/not-secure')).toBe(false);
+    expect(isValidCcwRoadshowPaymentUrl('https://example.com/pay')).toBe(false);
+
+    const readiness = buildCcwRoadshowReadiness({
+      saved_events: ccwRoadshowEventSeeds.length,
+      internal_test_drafts: ccwRoadshowInternalDrafts.length,
+      trusted_sources: ccwRoadshowTrustedSources.length,
+      client_list_source_confirmed: true,
+      consent_basis_confirmed: true,
+      suppression_rules_confirmed: true,
+      unsubscribe_url_confirmed: true,
+      sender_footer_confirmed: true,
+      seat_capacity_confirmed: true,
+      payment_pricing_confirmed: true,
+      payment_checkout_url_confirmed: true,
+      payment_checkout_url: 'https://example.com/pay',
+      final_approval_confirmed: true,
+    });
+
+    expect(readiness.ready_for_client_list_send).toBe(false);
+    expect(readiness.items.find((item) => item.key === 'payment_checkout_url')?.ready).toBe(false);
   });
 });

--- a/src/lib/phone-agent/roadshow-campaign.ts
+++ b/src/lib/phone-agent/roadshow-campaign.ts
@@ -3,6 +3,10 @@ export const CCW_ROADSHOW_FEATURE_SLUG = 'carsi_ccw_roadshow_campaign';
 export const CCW_ROADSHOW_BOOKING_URL = 'https://www.carsi.com.au/events/ccw-roadshow';
 export const CCW_ROADSHOW_OWNER_EMAIL = 'toby.b@ccwarehouse.com.au';
 export const CCW_ROADSHOW_DISTRIBUTION_EMAIL = 'annef@ccwarehouse.com.au';
+export const CCW_ROADSHOW_CURRENCY = 'AUD';
+export const CCW_ROADSHOW_SINGLE_TICKET_PRICE = 175;
+export const CCW_ROADSHOW_FIVE_PACK_PRICE = 500;
+export const CCW_ROADSHOW_FIVE_PACK_QUANTITY = 5;
 
 export const ccwRoadshowComplianceFlagKeys = [
   'client_list_source_confirmed',
@@ -11,6 +15,8 @@ export const ccwRoadshowComplianceFlagKeys = [
   'unsubscribe_url_confirmed',
   'sender_footer_confirmed',
   'seat_capacity_confirmed',
+  'payment_pricing_confirmed',
+  'payment_checkout_url_confirmed',
   'final_approval_confirmed',
 ] as const;
 
@@ -20,6 +26,7 @@ export type CcwRoadshowComplianceState = Record<CcwRoadshowComplianceFlagKey, bo
   updated_by: string | null;
   updated_at: string | null;
   notes: string | null;
+  payment_checkout_url: string | null;
 };
 
 export type CcwRoadshowEventSeed = {
@@ -42,6 +49,7 @@ export type CcwRoadshowReadinessInput = {
   saved_events: number;
   internal_test_drafts: number;
   trusted_sources: number;
+  payment_checkout_url?: string | null;
 } & Partial<Record<CcwRoadshowComplianceFlagKey, boolean>>;
 
 export type CcwRoadshowReadinessItem = {
@@ -123,6 +131,23 @@ export function buildCcwRoadshowInternalTestEmail(draft: CcwRoadshowInternalDraf
   ].join('\n');
 }
 
+export function isValidCcwRoadshowPaymentUrl(value: unknown): value is string {
+  if (typeof value !== 'string' || !value.trim()) return false;
+  try {
+    const url = new URL(value.trim());
+    const hostname = url.hostname.toLowerCase();
+    return (
+      url.protocol === 'https:' &&
+      (hostname === 'www.carsi.com.au' ||
+        hostname === 'carsi.com.au' ||
+        hostname.endsWith('.stripe.com') ||
+        hostname === 'stripe.com')
+    );
+  } catch {
+    return false;
+  }
+}
+
 function bool(value: unknown, fallback = false): boolean {
   if (typeof value === 'boolean') return value;
   if (typeof value === 'string') {
@@ -145,10 +170,13 @@ export function defaultCcwRoadshowComplianceState(): CcwRoadshowComplianceState 
     unsubscribe_url_confirmed: false,
     sender_footer_confirmed: false,
     seat_capacity_confirmed: false,
+    payment_pricing_confirmed: false,
+    payment_checkout_url_confirmed: false,
     final_approval_confirmed: false,
     updated_by: null,
     updated_at: null,
     notes: null,
+    payment_checkout_url: null,
   };
 }
 
@@ -164,14 +192,21 @@ export function normaliseCcwRoadshowComplianceState(
     unsubscribe_url_confirmed: bool(source.unsubscribe_url_confirmed, defaults.unsubscribe_url_confirmed),
     sender_footer_confirmed: bool(source.sender_footer_confirmed, defaults.sender_footer_confirmed),
     seat_capacity_confirmed: bool(source.seat_capacity_confirmed, defaults.seat_capacity_confirmed),
+    payment_pricing_confirmed: bool(source.payment_pricing_confirmed, defaults.payment_pricing_confirmed),
+    payment_checkout_url_confirmed: bool(
+      source.payment_checkout_url_confirmed,
+      defaults.payment_checkout_url_confirmed
+    ),
     final_approval_confirmed: bool(source.final_approval_confirmed, defaults.final_approval_confirmed),
     updated_by: text(source.updated_by, defaults.updated_by),
     updated_at: text(source.updated_at, defaults.updated_at),
     notes: text(source.notes, defaults.notes),
+    payment_checkout_url: text(source.payment_checkout_url, defaults.payment_checkout_url),
   };
 }
 
 export function buildCcwRoadshowReadiness(input: CcwRoadshowReadinessInput) {
+  const paymentUrlReady = input.payment_checkout_url_confirmed === true && isValidCcwRoadshowPaymentUrl(input.payment_checkout_url);
   const items: CcwRoadshowReadinessItem[] = [
     {
       key: 'events_seeded',
@@ -222,6 +257,19 @@ export function buildCcwRoadshowReadiness(input: CcwRoadshowReadinessInput) {
       blocker: 'Confirm the capacity for Melbourne and Sydney before using urgency claims.',
     },
     {
+      key: 'payment_pricing',
+      label: '$175 single and $500 five-pack pricing confirmed',
+      ready: input.payment_pricing_confirmed === true,
+      blocker: 'Confirm the public roadshow pricing before publishing payment links or campaign copy.',
+    },
+    {
+      key: 'payment_checkout_url',
+      label: 'CARSI/Stripe checkout URL saved and verified',
+      ready: paymentUrlReady,
+      blocker:
+        'Add the live CARSI or Stripe checkout URL and tick the payment URL gate before bookings are treated as payment-ready.',
+    },
+    {
       key: 'final_approval',
       label: 'Toby final approval recorded before live send',
       ready: input.final_approval_confirmed === true,
@@ -233,6 +281,14 @@ export function buildCcwRoadshowReadiness(input: CcwRoadshowReadinessInput) {
   return {
     campaign_slug: CCW_ROADSHOW_CAMPAIGN_SLUG,
     booking_url: CCW_ROADSHOW_BOOKING_URL,
+    payment_checkout_url: input.payment_checkout_url ?? null,
+    payment: {
+      currency: CCW_ROADSHOW_CURRENCY,
+      single_ticket_price: CCW_ROADSHOW_SINGLE_TICKET_PRICE,
+      five_pack_price: CCW_ROADSHOW_FIVE_PACK_PRICE,
+      five_pack_quantity: CCW_ROADSHOW_FIVE_PACK_QUANTITY,
+      checkout_url_ready: paymentUrlReady,
+    },
     owner_email: CCW_ROADSHOW_OWNER_EMAIL,
     distribution_email: CCW_ROADSHOW_DISTRIBUTION_EMAIL,
     ready_for_client_list_send: readyCount === items.length,


### PR DESCRIPTION
## Summary
- adds roadshow payment readiness gates for the approved  single ticket and  five-pack pricing
- persists a live CARSI/Stripe checkout URL in the Roadshow feature config and validates it before the campaign can be marked send-ready
- surfaces the payment setup block in the CCW Phone Agent Roadshow dashboard
- stamps seeded roadshow event metadata with pricing and payment-link-required markers

## Verification
- npm test -- --run src/lib/phone-agent/__tests__/roadshow-campaign.test.ts
- npm run type-check
- npm run lint
- npm run build

## Notes for Rana
- This stops short of creating live Stripe products/payment links because Toby still needs to provide or approve the live checkout configuration.
- Valid payment URLs are restricted to HTTPS CARSI or Stripe domains.