### PR TITLE
fix(uni-2106): stop reporting Sentry as connected from DSN presence alone

### DIFF
--- a/src/lib/connections/__tests__/status.test.ts
+++ b/src/lib/connections/__tests__/status.test.ts
@@ -48,7 +48,7 @@ describe('buildCcwConnectionStatus', () => {
     expect(byId.database.state).toBe('blocked');
     expect(byId.auth.state).toBe('blocked');
     expect(byId.crons.state).toBe('blocked');
-    expect(byId.sentry.state).toBe('unknown');
+    expect(byId.sentry.state).toBe('blocked');
     expect(byId.ai_openai.state).toBe('blocked');
     expect(byId.unite_group.state).toBe('ready');
     expect(status.summary.total).toBe(status.connections.length);
@@ -71,10 +71,33 @@ describe('buildCcwConnectionStatus', () => {
 
     expect(byId.database.state).toBe('connected');
     expect(byId.auth.state).toBe('connected');
-    expect(byId.sentry.state).toBe('connected');
     expect(byId.crons.state).toBe('ready');
     expect(byId.crons.nextAction).toBe('Confirm cron enablement in the Vercel project settings.');
     expect(status.project.environment).toBe('production');
+  });
+
+  it('does not report Sentry as connected from DSN presence alone (SDK is not installed)', () => {
+    // @sentry/nextjs was removed from this repo in 5165367e "remove unused
+    // Sentry SDK to unblock UNI-1949" — no package dependency, no
+    // sentry.{client,server,edge}.config.ts, no instrumentation.ts hook, and
+    // no Sentry.captureException call anywhere in src/. Setting SENTRY_DSN
+    // per .env.example therefore does not cause a single error to be
+    // captured or transmitted. Reporting 'connected' here is a false
+    // positive: Mission Control would believe error monitoring is live when
+    // it is entirely inert.
+    const status = buildCcwConnectionStatus(FULL_ENV, [], '2026-07-02T00:00:00.000Z');
+    const byId = Object.fromEntries(status.connections.map((c) => [c.id, c]));
+
+    expect(byId.sentry.state).not.toBe('connected');
+    expect(byId.sentry.state).toBe('blocked');
+    expect(byId.sentry.detail).toMatch(/sdk/i);
+  });
+
+  it('reports Sentry as blocked (not merely unknown) when the DSN is unset', () => {
+    const status = buildCcwConnectionStatus(EMPTY_ENV, [], '2026-07-02T00:00:00.000Z');
+    const byId = Object.fromEntries(status.connections.map((c) => [c.id, c]));
+
+    expect(byId.sentry.state).toBe('blocked');
   });
 
   it('never leaks secret values into the payload', () => {

--- a/src/lib/connections/status.ts
+++ b/src/lib/connections/status.ts
@@ -124,14 +124,24 @@ export function buildCcwConnectionStatus(
         : 'Set CRON_SECRET in the deploy environment.',
     },
     {
+      // The @sentry/nextjs SDK was removed from this app entirely (see
+      // 5165367e "remove unused Sentry SDK to unblock UNI-1949"): no
+      // package dependency, no sentry.{client,server,edge}.config.ts, no
+      // instrumentation.ts hook, no Sentry.captureException call anywhere
+      // in the codebase. SENTRY_DSN/NEXT_PUBLIC_SENTRY_DSN lingering in
+      // .env.example are stale from before that removal. Do not report
+      // 'connected' from DSN presence alone — that would tell Mission
+      // Control error monitoring is live when nothing is ever captured or
+      // transmitted. Always report 'blocked' until the SDK is reinstalled.
       id: 'sentry',
       label: 'Error monitoring (Sentry)',
-      state: sentryReady ? 'connected' : 'unknown',
+      state: 'blocked',
       safeForMissionControl: true,
       detail: sentryReady
-        ? 'Sentry DSN present.'
-        : 'No Sentry DSN detected — errors are not being reported.',
-      nextAction: sentryReady ? undefined : 'Set SENTRY_DSN (and NEXT_PUBLIC_SENTRY_DSN).',
+        ? 'SENTRY_DSN is set, but the Sentry SDK is not installed in this app — no errors are captured or sent.'
+        : 'No Sentry DSN detected, and the Sentry SDK is not installed — errors are not being reported.',
+      nextAction:
+        'Reinstall @sentry/nextjs and wire sentry.{client,server,edge}.config.ts before relying on SENTRY_DSN.',
     },
     {
       id: 'ai_openai',


### PR DESCRIPTION
## Summary
- The `@sentry/nextjs` SDK was fully removed from this app in commit `5165367e` ("remove unused Sentry SDK to unblock UNI-1949") — no package dependency, no `sentry.{client,server,edge}.config.ts`, no `instrumentation.ts` hook, and zero `Sentry.captureException`/`setUser` calls anywhere in `src/`
- The env-var consolidation into a single root `.env.example` happened separately and was never touched by that removal, so 11 stale `SENTRY_DSN`/`NEXT_PUBLIC_SENTRY_DSN` references still exist there today, orphaned from an SDK that no longer exists
- `src/lib/connections/status.ts` (the Mission Control connections manifest, UNI-2139) derived the Sentry entry's state purely from `SENTRY_DSN` presence and reported `'connected'` when set — telling operators error monitoring is live when it's completely inert. Same class of "looks connected but isn't" issue as the Xero cross-tenant token bug (#229), just on an observability control instead of an auth token.

## Fix
`sentry` connection entry now always reports `state: 'blocked'` (never `'connected'`), with a `detail` distinguishing "DSN set but SDK missing" from "DSN unset," and a `nextAction` pointing at reinstalling `@sentry/nextjs`.

## Test plan
- [x] New tests assert Sentry is never `'connected'` even with a full mocked env (`SENTRY_DSN` set), and is `'blocked'` (not the old `'unknown'`) when unset
- [x] Full suite (`npx vitest run`) — no regressions (independently re-verified after merge: 48/48 files, 353/353 tests)
- [x] `npx tsc --noEmit` — 0 errors

No real Sentry DSN or credentials used — tests use a placeholder string already present in the existing fixture.

Linear: [UNI-2106](https://linear.app/unite-group/issue/UNI-2106/ccw-p0-build-loop-promote-shopifyxerosendgridsentry-from-demo-to)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sentry connection status now consistently shows as blocked when it isn’t fully set up.
  - Status details now clearly indicate that the Sentry SDK is missing and provide updated next steps for restoring error monitoring.
  - Improved status reporting so an unset Sentry DSN no longer appears as an unclear or partially connected state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->