### PR TITLE
fix(uni-2106): scope Xero token resolution strictly to authenticated workspace

### DIFF
--- a/src/lib/integrations/__tests__/xero-tokens-org-scope.test.ts
+++ b/src/lib/integrations/__tests__/xero-tokens-org-scope.test.ts
@@ -1,0 +1,98 @@
+/**
+ * UNI-2106: Xero tokens must be scoped to the authenticated user's workspace/org.
+ *
+ * Bug: getValidXeroTokens() falls back to reading `xero_access_token` /
+ * `xero_refresh_token` / `xero_tenant_id` straight off the request's cookies
+ * whenever the workspace-scoped DB lookup misses (e.g. a brand-new workspace
+ * that hasn't connected Xero yet, or a transient DB read issue). Those cookies
+ * are NOT namespaced per workspace — they are plain browser cookies set by the
+ * OAuth callback. On a shared browser/session (agency staff, kiosk machine,
+ * user who is a member of multiple workspaces) this lets Org B's authenticated
+ * request silently pick up Org A's Xero access token/tenant, i.e. an org-context
+ * leak across workspaces.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/auth/workspace-scope', () => ({
+  getWorkspaceIdForUser: vi.fn(),
+}));
+
+vi.mock('@/lib/integrations/xero', () => ({
+  getConfiguredTokenSource: vi.fn(),
+  getXeroClientId: vi.fn(() => ''),
+  getXeroClientSecret: vi.fn(() => ''),
+}));
+
+vi.mock('@/lib/integrations/xero-oauth', () => ({
+  refreshXeroAccessToken: vi.fn(),
+}));
+
+vi.mock('@/lib/integrations/xero-storage', () => ({
+  isXeroTokenExpired: vi.fn(() => false),
+  loadWorkspaceXeroConnection: vi.fn(),
+  saveWorkspaceXeroConnection: vi.fn(),
+}));
+
+import { getWorkspaceIdForUser } from '@/lib/auth/workspace-scope';
+import { getConfiguredTokenSource } from '@/lib/integrations/xero';
+import { loadWorkspaceXeroConnection } from '@/lib/integrations/xero-storage';
+import { getValidXeroTokens } from '../xero-tokens';
+
+function requestWithLeftoverCookiesFromOrgA(): NextRequest {
+  // Simulates a browser that still carries Org A's Xero session cookies
+  // (e.g. set by an earlier OAuth callback) while the *currently
+  // authenticated* user now belongs to Org B.
+  const req = new NextRequest('http://localhost/api/integrations/xero/status');
+  req.cookies.set('xero_access_token', 'ORG-A-ACCESS-TOKEN');
+  req.cookies.set('xero_refresh_token', 'ORG-A-REFRESH-TOKEN');
+  req.cookies.set('xero_tenant_id', 'ORG-A-TENANT-ID');
+  return req;
+}
+
+describe('getValidXeroTokens org-context scoping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // No global env token configured — getConfiguredTokenSource only returns
+    // cookie-derived data (mirrors the "not configured via env" prod case).
+    vi.mocked(getConfiguredTokenSource).mockImplementation((request?: NextRequest) => {
+      if (!request) return null;
+      const accessToken = request.cookies.get('xero_access_token')?.value;
+      const refreshToken = request.cookies.get('xero_refresh_token')?.value;
+      const tenantId = request.cookies.get('xero_tenant_id')?.value;
+      if (!accessToken || !tenantId) return null;
+      return { accessToken, refreshToken, tenantId };
+    });
+  });
+
+  it('does NOT leak Org A cookie tokens into Org B when Org B has no stored Xero connection', async () => {
+    vi.mocked(getWorkspaceIdForUser).mockResolvedValue('workspace-org-b');
+    vi.mocked(loadWorkspaceXeroConnection).mockResolvedValue(null); // Org B never connected Xero
+
+    const req = requestWithLeftoverCookiesFromOrgA();
+    const tokens = await getValidXeroTokens(req, 'user-in-org-b');
+
+    // Org B has no Xero connection of its own — the resolver must not hand
+    // back Org A's leftover cookie-based tenant/token.
+    expect(tokens).toBeNull();
+  });
+
+  it('uses the workspace-scoped connection for the authenticated org, ignoring stale cookies', async () => {
+    vi.mocked(getWorkspaceIdForUser).mockResolvedValue('workspace-org-b');
+    vi.mocked(loadWorkspaceXeroConnection).mockResolvedValue({
+      workspaceId: 'workspace-org-b',
+      tenantId: 'ORG-B-TENANT-ID',
+      tenantName: 'Org B Pty Ltd',
+      accessToken: 'ORG-B-ACCESS-TOKEN',
+      refreshToken: 'ORG-B-REFRESH-TOKEN',
+      tokenExpiresAt: null,
+    });
+
+    const req = requestWithLeftoverCookiesFromOrgA();
+    const tokens = await getValidXeroTokens(req, 'user-in-org-b');
+
+    expect(tokens?.tenantId).toBe('ORG-B-TENANT-ID');
+    expect(tokens?.accessToken).toBe('ORG-B-ACCESS-TOKEN');
+    expect(tokens?.source).toBe('workspace');
+  });
+});

--- a/src/lib/integrations/xero-tokens.ts
+++ b/src/lib/integrations/xero-tokens.ts
@@ -51,6 +51,16 @@ async function refreshAndPersistWorkspace(
 
 /**
  * Resolves a valid Xero access token (env → workspace DB with refresh → session cookies).
+ *
+ * IMPORTANT (org-context scoping): the raw-cookie fallback (`xero_access_token` /
+ * `xero_refresh_token` / `xero_tenant_id`) is NOT namespaced per workspace — it is a
+ * plain browser cookie set by the OAuth callback. It must only ever be used when the
+ * caller has no authenticated user context at all (legacy/unauthenticated call sites).
+ * Once a `userId` is known, the authenticated user's workspace is the sole source of
+ * truth: if that workspace has no stored Xero connection, we must return null rather
+ * than falling through to whatever Xero cookies happen to be sitting in the browser,
+ * which could belong to a *different* org (e.g. a user who is a member of multiple
+ * workspaces, or a shared/kiosk browser that never cleared a previous org's session).
  */
 export async function getValidXeroTokens(
   request?: NextRequest,
@@ -67,34 +77,38 @@ export async function getValidXeroTokens(
   }
 
   if (userId) {
+    // Authenticated call: resolve strictly from this user's workspace. Do NOT fall
+    // back to unscoped request cookies below — those could belong to another org.
     const workspaceId = await getWorkspaceIdForUser(userId);
-    if (workspaceId) {
-      const stored = await loadWorkspaceXeroConnection(workspaceId);
-      if (stored) {
-        if (
-          isXeroTokenExpired(stored.tokenExpiresAt) &&
-          stored.refreshToken
-        ) {
-          const refreshed = await refreshAndPersistWorkspace(
-            workspaceId,
-            stored.refreshToken,
-            stored.tenantId,
-            stored.tenantName
-          );
-          if (refreshed) return refreshed;
-        }
-        return {
-          accessToken: stored.accessToken,
-          refreshToken: stored.refreshToken ?? undefined,
-          tenantId: stored.tenantId,
-          tenantName: stored.tenantName,
-          source: 'workspace',
-          expiresAt: stored.tokenExpiresAt,
-        };
-      }
+    if (!workspaceId) return null;
+
+    const stored = await loadWorkspaceXeroConnection(workspaceId);
+    if (!stored) return null;
+
+    if (isXeroTokenExpired(stored.tokenExpiresAt) && stored.refreshToken) {
+      const refreshed = await refreshAndPersistWorkspace(
+        workspaceId,
+        stored.refreshToken,
+        stored.tenantId,
+        stored.tenantName
+      );
+      if (refreshed) return refreshed;
     }
+
+    return {
+      accessToken: stored.accessToken,
+      refreshToken: stored.refreshToken ?? undefined,
+      tenantId: stored.tenantId,
+      tenantName: stored.tenantName,
+      source: 'workspace',
+      expiresAt: stored.tokenExpiresAt,
+    };
   }
 
+  // No authenticated user context provided at all — legacy cookie-based resolution
+  // for call sites that predate workspace scoping. Never reached once a userId is
+  // supplied, which all current API routes do (see xero/status, xero/refresh,
+  // xero/invoice, xero/sync-order).
   if (request) {
     const cookieTokens = getLegacyTokenSource(request);
     if (cookieTokens) {


### PR DESCRIPTION
## Summary
- Fixes a cross-tenant Xero token leak: `getValidXeroTokens()` would fall through to raw, unscoped browser cookies (`xero_access_token`/`xero_refresh_token`/`xero_tenant_id`) whenever a `userId` was passed but that user's workspace had no stored Xero connection
- Those cookies are not namespaced per workspace — on a shared/kiosk browser, or a user belonging to multiple workspaces, this could hand one org's Xero tenant/token to a different org
- Once `userId` is present, resolution is now strictly workspace-scoped and returns `null` on no stored connection instead of falling through to cookies. The cookie fallback remains only for the legacy no-`userId` path, which no current API route uses.

## Scope note (UNI-2106)
This is slice 1 of the broader "Shopify/Xero/SendGrid/Sentry demo → staging" ticket — the Xero org-context gap it explicitly flagged. Shopify, SendGrid, and Sentry are untouched. No real credentials were added or used; this is a code-level fix backed by mocked unit tests. Live staging verification against real third-party APIs is out of scope here and needs a human with real credentials.

## Test plan
- [x] New regression test (`src/lib/integrations/__tests__/xero-tokens-org-scope.test.ts`) fails against pre-fix code, reproducing the leak; passes after the fix
- [x] `npx vitest run` (full suite) — 46/46 files, 345/345 tests pass, no regressions
- [x] `npx tsc --noEmit` — 0 errors

Linear: [UNI-2106](https://linear.app/unite-group/issue/UNI-2106/ccw-p0-build-loop-promote-shopifyxerosendgridsentry-from-demo-to)

🤖 Generated with [Claude Code](https://claude.com/claude-code)