### PR TITLE
fix: feature-flag AI quote generator wired to missing endpoint (UNI-2120)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1135,6 +1135,9 @@ NEXT_PUBLIC_AI_ENABLED=true
 NEXT_PUBLIC_FEATURE_VOICE_ASSISTANT=false
 NEXT_PUBLIC_FEATURE_AI_INSIGHTS=true
 NEXT_PUBLIC_FEATURE_MULTI_STORE=true
+# Keep false until /api/ai/generate/quote is implemented (UNI-2120) —
+# the quote-form AI generator 404s without it.
+NEXT_PUBLIC_FEATURE_AI_QUOTE_GENERATOR=false
 
 # ============================================
 # Analytics (OPTIONAL)
@@ -1200,6 +1203,9 @@ NEXT_PUBLIC_SENTRY_DSN=
 NEXT_PUBLIC_FEATURE_VOICE_ASSISTANT=false
 NEXT_PUBLIC_FEATURE_AI_INSIGHTS=true
 NEXT_PUBLIC_FEATURE_MULTI_STORE=true
+# Keep false until /api/ai/generate/quote is implemented (UNI-2120) —
+# the quote-form AI generator 404s without it.
+NEXT_PUBLIC_FEATURE_AI_QUOTE_GENERATOR=false
 
 # =============================================================================
 # Former file: apps/web/.env.production.local.example
@@ -1256,6 +1262,9 @@ NEXT_PUBLIC_SENTRY_DSN=
 NEXT_PUBLIC_FEATURE_VOICE_ASSISTANT=false
 NEXT_PUBLIC_FEATURE_AI_INSIGHTS=true
 NEXT_PUBLIC_FEATURE_MULTI_STORE=true
+# Keep false until /api/ai/generate/quote is implemented (UNI-2120) —
+# the quote-form AI generator 404s without it.
+NEXT_PUBLIC_FEATURE_AI_QUOTE_GENERATOR=false
 
 # ============================================
 # HOW TO GET YOUR CREDENTIALS

--- a/src/app/(dashboard)/dashboard/operations/quotes/components/QuoteForm.tsx
+++ b/src/app/(dashboard)/dashboard/operations/quotes/components/QuoteForm.tsx
@@ -79,6 +79,9 @@ export function QuoteForm({ quote, open, onOpenChange, onSuccess }: QuoteFormPro
   const [lineItemErrors, setLineItemErrors] = useState<string[]>([]);
   const [selectedLocation, setSelectedLocation] = useState<string>('brisbane');
   const [aiDialogOpen, setAiDialogOpen] = useState(false); // PHASE C: AI dialog state
+  // Gated off by default: /api/ai/generate/quote is not implemented, so the
+  // generator 404s on every use (UNI-2120). Enable once the endpoint exists.
+  const aiQuoteGeneratorEnabled = process.env.NEXT_PUBLIC_FEATURE_AI_QUOTE_GENERATOR === 'true';
   const { toast } = useToast();
   const isEdit = !!quote;
 
@@ -286,7 +289,7 @@ export function QuoteForm({ quote, open, onOpenChange, onSuccess }: QuoteFormPro
           <DialogHeader>
             <DialogTitle className="flex w-full items-center justify-between">
               <span>{isEdit ? 'Edit Quote' : 'Create Quote'}</span>
-              {!isEdit && (
+              {!isEdit && aiQuoteGeneratorEnabled && (
                 <Button
                   variant="outline"
                   size="sm"
@@ -487,12 +490,14 @@ export function QuoteForm({ quote, open, onOpenChange, onSuccess }: QuoteFormPro
       </Dialog>
 
       {/* PHASE C: AI Quote Assistant */}
-      <AIQuoteGenerator
-        open={aiDialogOpen}
-        onOpenChange={setAiDialogOpen}
-        customerId={form.watch('customer_id')}
-        onQuoteGenerated={handleAIQuoteGenerated}
-      />
+      {aiQuoteGeneratorEnabled && (
+        <AIQuoteGenerator
+          open={aiDialogOpen}
+          onOpenChange={setAiDialogOpen}
+          customerId={form.watch('customer_id')}
+          onQuoteGenerated={handleAIQuoteGenerated}
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary
Working [UNI-2120](https://linear.app/unite-group/issue/UNI-2120)'s feature-flag acceptance path. The quote form's **Generate with AI** button (`QuoteForm.tsx`) posts to `/api/ai/generate/quote` via `src/lib/api/ai-generate.ts:75` — that route does not exist in this codebase (`src/app/api/ai/generate/` is absent), so every click ships a guaranteed 404 to the user. The conversational `/api/ai/copilot/quote` route that DOES exist has a different contract (chat preview vs structured quote with SKUs/stock/tax), so it is not a drop-in target.

## Change
- Gate the button and the `AIQuoteGenerator` mount behind `NEXT_PUBLIC_FEATURE_AI_QUOTE_GENERATOR === 'true'` (default off).
- Document the flag in all three `.env.example` blocks with the why.

Re-enabling later = implement the endpoint, flip the flag. The legacy `generateEmail`/`generateSummary` clients point at equally-missing routes but have no live UI callers found — left untouched.

## Verification
- `npm run type-check` → clean (exit 0)
- `eslint QuoteForm.tsx` → clean (exit 0)
- `npm test` → 42 files / 321 tests passed

Opened as **draft** per the standing agent-PR rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)