### PR TITLE
fix: exempt connections-status manifest from auth middleware (UNI-2139)

### DIFF
--- a/src/lib/auth/update-session.ts
+++ b/src/lib/auth/update-session.ts
@@ -81,6 +81,8 @@ export async function updateSession(request: NextRequest) {
     '/api/cron',
     '/api/auth',
     '/api/public',
+    // Secret-free readiness manifest polled by Unite-Group Mission Control (UNI-2139).
+    '/api/v1/connections/status',
     // OAuth redirects must load without a prior session (provider sends user back to callback).
     '/api/integrations/xero/callback',
     '/api/integrations/xero/auth',


### PR DESCRIPTION
## Summary
Post-merge probe of #226's endpoint returned `307 → /login?redirect=%2Fapi%2Fv1%2Fconnections%2Fstatus` — `updateSession`'s `publicPaths` never exempted the route, so Mission Control's unauthenticated poll can't reach it. One-line allowlist addition; the manifest payload is presence-only (no secret values, proven by the no-leak test in #226).

## Verification
- `npm run type-check` → exit 0 · `eslint update-session.ts` → exit 0 · `npm test` → 44/44 files
- Post-merge: re-probe must return HTTP 200 with `project.slug = ccw-erp` before the URL is wired into the command centre.

Opened as **draft** per the standing agent-PR rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)