### PR TITLE
fix: replace warehouse ops demo fallbacks with honest empty states

### DIFF
--- a/src/app/(dashboard)/warehouse/page.tsx
+++ b/src/app/(dashboard)/warehouse/page.tsx
@@ -174,6 +174,8 @@ export default function WarehouseOpsPage() {
   const pickQueue = data?.pickQueue ?? [];
   const returnsQueue = data?.returnsQueue ?? [];
   const aiGuidance = data?.aiGuidance ?? [];
+  const returnsConnected = data?.sources?.returns === 'live';
+  const aiGuidanceConnected = data?.sources?.aiGuidance === 'live';
   const lastUpdated = useMemo(() => {
     if (!data?.updatedAt) return null;
     return new Date(data.updatedAt).toLocaleTimeString();
@@ -485,9 +487,11 @@ export default function WarehouseOpsPage() {
               <RefreshCw className="text-muted-foreground h-4 w-4" />
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold">{metrics?.returnsOpen ?? 0}</div>
+              <div className="text-2xl font-bold">
+                {returnsConnected ? (metrics?.returnsOpen ?? 0) : '—'}
+              </div>
               <p className="text-muted-foreground text-xs">
-                {metrics?.returnSlaRisk ?? 0} SLA risk
+                {returnsConnected ? `${metrics?.returnSlaRisk ?? 0} SLA risk` : 'Not connected'}
               </p>
             </CardContent>
           </Card>
@@ -497,8 +501,12 @@ export default function WarehouseOpsPage() {
               <Clock className="text-muted-foreground h-4 w-4" />
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold">{metrics?.onTimeRate ?? 0}%</div>
-              <p className="text-muted-foreground text-xs">Last 7 days</p>
+              <div className="text-2xl font-bold">
+                {metrics?.onTimeRate != null ? `${metrics.onTimeRate}%` : '—'}
+              </div>
+              <p className="text-muted-foreground text-xs">
+                {metrics?.onTimeRate != null ? 'Last 7 days' : 'Not tracked yet'}
+              </p>
             </CardContent>
           </Card>
         </div>
@@ -542,6 +550,11 @@ export default function WarehouseOpsPage() {
                     </div>
                   </CardHeader>
                   <CardContent className="space-y-4">
+                    {receivingQueue.length === 0 ? (
+                      <p className="text-muted-foreground py-6 text-center text-sm">
+                        No inbound shipments scheduled.
+                      </p>
+                    ) : null}
                     {receivingQueue.map((shipment) => (
                       <div
                         key={shipment.id}
@@ -586,6 +599,11 @@ export default function WarehouseOpsPage() {
                     </div>
                   </CardHeader>
                   <CardContent className="space-y-4">
+                    {pickQueue.length === 0 ? (
+                      <p className="text-muted-foreground py-6 text-center text-sm">
+                        No orders in the pick queue.
+                      </p>
+                    ) : null}
                     {pickQueue.map((pick) => (
                       <div
                         key={pick.id}
@@ -626,6 +644,13 @@ export default function WarehouseOpsPage() {
                     </div>
                   </CardHeader>
                   <CardContent className="space-y-4">
+                    {returnsQueue.length === 0 ? (
+                      <p className="text-muted-foreground py-6 text-center text-sm">
+                        {returnsConnected
+                          ? 'No open returns or service cases.'
+                          : 'Returns tracking is not connected yet.'}
+                      </p>
+                    ) : null}
                     {returnsQueue.map((rma) => (
                       <div
                         key={rma.id}
@@ -675,6 +700,13 @@ export default function WarehouseOpsPage() {
                     </CardDescription>
                   </CardHeader>
                   <CardContent className="space-y-4">
+                    {aiGuidance.length === 0 ? (
+                      <p className="text-primary-foreground/70 py-6 text-center text-sm">
+                        {aiGuidanceConnected
+                          ? 'No guidance right now.'
+                          : 'AI guidance is not connected yet.'}
+                      </p>
+                    ) : null}
                     {aiGuidance.map((item) => (
                       <div
                         key={item.title}

--- a/src/app/api/warehouse/ops/route.ts
+++ b/src/app/api/warehouse/ops/route.ts
@@ -4,115 +4,14 @@ import { prisma } from '@/lib/db/prisma';
 import { requireAuthScope } from '@/lib/auth/data-scope';
 import { getWorkspaceMemberUserIds } from '@/lib/auth/workspace-scope';
 
-const FALLBACK_RECEIVING = [
-  {
-    id: 'RCV-2041',
-    supplier: 'Bennett Logistics',
-    container: 'MSKU-4092',
-    eta: 'Today 2:30 PM',
-    dock: 'Dock 3',
-    items: 48,
-    status: 'scheduled',
-    priority: 'high',
-  },
-  {
-    id: 'RCV-2038',
-    supplier: 'CleanTech Supplies',
-    container: 'OOLU-8812',
-    eta: 'Tomorrow 9:10 AM',
-    dock: 'Dock 1',
-    items: 32,
-    status: 'in_progress',
-    priority: 'normal',
-  },
-  {
-    id: 'RCV-2033',
-    supplier: 'Pacific Restoration',
-    container: 'TGHU-2217',
-    eta: 'Tomorrow 1:45 PM',
-    dock: 'Dock 2',
-    items: 21,
-    status: 'scheduled',
-    priority: 'low',
-  },
-];
-
-const FALLBACK_PICKS = [
-  {
-    id: 'PICK-8412',
-    customer: 'Metro Facility Services',
-    zone: 'BNE-02',
-    lines: 12,
-    promised: 'Today 5:00 PM',
-    status: 'picking',
-    priority: 'rush',
-  },
-  {
-    id: 'PICK-8401',
-    customer: 'Aero Services Group',
-    zone: 'SYD-01',
-    lines: 6,
-    promised: 'Today 4:00 PM',
-    status: 'queued',
-    priority: 'normal',
-  },
-  {
-    id: 'PICK-8396',
-    customer: 'Harbour Hospitality',
-    zone: 'BNE-01',
-    lines: 9,
-    promised: 'Tomorrow 11:00 AM',
-    status: 'queued',
-    priority: 'normal',
-  },
-];
-
-const FALLBACK_RETURNS = [
-  {
-    id: 'RMA-4321',
-    customer: 'Sapphire Maintenance',
-    reason: 'Damaged on arrival',
-    items: 2,
-    sla: 'Due in 4h',
-    status: 'inspection',
-  },
-  {
-    id: 'RMA-4316',
-    customer: 'Metro Facility Services',
-    reason: 'Warranty service',
-    items: 1,
-    sla: 'Due tomorrow',
-    status: 'awaiting_parts',
-  },
-  {
-    id: 'SRV-1198',
-    customer: 'Aero Services Group',
-    reason: 'Motor replacement',
-    items: 1,
-    sla: 'Due in 2d',
-    status: 'in_progress',
-  },
-];
-
-const AI_GUIDANCE = [
-  {
-    title: 'Rebalance BNE-02 picks',
-    detail:
-      '4 priority picks share the same zone. Recommend splitting to BNE-03 for faster throughput.',
-    impact: 'ETA risk reduced by 22%',
-  },
-  {
-    title: 'Inbound ETA risk',
-    detail:
-      'RCV-2041 has a 2h dock delay trend. Notify supplier and adjust labor plan.',
-    impact: 'Prevents overtime spike',
-  },
-  {
-    title: 'Return SLA breach',
-    detail: 'RMA-4321 is 4h from SLA. Assign QA to close inspection.',
-    impact: 'SLA compliance maintained',
-  },
-];
+// Returns/service and AI guidance have no backing data source yet. They are
+// reported as not_connected with empty queues — never populated with demo data.
+const SOURCES = {
+  receiving: 'live',
+  picks: 'live',
+  returns: 'not_connected',
+  aiGuidance: 'not_connected',
+} as const;
 
 function poToReceiving(
   po: {
@@ -153,10 +52,6 @@ export async function GET(request: NextRequest) {
   const startOfDay = new Date();
   startOfDay.setHours(0, 0, 0, 0);
 
-  let receivingQueue = FALLBACK_RECEIVING;
-  let pickQueue = FALLBACK_PICKS;
-  const returnsQueue = FALLBACK_RETURNS;
-
   try {
     const inboundToday = await prisma.purchaseOrder.count({
       where: {
@@ -179,9 +74,7 @@ export async function GET(request: NextRequest) {
       orderBy: { updatedAt: 'desc' },
     });
 
-    if (inboundPos.length > 0) {
-      receivingQueue = inboundPos.map((po, i) => poToReceiving(po, i));
-    }
+    const receivingQueue = inboundPos.map((po, i) => poToReceiving(po, i));
 
     const openOrders = await prisma.order.findMany({
       where: {
@@ -196,54 +89,41 @@ export async function GET(request: NextRequest) {
       orderBy: { createdAt: 'asc' },
     });
 
-    if (openOrders.length > 0) {
-      pickQueue = openOrders.map((o) => ({
-        id: o.orderNumber,
-        customer: o.customer.companyName,
-        zone: 'WH-OPS',
-        lines: o.lineItems.length,
-        promised: format(o.createdAt, 'MMM d, yyyy'),
-        status: o.lineItems.length > 8 ? 'picking' : 'queued',
-        priority: o.total > 5000 ? ('rush' as const) : ('normal' as const),
-      }));
-    }
+    const pickQueue = openOrders.map((o) => ({
+      id: o.orderNumber,
+      customer: o.customer.companyName,
+      zone: 'WH-OPS',
+      lines: o.lineItems.length,
+      promised: format(o.createdAt, 'MMM d, yyyy'),
+      status: o.lineItems.length > 8 ? 'picking' : 'queued',
+      priority: o.total > 5000 ? ('rush' as const) : ('normal' as const),
+    }));
 
     const rushPicks = pickQueue.filter((p) => p.priority === 'rush').length;
 
     return NextResponse.json({
       updatedAt: new Date().toISOString(),
+      sources: SOURCES,
       metrics: {
         inboundToday,
         inboundDocked: receivingQueue.filter((r) => r.status === 'in_progress').length,
         inboundScheduled: receivingQueue.filter((r) => r.status === 'scheduled').length,
         picksDueToday: pickQueue.length,
         rushPicks,
-        returnsOpen: returnsQueue.length,
-        returnSlaRisk: returnsQueue.length > 0 ? 1 : 0,
-        onTimeRate: openOrders.length > 0 ? 93 : 96,
+        returnsOpen: 0,
+        returnSlaRisk: 0,
+        // No on-time tracking exists yet; null means "not tracked", not 0%.
+        onTimeRate: null,
       },
       receivingQueue,
       pickQueue,
-      returnsQueue,
-      aiGuidance: AI_GUIDANCE,
+      returnsQueue: [],
+      aiGuidance: [],
     });
   } catch {
-    return NextResponse.json({
-      updatedAt: new Date().toISOString(),
-      metrics: {
-        inboundToday: FALLBACK_RECEIVING.length,
-        inboundDocked: 2,
-        inboundScheduled: 1,
-        picksDueToday: FALLBACK_PICKS.length,
-        rushPicks: 1,
-        returnsOpen: FALLBACK_RETURNS.length,
-        returnSlaRisk: 1,
-        onTimeRate: 96,
-      },
-      receivingQueue: FALLBACK_RECEIVING,
-      pickQueue: FALLBACK_PICKS,
-      returnsQueue: FALLBACK_RETURNS,
-      aiGuidance: AI_GUIDANCE,
-    });
+    return NextResponse.json(
+      { detail: 'Warehouse operations data is currently unavailable.' },
+      { status: 503 },
+    );
   }
 }

--- a/src/types/inventory.ts
+++ b/src/types/inventory.ts
@@ -332,6 +332,13 @@ export interface AdjustmentFormData {
  */
 export interface WarehouseOpsPayload {
   updatedAt: string;
+  /** Data provenance per feed — 'not_connected' feeds always return empty queues. */
+  sources: {
+    receiving: 'live' | 'not_connected';
+    picks: 'live' | 'not_connected';
+    returns: 'live' | 'not_connected';
+    aiGuidance: 'live' | 'not_connected';
+  };
   metrics: {
     inboundToday: number;
     inboundDocked: number;
@@ -340,7 +347,8 @@ export interface WarehouseOpsPayload {
     rushPicks: number;
     returnsOpen: number;
     returnSlaRisk: number;
-    onTimeRate: number;
+    /** null = on-time tracking not connected yet (never rendered as 0%). */
+    onTimeRate: number | null;
   };
   receivingQueue: Array<{
     id: string;


### PR DESCRIPTION
## Summary
`src/app/api/warehouse/ops/route.ts` served hardcoded demo arrays (`FALLBACK_RECEIVING`, `FALLBACK_PICKS`, `FALLBACK_RETURNS`, `AI_GUIDANCE`) whenever the database was empty or the query threw — the warehouse dashboard rendered fabricated suppliers, containers, RMAs, and SLA warnings as if real. Flagged as a separate fake-as-real surface during UNI-2119 (#224).

## Changes
- **Route**: deleted all four fallback arrays. Receiving and pick queues come only from Prisma (empty DB → empty arrays). Returns and AI guidance have no backing data source yet, so they always return `[]` and are declared via a new `sources` payload field (`live` / `not_connected`).
- **Honest metrics**: `onTimeRate` is now `null` (nothing computes it — the old 93/96% was fabricated); returns metrics are 0 with the card showing "Not connected".
- **Error path**: a DB failure now returns **503** with a detail message instead of a 200 full of demo data; the dashboard already surfaces this as an error badge.
- **UI** (`warehouse/page.tsx`): explicit empty states for all four queues ("No inbound shipments scheduled", "Returns tracking is not connected yet", etc.) and `—` for untracked metrics, so empty no longer renders as blank cards or fake zeros.
- **Types**: `WarehouseOpsPayload` gains `sources`; `onTimeRate` is `number | null`.

## Verification
- `npm run type-check` — clean
- `npx eslint` on the three edited files — clean
- `npm test` — 328/328 passing
- `npm run build` — succeeds

Only the three edited files were staged (repo has CRLF phantom diffs on checkout).

## Out of scope (same page, separate surface)
The static "Operational risks" and "Labor plan" cards on the dashboard are hardcoded JSX fabrications (not API-fed) — left untouched here to keep this PR one-issue-one-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)