### PR TITLE
chore: restore CCW SEO audit loop + 02/07 recheck report (UNI-2156)

### DIFF
--- a/docs/audit-reports/ccw-semrush-seo-baseline-2026-06-18.md
+++ b/docs/audit-reports/ccw-semrush-seo-baseline-2026-06-18.md
@@ -1,0 +1,239 @@
+# CCW Semrush SEO Baseline Audit
+
+Date: 2026-06-18 10:50 AEST  
+Site audited: `https://ccwonline.com.au`  
+Semrush project: `Carpet Cleaners Warehouse`  
+Purpose: establish the before-repair baseline Toby can compare against after remediation and a fresh Semrush crawl.
+
+## Executive Summary
+
+CCW is crawlable and already exposes modern Shopify agent surfaces, but Semrush currently scores the project at **86% Site Health** and **75% AI Search Health**. The most important blockers are not keyword tweaks; they are Shopify/theme crawl weight, sitemap/internal-link quality, structured data, and crawl freshness.
+
+The Semrush Site Audit snapshot for CCW is stale: it was last updated on **2026-02-03**, while live checks on **2026-06-18** show `/llms.txt`, `/agents.md`, and `/.well-known/ucp` all return `200`. So the first repair loop should fix visible issues, then rerun the Semrush campaign before presenting final progress.
+
+## Evidence Sources
+
+- Semrush UI via signed-in Chrome session, project `Carpet Cleaners Warehouse`.
+- Live HTTP checks against `https://ccwonline.com.au`.
+- Live sitemap crawl of `https://ccwonline.com.au/sitemap.xml`.
+- Sample page fetches across home, collection, product, page, and blog surfaces.
+
+## Semrush Baseline
+
+### Site Audit
+
+From Semrush Site Audit for `ccwonline.com.au`:
+
+| Metric | Current Semrush Value |
+| --- | ---: |
+| Site Health | 86% |
+| Top 10% benchmark | 92% |
+| AI Search Health | 75% |
+| AI Search target hint | Reach 80% |
+| Pages crawled | 214 / 500 |
+| Healthy pages | 2 |
+| Broken pages | 1 |
+| Pages with issues | 201 |
+| Redirect pages | 1 |
+| Blocked pages | 9 |
+| Errors | 197 |
+| Warnings | 9 |
+| Semrush audit updated | 2026-02-03 |
+
+### Issue Inventory
+
+| Severity | Semrush issue | Count | Repair priority |
+| --- | --- | ---: | --- |
+| Error | Pages have too large HTML size | 196 pages | P0 |
+| Error | Structured data item is invalid | 1 item | P0 |
+| Warning | Images missing alt attributes | 3 images | P2 |
+| Warning | Unminified JavaScript and CSS files | 3 issues | P1 |
+| Warning | Title tag too long | 1 page | P2 |
+| Warning | Low text-to-HTML ratio | 1 page | P1 |
+| Warning | Blocked internal resource in robots.txt | 1 issue | P1 |
+| Notice | Orphaned pages in sitemaps | 2,690 pages | P0 |
+| Notice | Pages have only one incoming internal link | 197 pages | P0 |
+| Notice | Pages contain too much content for AI Search | 196 pages | P0 |
+| Notice | Pages blocked from crawling | 9 pages | P1 |
+| Notice | `llms.txt` not found | 1 page | Recheck |
+| Notice | Blocked external resource in robots.txt | 1 issue | P2 |
+
+## Ranking And Visibility Baseline
+
+### Position Tracking
+
+Semrush Position Tracking is configured for **Australia (Google) - English** and was updated about 21 hours before the audit.
+
+| Metric | Value |
+| --- | ---: |
+| Visibility | 0% |
+| Top 3 tracked keywords | 0 |
+| Top 10 tracked keywords | 0 |
+| Top 20 tracked keywords | 0 |
+| Top 100 tracked keywords | 0 |
+
+Visible tracked keywords are too broad for CCW's strongest commercial intent:
+
+- `cleaning product supplier`
+- `equipment supplier`
+- `machine maintenance service`
+- `manufacturer`
+- `repair services`
+
+These should be replaced or expanded with specific commercial and local-intent terms such as carpet cleaning equipment, carpet cleaning chemicals, restoration equipment, truckmount servicing, upholstery cleaning chemicals, tile cleaning products, and CCW branch/location terms.
+
+### AI Search
+
+Semrush AI Search widget for Australia:
+
+| Metric | Value |
+| --- | ---: |
+| AI Visibility | 15 |
+| Mentions | 33 |
+| Cited pages | 80 |
+| ChatGPT mentions | 4 |
+| Google AI Overview mentions | 10 |
+| Google AI Mode mentions | 4 |
+| Gemini mentions | 15 |
+
+This is a stronger starting point than Position Tracking, but the AI Search Health audit still flags crawl/content issues.
+
+## Live Site Verification
+
+### Agent And AI Discovery
+
+Live checks on 2026-06-18:
+
+| URL | Status | Notes |
+| --- | ---: | --- |
+| `https://ccwonline.com.au/robots.txt` | 200 | Public Shopify surfaces allowed; private/transactional paths blocked. |
+| `https://ccwonline.com.au/sitemap.xml` | 200 | Shopify sitemap index available. |
+| `https://ccwonline.com.au/llms.txt` | 200 | Semrush's stale "not found" notice should clear after rerun. |
+| `https://ccwonline.com.au/agents.md` | 200 | Agent instructions available. |
+| `https://ccwonline.com.au/.well-known/ucp` | 200 | UCP discovery endpoint available. |
+
+Live `robots.txt` also advertises:
+
+- `https://ccwonline.com.au/agents.md`
+- `https://ccwonline.com.au/.well-known/ucp`
+- `https://ccwonline.com.au/api/ucp/mcp`
+
+### Sitemap Counts
+
+Live sitemap crawl:
+
+| Sitemap | URLs |
+| --- | ---: |
+| `sitemap_agentic_discovery.xml` | 1 |
+| `sitemap_products_1.xml` | 2,501 |
+| `sitemap_pages_1.xml` | 11 |
+| `sitemap_collections_1.xml` | 295 |
+| `sitemap_blogs_1.xml` | 97 |
+| Total sitemap entries | 2,905 |
+| Unique URLs | 1,656 |
+
+URL type count:
+
+| Type | Count |
+| --- | ---: |
+| Product | 2,500 |
+| Collection | 295 |
+| Blog | 97 |
+| Page | 11 |
+| Other | 2 |
+
+The gap between 2,905 entries and 1,656 unique URLs needs review. It may be normal Shopify duplication in generated sitemaps, but it aligns with Semrush's orphaned-page and weak-internal-link findings.
+
+### Sample Page Findings
+
+Several sampled HTML pages exceeded the first 1 MB fetched, including home, collection, product, page, and blog surfaces. This supports Semrush's "large HTML page size" and "too much content" findings.
+
+Sample observations:
+
+| Page type | Example | Finding |
+| --- | --- | --- |
+| Home | `/` | Title length 88; first 1 MB fetched; 55 image tags; 4 missing alt attributes in first MB. |
+| Collection | `/collections/frontpage` | First 1 MB fetched; no meta description detected in first MB; 4 missing alt attributes. |
+| Product | `/products/flex-traffic-lane-clnr-3-78ltr` | First 1 MB fetched; meta description length 304; 6 missing alt attributes. |
+| Page | `/pages/wish-list` | First 1 MB fetched; no meta description detected; 4 missing alt attributes. |
+| Blog index | `/blogs/news` | First 1 MB fetched; no meta description detected; 4 missing alt attributes. |
+
+No `application/ld+json` blocks were detected in the first 1 MB of sampled HTML. The invalid structured data issue should be inspected in Semrush and Google Rich Results after the current crawl is rerun, because Shopify themes can emit structured data after the sampled slice or through app/theme snippets.
+
+## Highest-Impact Repair Queue
+
+### P0 - Score And Crawl Health
+
+1. **Rerun Semrush Site Audit after recording this baseline.**  
+   The audit is stale and already disagrees with live `/llms.txt` and `/agents.md`.
+
+2. **Reduce Shopify theme/page HTML weight.**  
+   Target the 196 pages over Semrush's HTML-size threshold and the 196 pages flagged for AI "too much content".
+
+3. **Resolve sitemap orphan/internal-link structure.**  
+   Prioritize pages in sitemaps with one or zero internal links, especially products and collections that should rank or convert.
+
+4. **Fix invalid structured data.**  
+   Inspect the exact Semrush issue detail and Google Rich Results output after rerun. Ensure Product, Organization, Breadcrumb, and LocalBusiness schema are valid and not duplicated/conflicting.
+
+### P1 - AI Search And Crawlability
+
+5. **Confirm `llms.txt` clears in Semrush.**  
+   Live site returns `200`, so this should be marked fixed after rerun.
+
+6. **Review blocked pages/resources.**  
+   Shopify correctly blocks private/transactional routes. Only fix blocked resources if the blocked resource is required for rendering crawlable content.
+
+7. **Add or tune internal links between equipment, service, chemicals, and training pathways.**  
+   This directly addresses weak internal linking and supports CCW/CARSI ecosystem discovery without mixing ownership of the two sites.
+
+### P2 - Content Quality
+
+8. **Fix missing image alt text on key templates.**
+9. **Shorten the one overlong title tag.**
+10. **Add/repair meta descriptions on thin Shopify page, collection, and blog templates.**
+11. **Review unminified JS/CSS warnings, but only after theme/app bloat is understood.**
+
+## Keyword Tracking Fix
+
+The current tracked keyword set is too broad. Add a practical Australian keyword set grouped by purchase intent:
+
+| Cluster | Example keywords |
+| --- | --- |
+| Equipment | carpet cleaning equipment, carpet cleaning machine, truckmount carpet cleaner, portable carpet cleaner |
+| Chemicals | carpet cleaning chemicals, upholstery cleaning chemicals, stain removal chemicals, tile cleaning chemicals |
+| Service | carpet cleaning machine service, truckmount servicing, carpet extractor repair, carpet cleaning equipment repairs |
+| Business growth | start a carpet cleaning business, carpet cleaning business equipment, carpet cleaning training Australia |
+| Local/brand | carpet cleaners warehouse, CCW carpet cleaners warehouse, carpet cleaning supplies Brisbane, carpet cleaning supplies Sydney, carpet cleaning supplies Melbourne |
+
+## Toby-Facing Before/After Metrics
+
+Use this scorecard for the repair presentation.
+
+| Metric | Baseline | After repairs |
+| --- | ---: | ---: |
+| Site Health | 86% | TBD |
+| AI Search Health | 75% | TBD |
+| Errors | 197 | TBD |
+| Warnings | 9 | TBD |
+| Pages with large HTML | 196 | TBD |
+| Pages with too much AI-search content | 196 | TBD |
+| Orphaned pages in sitemaps | 2,690 | TBD |
+| Pages with only one internal link | 197 | TBD |
+| Position Tracking visibility | 0% | TBD |
+| Tracked keywords in Top 10 | 0 | TBD |
+| AI Visibility Australia | 15 | TBD |
+| AI mentions Australia | 33 | TBD |
+| AI cited pages Australia | 80 | TBD |
+
+## Recommended Next Step
+
+Run repairs in this order:
+
+1. Rerun Semrush crawl or record the current stale Semrush baseline as the "before" state.
+2. Fix theme/page bloat and template-level HTML weight.
+3. Fix internal-link architecture and sitemap orphan issues.
+4. Validate structured data.
+5. Replace broad tracked keywords with CCW-specific Australian commercial terms.
+6. Rerun Semrush and complete the "After repairs" column.
+

--- a/docs/audit-reports/ccw-semrush-seo-recheck-2026-07-02.md
+++ b/docs/audit-reports/ccw-semrush-seo-recheck-2026-07-02.md
@@ -1,0 +1,79 @@
+# CCW SEO Repair — Live Recheck 02/07/2026 (pre-implementation "before" numbers)
+
+Companion to `ccw-semrush-seo-baseline-2026-06-18.md`. Gathered 02/07/2026 ~22:30 AEST
+during the UNI-2156 implementation session, before any Shopify-side change. Static-HTML
+numbers via direct HTTP fetch (curl, audit user-agent); rendered-DOM numbers via a
+browser session on the live site.
+
+## Sitemap (unchanged since baseline)
+
+- Child sitemaps: 5
+- Total entries: 2,905
+- Unique entries: 1,656
+- Duplicate entries: 1,249
+
+## Sampled page weight (static HTML, 8 pages)
+
+| Page | Bytes | Script tags (static) |
+|---|---:|---:|
+| `/` (home) | 2,367,026 | 120 |
+| `/products/1-4-inch-brass-strainer-body` | 2,304,207 | 112 |
+| `/products/1-5ltr-volkenex-viton-hand-sprayer` | 2,319,660 | 113 |
+| `/products/120ml-4oz-measuring-cup` | 2,303,274 | 112 |
+| `/collections/3m` | 2,404,027 | 103 |
+| `/collections/accessories` | 2,498,457 | 110 |
+| `/pages/about-us` | 2,307,190 | 97 |
+| `/blogs/home` | 2,301,648 | 97 |
+
+All sampled pages remain 2.30–2.50 MB — the baseline's 196-page "too large HTML"
+population is un-remediated. Rendered DOM is heavier still: 152 script tags on the
+homepage (68 external / 84 inline), 145 on a product page.
+
+## Payload attribution (homepage)
+
+External hosts by reference count: `cdn.shopify.com` ×12–15, `googletagmanager.com` ×6,
+`zooomyapps.com` ×4, `gravity-software.com` ×4, `connect.facebook.net` ×3,
+`maxcdn.bootstrapcdn.com` ×3 (Bootstrap 3.3.7), `cp.boldapps.net` ×2 (Bold),
+Mailchimp, Hextom, POWr, Hotjar ×2, Quantcast, `ajax.googleapis.com` (jQuery 3.2.1),
+`ajax.aspnetcdn.com`; product pages additionally load Zip (`bpi.zip.co`,
+`static.zipmoney.com.au`). Inline Globo pre-order/menus config blocks dominate inline
+script volume (globopreorderparams / globomenus markers ×30+).
+
+No single dominant file: the driver is ~68–70 external requests per page plus 75–84
+inline blocks from app embeds layered on a legacy theme that ships jQuery 3.2.1 and
+Bootstrap 3.3.7 from the product-template section.
+
+## Invalid homepage structured data — root cause (pinned)
+
+The homepage emits **no JSON-LD**. The invalid item is **microdata**: exactly one
+`itemscope itemtype="http://schema.org/Product"` element (static HTML line ~3841):
+
+```html
+<div itemscope itemtype="http://schema.org/Product" id="ProductSection"
+  data-section-id="1500036668254" data-section-type="product-template" ...>
+```
+
+It is the theme's **product-template section rendered on the homepage without a product
+context** (wrapped in `<div id="shopify-section-1500036668254" class="shopify-section">`),
+so the Product wrapper renders with **no `name` and no `offers`** — the two invalid
+fields Semrush reports. On real product pages the identical section renders valid
+schema. The same section also injects the jQuery 3.2.1 / Bootstrap 3.3.7 loads.
+
+## Proposed fix (approval-gated — no theme change made)
+
+1. Remove the stale product-template section `1500036668254` from the homepage template
+   (preferred), or gate its `itemscope`/`itemtype` attributes in Liquid so Product
+   schema emits only when a product object is present.
+2. Homepage schema should be Organization / WebSite / BreadcrumbList / LocalBusiness
+   only; Product schema reserved for product templates.
+3. Bloat reduction order of attack: audit/remove unused app embeds (Bold, Zooomy,
+   Hextom, POWr, Quantcast candidates), consolidate Globo inline config, retire the
+   jQuery 3.2.1 + Bootstrap 3.3.7 loads with the same section removal.
+
+## Session status
+
+- Semrush Site Audit re-crawl of project "Carpet Cleaners Warehouse" triggered
+  02/07/2026 ~22:30 AEST (previous crawl 03/02/2026); JS rendering currently Disabled.
+- Shopify crawler signature NOT yet saved — blocked at Shopify admin login
+  (`accounts.shopify.com/lookup`); requires the store owner's session.
+- No Shopify theme, app, or content change was made.

--- a/docs/runbooks/ccw-seo-repair-loop.md
+++ b/docs/runbooks/ccw-seo-repair-loop.md
@@ -1,0 +1,128 @@
+# CCW SEO Repair Loop
+
+Use this runbook to move `ccwonline.com.au` from the Semrush baseline toward a clean audit without mixing CCW-CRM code changes with Shopify storefront changes.
+
+## Trigger
+
+- Toby needs a before/after SEO, AI-search, or Semrush repair report.
+- Semrush Site Audit shows regressions for `ccwonline.com.au`.
+- Google/Bing/Search Console or LLM discovery work needs current public-site evidence.
+
+## Guardrails
+
+- CCW-CRM is not the Shopify theme repo.
+- Do not publish Shopify theme, product, collection, page, or public website copy changes without explicit approval immediately before the save/publish action.
+- Use live checks before relying on stale Semrush findings. The 2026-06-18 baseline showed Semrush still reported `llms.txt` missing even though the live site returned `200`.
+
+## First Response
+
+1. Run the local public-site audit:
+
+   ```bash
+   npm run audit:ccw-seo -- --sample-size=24
+   ```
+
+2. Save a JSON evidence bundle when preparing a Toby-facing report:
+
+   ```bash
+   npm run audit:ccw-seo -- --sample-size=40 --json > docs/audit-reports/ccw-seo-live-$(date +%F).json
+   ```
+
+3. Open Semrush Site Audit for the `Carpet Cleaners Warehouse` project and rerun the campaign after repairs.
+
+4. If Semrush shows the Shopify signature service message, generate the signature values in Shopify first, then save them in Semrush:
+   - Signature Agent: `"https://shopify.com"`
+   - Signature Input: generated in the Shopify profile
+   - Signature: generated in the Shopify profile
+
+   This was visible in Semrush on 2026-06-18. It cannot be completed from CCW-CRM alone, and the browser was not signed into the CCW Shopify admin session during the repair pass.
+
+## Repair Order
+
+### P0 - Crawl Weight And AI Search Health
+
+Reduce the Shopify HTML payload on product, collection, blog, and home templates. Prioritize:
+
+- repeated app blocks injected into every page;
+- oversized product option/data JSON rendered into HTML;
+- unused review, popup, tracking, chat, and merchandising snippets;
+- duplicated section content rendered for desktop and mobile at the same time;
+- collection pages rendering too many products or hidden filters in source HTML.
+
+The 2026-06-18 public product-page source check showed a single product page at roughly 2.35 MB with 111 script tags. The first repair inspection should review Shopify app/theme sources including Bold upsell assets, Globo preorder/menu assets, Zooomy wishlist/collection assets, Zip widgets, Mailchimp embeds, jQuery/Bootstrap bundles, and legacy custom theme CSS/JS.
+
+Success signal: the local audit samples fewer pages over 1 MB, then Semrush reduces the `large HTML page size` and `too much content` findings.
+
+### P0 - Structured Data
+
+Inspect the exact Semrush structured-data URL and validate it with Google Rich Results Test. Fix duplicate or malformed Product, Organization, BreadcrumbList, and LocalBusiness schema in the Shopify theme/app snippets.
+
+Current Semrush target from the 2026-02-03 crawl:
+
+- URL: `https://ccwonline.com.au/`
+- Issue: `1 structured data item is invalid`
+- Structured data type: `Product snippet`
+- Affected fields: `2 fields`
+- Semrush issue detail: check `45`
+
+The home page should not emit Product schema unless it is describing a real primary product with valid required fields. Prefer Organization, WebSite, BreadcrumbList, and LocalBusiness schema on the home page; reserve Product schema for product pages.
+
+Success signal: Semrush structured-data error count reaches `0`.
+
+### P0 - Internal Linking
+
+Strengthen internal links between:
+
+- professional equipment;
+- repairs and machine service;
+- chemicals and stain removal;
+- CCW/CARSI training pathways.
+
+Use contextual links from collections, product descriptions, blog posts, and educational pages. Keep CARSI ownership separate from CCW-CRM while making the customer journey visible.
+
+Success signal: Semrush reduces `orphaned pages in sitemaps` and `only one incoming internal link`.
+
+### P1 - Crawlability And AI Discovery
+
+Confirm these live discovery surfaces stay healthy:
+
+- `https://ccwonline.com.au/robots.txt`
+- `https://ccwonline.com.au/sitemap.xml`
+- `https://ccwonline.com.au/llms.txt`
+- `https://ccwonline.com.au/agents.md`
+- `https://ccwonline.com.au/.well-known/ucp`
+
+Only change robots rules when the blocked resource is required for rendering public crawlable content.
+
+### P2 - Content Hygiene
+
+Fix missing image alt attributes, overlong titles, weak/missing meta descriptions, and low text-to-HTML pages on templates first. Template fixes clear more audit debt than one-off product edits.
+
+## Semrush Keyword Tracking Repair
+
+Replace broad tracked keywords with Australian commercial-intent groups:
+
+- carpet cleaning equipment;
+- carpet cleaning machine;
+- truckmount carpet cleaner;
+- portable carpet cleaner;
+- carpet cleaning chemicals;
+- upholstery cleaning chemicals;
+- stain removal chemicals;
+- tile cleaning chemicals;
+- carpet cleaning machine service;
+- truckmount servicing;
+- carpet extractor repair;
+- carpet cleaners warehouse;
+- carpet cleaning supplies Brisbane;
+- carpet cleaning supplies Sydney;
+- carpet cleaning supplies Melbourne;
+- start a carpet cleaning business;
+- carpet cleaning training Australia.
+
+## Done When
+
+- A fresh Semrush crawl is newer than the repair work.
+- The local audit output is saved with the post-repair report.
+- Toby can compare the baseline in `docs/audit-reports/ccw-semrush-seo-baseline-2026-06-18.md` against the fresh Semrush numbers.
+- Any public Shopify changes have an approval trail and are listed in the report.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "type-check": "tsc --noEmit",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "db:migrate": "prisma migrate dev"
+    "db:migrate": "prisma migrate dev",
+    "audit:ccw-seo": "node scripts/audit-ccw-seo.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/scripts/audit-ccw-seo.mjs
+++ b/scripts/audit-ccw-seo.mjs
@@ -1,0 +1,468 @@
+#!/usr/bin/env node
+
+const DEFAULT_SITE = 'https://ccwonline.com.au';
+const DEFAULT_SAMPLE_SIZE = 24;
+const REQUEST_TIMEOUT_MS = 15000;
+
+const args = parseArgs(process.argv.slice(2));
+const site = normaliseSite(args.site || DEFAULT_SITE);
+const sampleSize = Number.parseInt(args['sample-size'] || `${DEFAULT_SAMPLE_SIZE}`, 10);
+const outputJson = Boolean(args.json);
+
+const userAgent = 'CCW-CRM SEO Repair Audit/1.0 (+https://github.com/CleanExpo/CCW-CRM)';
+
+main().catch((error) => {
+  console.error(`Audit failed: ${error.message}`);
+  process.exitCode = 1;
+});
+
+async function main() {
+  const startedAt = new Date().toISOString();
+  const discovery = await checkDiscovery(site);
+  const sitemap = await crawlSitemapIndex(`${site}/sitemap.xml`);
+  const sampledUrls = chooseSample(sitemap.urls, sampleSize);
+  const pages = await mapLimit(sampledUrls, 4, (url) => auditPage(url));
+
+  const result = {
+    site,
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    discovery,
+    sitemap: summariseSitemap(sitemap),
+    pages,
+    findings: summariseFindings(discovery, sitemap, pages),
+  };
+
+  if (outputJson) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  printHumanSummary(result);
+}
+
+function parseArgs(rawArgs) {
+  const parsed = {};
+
+  for (const arg of rawArgs) {
+    if (arg === '--json') {
+      parsed.json = true;
+      continue;
+    }
+
+    if (arg.startsWith('--') && arg.includes('=')) {
+      const [key, ...valueParts] = arg.slice(2).split('=');
+      parsed[key] = valueParts.join('=');
+    }
+  }
+
+  return parsed;
+}
+
+function normaliseSite(value) {
+  return value.replace(/\/+$/, '');
+}
+
+async function checkDiscovery(baseUrl) {
+  const paths = ['/robots.txt', '/sitemap.xml', '/llms.txt', '/agents.md', '/.well-known/ucp'];
+  const checks = {};
+
+  for (const path of paths) {
+    const url = `${baseUrl}${path}`;
+    const response = await fetchText(url);
+    checks[path] = {
+      url,
+      status: response.status,
+      ok: response.ok,
+      contentType: response.contentType,
+      bytes: response.bytes,
+    };
+  }
+
+  return checks;
+}
+
+async function crawlSitemapIndex(sitemapUrl) {
+  const index = await fetchText(sitemapUrl);
+  const childSitemaps = extractLocs(index.body);
+  const sitemapEntries = [];
+  const urls = [];
+
+  for (const childUrl of childSitemaps) {
+    const child = await fetchText(childUrl);
+    const childUrls = extractLocs(child.body);
+    sitemapEntries.push({
+      url: childUrl,
+      status: child.status,
+      ok: child.ok,
+      entries: childUrls.length,
+    });
+    urls.push(...childUrls.map((url) => ({ url, sitemap: childUrl })));
+  }
+
+  return {
+    index: {
+      url: sitemapUrl,
+      status: index.status,
+      ok: index.ok,
+      childSitemaps: childSitemaps.length,
+    },
+    sitemaps: sitemapEntries,
+    urls,
+  };
+}
+
+function extractLocs(xml) {
+  const locs = [];
+  const locPattern = /<loc>\s*([^<]+?)\s*<\/loc>/gi;
+  let match;
+
+  while ((match = locPattern.exec(xml)) !== null) {
+    locs.push(decodeXml(match[1].trim()));
+  }
+
+  return locs;
+}
+
+function decodeXml(value) {
+  return value
+    .replaceAll('&amp;', '&')
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&apos;', "'");
+}
+
+function summariseSitemap(sitemap) {
+  const uniqueUrls = new Set(sitemap.urls.map((entry) => entry.url));
+  const duplicateUrls = sitemap.urls.length - uniqueUrls.size;
+  const byType = {};
+
+  for (const entry of uniqueUrls) {
+    const type = classifyUrl(entry);
+    byType[type] = (byType[type] || 0) + 1;
+  }
+
+  return {
+    index: sitemap.index,
+    sitemaps: sitemap.sitemaps,
+    totalEntries: sitemap.urls.length,
+    uniqueEntries: uniqueUrls.size,
+    duplicateEntries: duplicateUrls,
+    byType,
+  };
+}
+
+function chooseSample(urlEntries, limit) {
+  const seen = new Set();
+  const buckets = new Map();
+
+  for (const entry of urlEntries) {
+    if (seen.has(entry.url)) {
+      continue;
+    }
+    seen.add(entry.url);
+
+    const type = classifyUrl(entry.url);
+    if (!buckets.has(type)) {
+      buckets.set(type, []);
+    }
+    buckets.get(type).push(entry.url);
+  }
+
+  const typeOrder = ['home', 'page', 'collection', 'product', 'blog', 'other'];
+  const sample = [];
+
+  for (const type of typeOrder) {
+    const urls = buckets.get(type) || [];
+    const typeLimit = Math.max(1, Math.floor(limit / typeOrder.length));
+    sample.push(...urls.slice(0, typeLimit));
+  }
+
+  for (const urls of buckets.values()) {
+    for (const url of urls) {
+      if (sample.length >= limit) {
+        return sample;
+      }
+      if (!sample.includes(url)) {
+        sample.push(url);
+      }
+    }
+  }
+
+  return sample.slice(0, limit);
+}
+
+function classifyUrl(url) {
+  const { pathname } = new URL(url);
+
+  if (pathname === '/') {
+    return 'home';
+  }
+  if (pathname.startsWith('/products/')) {
+    return 'product';
+  }
+  if (pathname.startsWith('/collections/')) {
+    return 'collection';
+  }
+  if (pathname.startsWith('/blogs/')) {
+    return 'blog';
+  }
+  if (pathname.startsWith('/pages/')) {
+    return 'page';
+  }
+
+  return 'other';
+}
+
+async function auditPage(url) {
+  const response = await fetchText(url);
+  const html = response.body || '';
+  const isHtml = /text\/html|application\/xhtml\+xml/i.test(response.contentType);
+
+  if (!isHtml) {
+    return {
+      url,
+      type: classifyUrl(url),
+      status: response.status,
+      ok: response.ok,
+      contentType: response.contentType,
+      bytes: response.bytes,
+      title: '',
+      titleLength: 0,
+      metaDescription: '',
+      metaDescriptionLength: 0,
+      canonical: '',
+      imageCount: 0,
+      missingAltCount: 0,
+      jsonLdBlockCount: 0,
+      jsonLdParseErrors: 0,
+      warnings: [],
+    };
+  }
+
+  const title = firstMatch(html, /<title[^>]*>([\s\S]*?)<\/title>/i);
+  const metaDescription = firstMatch(
+    html,
+    /<meta[^>]+name=["']description["'][^>]+content=["']([^"']*)["'][^>]*>/i
+  );
+  const canonical = firstMatch(
+    html,
+    /<link[^>]+rel=["']canonical["'][^>]+href=["']([^"']*)["'][^>]*>/i
+  );
+  const images = Array.from(html.matchAll(/<img\b[^>]*>/gi)).map((match) => match[0]);
+  const missingAlt = images.filter((tag) => !/\salt\s*=\s*["'][^"']*["']/i.test(tag));
+  const assets = Array.from(
+    html.matchAll(/<(script|link|img)[^>]+(?:src|href)=["']([^"']+)["']/gi)
+  ).map((match) => match[2]);
+  const jsonLdBlocks = Array.from(
+    html.matchAll(/<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi)
+  ).map((match) => match[1].trim());
+
+  return {
+    url,
+    type: classifyUrl(url),
+    status: response.status,
+    ok: response.ok,
+    contentType: response.contentType,
+    bytes: response.bytes,
+    title: cleanText(title),
+    titleLength: cleanText(title).length,
+    metaDescription: cleanText(metaDescription),
+    metaDescriptionLength: cleanText(metaDescription).length,
+    canonical,
+    scriptTagCount: countMatches(html, /<script\b/gi),
+    linkTagCount: countMatches(html, /<link\b/gi),
+    imageCount: images.length,
+    missingAltCount: missingAlt.length,
+    assetHostCounts: countAssetHosts(assets, url),
+    jsonLdBlockCount: jsonLdBlocks.length,
+    jsonLdParseErrors: jsonLdBlocks.filter((block) => !isJson(block)).length,
+    warnings: pageWarnings({
+      bytes: response.bytes,
+      title: cleanText(title),
+      metaDescription: cleanText(metaDescription),
+      missingAltCount: missingAlt.length,
+      jsonLdBlocks,
+    }),
+  };
+}
+
+function pageWarnings({ bytes, title, metaDescription, missingAltCount, jsonLdBlocks }) {
+  const warnings = [];
+
+  if (bytes >= 1_000_000) {
+    warnings.push('html_over_1mb');
+  }
+  if (!title) {
+    warnings.push('missing_title');
+  } else if (title.length > 60) {
+    warnings.push('long_title');
+  }
+  if (!metaDescription) {
+    warnings.push('missing_meta_description');
+  } else if (metaDescription.length > 160) {
+    warnings.push('long_meta_description');
+  }
+  if (missingAltCount > 0) {
+    warnings.push('missing_image_alt');
+  }
+  if (jsonLdBlocks.length === 0) {
+    warnings.push('no_json_ld_detected');
+  }
+
+  return warnings;
+}
+
+function firstMatch(value, pattern) {
+  const match = value.match(pattern);
+  return match ? match[1] : '';
+}
+
+function countMatches(value, pattern) {
+  return (value.match(pattern) || []).length;
+}
+
+function countAssetHosts(assets, pageUrl) {
+  const counts = {};
+
+  for (const asset of assets) {
+    let host = 'relative';
+    try {
+      host = new URL(asset, pageUrl).host;
+    } catch {
+      // Keep the relative fallback.
+    }
+    counts[host] = (counts[host] || 0) + 1;
+  }
+
+  return Object.fromEntries(
+    Object.entries(counts)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 12)
+  );
+}
+
+function cleanText(value) {
+  return decodeHtml(value || '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function decodeHtml(value) {
+  return value
+    .replaceAll('&amp;', '&')
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&#39;', "'");
+}
+
+function isJson(value) {
+  try {
+    JSON.parse(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function summariseFindings(discovery, sitemap, pages) {
+  const pageWarningCounts = {};
+
+  for (const page of pages) {
+    for (const warning of page.warnings) {
+      pageWarningCounts[warning] = (pageWarningCounts[warning] || 0) + 1;
+    }
+  }
+
+  return {
+    discoveryFailures: Object.entries(discovery)
+      .filter(([, check]) => !check.ok)
+      .map(([path]) => path),
+    duplicateSitemapEntries:
+      sitemap.urls.length - new Set(sitemap.urls.map((entry) => entry.url)).size,
+    sampledPages: pages.length,
+    pageWarningCounts,
+  };
+}
+
+async function fetchText(url) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        accept: 'text/html,application/xhtml+xml,application/xml,text/plain,*/*',
+        'user-agent': userAgent,
+      },
+    });
+    const body = await response.text();
+
+    return {
+      status: response.status,
+      ok: response.ok,
+      contentType: response.headers.get('content-type') || '',
+      bytes: Buffer.byteLength(body),
+      body,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function mapLimit(values, limit, worker) {
+  const results = [];
+  let index = 0;
+
+  async function run() {
+    while (index < values.length) {
+      const currentIndex = index;
+      index += 1;
+      results[currentIndex] = await worker(values[currentIndex]);
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(limit, values.length) }, run));
+  return results;
+}
+
+function printHumanSummary(result) {
+  console.log(`# CCW SEO Repair Audit`);
+  console.log(`Site: ${result.site}`);
+  console.log(`Started: ${result.startedAt}`);
+  console.log(`Finished: ${result.finishedAt}`);
+  console.log('');
+
+  console.log('Discovery surfaces');
+  for (const [path, check] of Object.entries(result.discovery)) {
+    console.log(`- ${path}: ${check.status} (${check.bytes} bytes)`);
+  }
+  console.log('');
+
+  console.log('Sitemap');
+  console.log(`- Child sitemaps: ${result.sitemap.index.childSitemaps}`);
+  console.log(`- Total entries: ${result.sitemap.totalEntries}`);
+  console.log(`- Unique entries: ${result.sitemap.uniqueEntries}`);
+  console.log(`- Duplicate entries: ${result.sitemap.duplicateEntries}`);
+  console.log(`- By type: ${JSON.stringify(result.sitemap.byType)}`);
+  console.log('');
+
+  console.log('Sampled page warnings');
+  for (const [warning, count] of Object.entries(result.findings.pageWarningCounts)) {
+    console.log(`- ${warning}: ${count}`);
+  }
+  console.log('');
+
+  console.log('Sampled pages');
+  for (const page of result.pages) {
+    console.log(
+      `- ${page.status} ${page.type} ${page.url} | ${page.bytes} bytes | title ${page.titleLength} | meta ${page.metaDescriptionLength} | scripts ${page.scriptTagCount || 0} | missing alt ${page.missingAltCount} | JSON-LD ${page.jsonLdBlockCount}/${page.jsonLdParseErrors} parse errors`
+    );
+    if (page.assetHostCounts && Object.keys(page.assetHostCounts).length > 0) {
+      console.log(`  asset hosts: ${JSON.stringify(page.assetHostCounts)}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
The CCW-CRM history rewrite (repo replaced with the Next.js ERP) orphaned commit `f1ccd3c1` — the SEO repair audit loop that [UNI-2156](https://linear.app/unite-group/issue/UNI-2156) depends on. This re-lands it and adds tonight's pre-implementation numbers.

- Restored from `f1ccd3c1` (fetched via GitHub contents API; content reviewed line-by-line — read-only HTTP audit, stdout only): `scripts/audit-ccw-seo.mjs`, `docs/runbooks/ccw-seo-repair-loop.md`, `docs/audit-reports/ccw-semrush-seo-baseline-2026-06-18.md`, plus the `audit:ccw-seo` npm script entry.
- New: `docs/audit-reports/ccw-semrush-seo-recheck-2026-07-02.md` — sitemap duplicates unchanged (2,905/1,656/1,249), sampled pages still 2.30–2.50 MB @ 97–120 static script tags, and the invalid homepage Product schema pinned to theme section `1500036668254` (product-template rendered on the homepage with no product context → missing `name` + `offers`).

Docs + standalone script only — no ERP app code touched.

Opened as **draft** per the standing agent-PR rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)