### PR TITLE
fix: land received PO stock in the delivery warehouse location (UNI-2119)

### DIFF
--- a/src/app/api/purchase-orders/[id]/items/[itemId]/receive/__tests__/route.test.ts
+++ b/src/app/api/purchase-orders/[id]/items/[itemId]/receive/__tests__/route.test.ts
@@ -1,0 +1,143 @@
+/**
+ * UNI-2119: PO item receive must move stock into the PO's delivery warehouse
+ * (ProductLocationStock), not just the global Product.stock counter, and must
+ * reject duplicate/over-receipt.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@/lib/auth/data-scope', () => ({
+  requireAuthScope: vi.fn(),
+}));
+
+vi.mock('@/lib/db/prisma', () => ({
+  prisma: {
+    purchaseOrderLine: { findFirst: vi.fn(), findMany: vi.fn(), update: vi.fn() },
+    product: { update: vi.fn() },
+    productLocationStock: { upsert: vi.fn() },
+    purchaseOrder: { update: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/db/purchase-order-serialize', () => ({
+  purchaseOrderToApi: vi.fn((po: unknown) => po),
+}));
+
+import { requireAuthScope } from '@/lib/auth/data-scope';
+import { prisma } from '@/lib/db/prisma';
+import { POST as receivePost } from '@/app/api/purchase-orders/[id]/items/[itemId]/receive/route';
+
+const OWNER = 'owner-uuid';
+const PO_ID = 'po-uuid';
+const LINE_ID = 'line-uuid';
+const PRODUCT_ID = 'product-uuid';
+
+function makeRequest(body: unknown) {
+  return new Request(`http://localhost/api/purchase-orders/${PO_ID}/items/${LINE_ID}/receive`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  }) as never;
+}
+
+const params = { params: Promise.resolve({ id: PO_ID, itemId: LINE_ID }) };
+
+function makeLine(overrides: Partial<{ quantity: number; quantityReceived: number; deliveryLocation: string }> = {}) {
+  return {
+    id: LINE_ID,
+    purchaseOrderId: PO_ID,
+    productId: PRODUCT_ID,
+    quantity: overrides.quantity ?? 10,
+    quantityReceived: overrides.quantityReceived ?? 0,
+    product: { id: PRODUCT_ID },
+    purchaseOrder: { deliveryLocation: overrides.deliveryLocation ?? 'Sydney' },
+  };
+}
+
+describe('UNI-2119 PO item receive', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireAuthScope).mockResolvedValue({ userId: OWNER, role: 'owner', isAdmin: true } as never);
+    vi.mocked(prisma.$transaction).mockImplementation(async (fn) => fn(prisma));
+    vi.mocked(prisma.purchaseOrderLine.findMany).mockResolvedValue([makeLine()] as never);
+    vi.mocked(prisma.purchaseOrder.update).mockResolvedValue({ id: PO_ID } as never);
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    vi.mocked(requireAuthScope).mockResolvedValue(null as never);
+    const res = await receivePost(makeRequest({ quantity_received: 1 }), params);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when quantity_received is missing or zero', async () => {
+    const res = await receivePost(makeRequest({}), params);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when the line does not exist for this owner', async () => {
+    vi.mocked(prisma.purchaseOrderLine.findFirst).mockResolvedValue(null as never);
+    const res = await receivePost(makeRequest({ quantity_received: 1 }), params);
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects duplicate receipt: receiving again after full receipt returns 400', async () => {
+    vi.mocked(prisma.purchaseOrderLine.findFirst).mockResolvedValue(
+      makeLine({ quantity: 10, quantityReceived: 10 }) as never
+    );
+    const res = await receivePost(makeRequest({ quantity_received: 5 }), params);
+    expect(res.status).toBe(400);
+    expect(prisma.productLocationStock.upsert).not.toHaveBeenCalled();
+    expect(prisma.product.update).not.toHaveBeenCalled();
+  });
+
+  it('moves received stock into the PO delivery warehouse (normalized location)', async () => {
+    vi.mocked(prisma.purchaseOrderLine.findFirst).mockResolvedValue(
+      makeLine({ quantity: 10, quantityReceived: 0, deliveryLocation: 'Sydney' }) as never
+    );
+    const res = await receivePost(makeRequest({ quantity_received: 4 }), params);
+    expect(res.status).toBe(200);
+
+    expect(prisma.productLocationStock.upsert).toHaveBeenCalledWith({
+      where: { productId_location: { productId: PRODUCT_ID, location: 'sydney' } },
+      update: { quantity: { increment: 4 } },
+      create: { productId: PRODUCT_ID, location: 'sydney', quantity: 4 },
+    });
+    expect(prisma.product.update).toHaveBeenCalledWith({
+      where: { id: PRODUCT_ID },
+      data: { stock: { increment: 4 } },
+    });
+    expect(prisma.purchaseOrderLine.update).toHaveBeenCalledWith({
+      where: { id: LINE_ID },
+      data: { quantityReceived: 4 },
+    });
+  });
+
+  it('defaults unknown delivery locations to the primary warehouse', async () => {
+    vi.mocked(prisma.purchaseOrderLine.findFirst).mockResolvedValue(
+      makeLine({ deliveryLocation: 'Springfield Depot' }) as never
+    );
+    const res = await receivePost(makeRequest({ quantity_received: 2 }), params);
+    expect(res.status).toBe(200);
+    expect(prisma.productLocationStock.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { productId_location: { productId: PRODUCT_ID, location: 'brisbane' } },
+      })
+    );
+  });
+
+  it('marks the PO received when all lines are fully received', async () => {
+    vi.mocked(prisma.purchaseOrderLine.findFirst).mockResolvedValue(
+      makeLine({ quantity: 10, quantityReceived: 6 }) as never
+    );
+    vi.mocked(prisma.purchaseOrderLine.findMany).mockResolvedValue([
+      { id: LINE_ID, quantity: 10, quantityReceived: 6 },
+    ] as never);
+    const res = await receivePost(makeRequest({ quantity_received: 4 }), params);
+    expect(res.status).toBe(200);
+    expect(prisma.purchaseOrder.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'received' }),
+      })
+    );
+  });
+});

--- a/src/app/api/purchase-orders/[id]/items/[itemId]/receive/route.ts
+++ b/src/app/api/purchase-orders/[id]/items/[itemId]/receive/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db/prisma';
 import { purchaseOrderToApi } from '@/lib/db/purchase-order-serialize';
 import { requireAuthScope } from '@/lib/auth/data-scope';
+import { normalizeWarehouseLocation } from '@/lib/db/inventory-location-transfer';
 import type { Prisma } from '@prisma/client';
 
 const INCLUDE = {
@@ -32,7 +33,10 @@ export async function POST(
           purchaseOrder: { ownerUserId: scope.userId },
           product: { ownerUserId: scope.userId },
         },
-        include: { product: true },
+        include: {
+          product: true,
+          purchaseOrder: { select: { deliveryLocation: true } },
+        },
       });
       if (!line) {
         throw new Error('LINE_NOT_FOUND');
@@ -50,6 +54,15 @@ export async function POST(
       await tx.product.update({
         where: { id: line.productId },
         data: { stock: { increment: qtyIn } },
+      });
+
+      // UNI-2119: land the received stock in the PO's delivery warehouse, not
+      // just the global counter, so location stock reflects the receipt.
+      const location = normalizeWarehouseLocation(line.purchaseOrder.deliveryLocation);
+      await tx.productLocationStock.upsert({
+        where: { productId_location: { productId: line.productId, location } },
+        update: { quantity: { increment: qtyIn } },
+        create: { productId: line.productId, location, quantity: qtyIn },
       });
 
       const allLines = await tx.purchaseOrderLine.findMany({ where: { purchaseOrderId: poId } });


### PR DESCRIPTION
## Summary
Works [UNI-2119](https://linear.app/unite-group/issue/UNI-2119) against the rewritten codebase (the cited `containers.py` is gone; the live receiving surface is `purchase-orders/[id]/items/[itemId]/receive`).

**Gap:** the receive route updated `purchaseOrderLine.quantityReceived` and incremented the global `Product.stock` counter, but never touched `ProductLocationStock` — received goods never landed in the PO's `deliveryLocation` warehouse.

**Fix (inside the existing `prisma.$transaction`):** upsert `ProductLocationStock` for `(productId, normalizeWarehouseLocation(po.deliveryLocation))`, incrementing by the received quantity. Unknown locations fall back to the primary warehouse per the existing `inventory-location-transfer` helper. No schema change — the model and its `@@unique([productId, location])` key already exist.

## Tests (failing-first)
New `__tests__/route.test.ts` (7 tests, written before the fix — the two warehouse-destination tests failed against the old code): auth 401, missing-quantity 400, line-not-found 404, **duplicate/over-receipt rejected with no stock mutation**, **destination upsert with normalised location**, unknown-location fallback, full-receipt status transition.

## Verification
- Targeted suite: 7/7 pass (2 failed pre-fix, by design)
- `npm run type-check` → exit 0
- `npm test` → 42→43 files, **328 tests passed**

Note for reviewer: the ticket asked for an "inventory movement transaction" — this schema has no movement-ledger model (only `StockTransfer` for location-to-location). Receipt auditability today = `quantityReceived` + location stock deltas inside one transaction; a proper movement ledger would be a schema addition worth its own ticket.

Opened as **draft** per the standing agent-PR rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)