### PR TITLE
fix(uni-2106): scope Shopify credential cookies to authenticated workspace

### DIFF
--- a/src/app/api/integrations/shopify/authorize/route.ts
+++ b/src/app/api/integrations/shopify/authorize/route.ts
@@ -7,6 +7,7 @@ import {
   getShopifyRedirectUri,
   getShopifyScopes,
   resolveMyshopifyHost,
+  shopifyCookieName,
 } from '@/lib/integrations/shopify';
 import {
   SHOPIFY_OAUTH_SHOP_COOKIE,
@@ -25,7 +26,9 @@ export async function GET(request: NextRequest) {
   }
 
   const shopParam = request.nextUrl.searchParams.get('shop')?.trim();
-  const shopFromCookie = request.cookies.get('shopify_shop_domain')?.value?.trim();
+  const shopFromCookie = request.cookies
+    .get(shopifyCookieName('shopify_shop_domain', workspaceId))
+    ?.value?.trim();
   const shopFromEnv = process.env.SHOPIFY_SHOP_DOMAIN?.trim();
   const raw = shopParam || shopFromCookie || shopFromEnv || '';
   const { adminHost } = resolveMyshopifyHost(raw);

--- a/src/app/api/integrations/shopify/callback/route.ts
+++ b/src/app/api/integrations/shopify/callback/route.ts
@@ -4,6 +4,7 @@ import { getWorkspaceIdForUser } from '@/lib/auth/workspace-scope';
 import {
   exchangeShopifyOAuthCode,
   getShopifyClientSecret,
+  shopifyCookieName,
   verifyShopifyOAuthHmac,
 } from '@/lib/integrations/shopify';
 import {
@@ -59,9 +60,9 @@ export async function GET(request: NextRequest) {
     const res = NextResponse.redirect(`${settingsUrl}?shopify_success=1`);
     const secure = process.env.NODE_ENV === 'production';
     const common = { httpOnly: true, sameSite: 'lax' as const, secure, path: '/', maxAge: 60 * 60 * 24 * 30 };
-    res.cookies.set('shopify_shop_domain', shop, common);
-    res.cookies.set('shopify_access_token', access_token, common);
-    res.cookies.set('shopify_connected', '1', common);
+    res.cookies.set(shopifyCookieName('shopify_shop_domain', workspaceId), shop, common);
+    res.cookies.set(shopifyCookieName('shopify_access_token', workspaceId), access_token, common);
+    res.cookies.set(shopifyCookieName('shopify_connected', workspaceId), '1', common);
     clearShopifyOAuthStateCookies(res);
     return res;
   } catch (e) {

--- a/src/app/api/integrations/shopify/configure/route.ts
+++ b/src/app/api/integrations/shopify/configure/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAuthScope } from '@/lib/auth/data-scope';
 import { getWorkspaceIdForUser } from '@/lib/auth/workspace-scope';
-import { getShopifyMode, resolveMyshopifyHost } from '@/lib/integrations/shopify';
+import { getShopifyMode, resolveMyshopifyHost, shopifyCookieName } from '@/lib/integrations/shopify';
 
 export async function POST(request: NextRequest) {
   const scope = await requireAuthScope(request);
@@ -51,11 +51,13 @@ export async function POST(request: NextRequest) {
   });
   const secure = process.env.NODE_ENV === 'production';
   const common = { httpOnly: true, sameSite: 'lax' as const, secure, path: '/', maxAge: 60 * 60 * 24 * 30 };
-  res.cookies.set('shopify_shop_domain', adminHost, common);
-  res.cookies.set('shopify_access_token', accessToken, common);
-  if (body.api_key) res.cookies.set('shopify_api_key', body.api_key, common);
-  if (body.api_secret) res.cookies.set('shopify_api_secret', body.api_secret, common);
-  if (body.webhook_secret) res.cookies.set('shopify_webhook_secret', body.webhook_secret, common);
-  res.cookies.set('shopify_connected', '0', common);
+  res.cookies.set(shopifyCookieName('shopify_shop_domain', workspaceId), adminHost, common);
+  res.cookies.set(shopifyCookieName('shopify_access_token', workspaceId), accessToken, common);
+  if (body.api_key) res.cookies.set(shopifyCookieName('shopify_api_key', workspaceId), body.api_key, common);
+  if (body.api_secret)
+    res.cookies.set(shopifyCookieName('shopify_api_secret', workspaceId), body.api_secret, common);
+  if (body.webhook_secret)
+    res.cookies.set(shopifyCookieName('shopify_webhook_secret', workspaceId), body.webhook_secret, common);
+  res.cookies.set(shopifyCookieName('shopify_connected', workspaceId), '0', common);
   return res;
 }

--- a/src/app/api/integrations/shopify/connect/route.ts
+++ b/src/app/api/integrations/shopify/connect/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAuthScope } from '@/lib/auth/data-scope';
 import { getWorkspaceIdForUser } from '@/lib/auth/workspace-scope';
-import { fetchShopifyShop, getConfiguredShopifyFromRequest } from '@/lib/integrations/shopify';
+import {
+  fetchShopifyShop,
+  getConfiguredShopifyFromRequest,
+  shopifyCookieName,
+} from '@/lib/integrations/shopify';
 
 export async function POST(request: NextRequest) {
   const scope = await requireAuthScope(request);
@@ -14,7 +18,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ detail: 'No workspace found for this user' }, { status: 403 });
   }
 
-  const creds = getConfiguredShopifyFromRequest(request);
+  const creds = getConfiguredShopifyFromRequest(request, workspaceId);
   if (!creds) {
     return NextResponse.json({ detail: 'Shopify credentials not configured.' }, { status: 400 });
   }
@@ -33,7 +37,7 @@ export async function POST(request: NextRequest) {
     shop_name: shop.name,
     message: `Connected to ${shop.name}.`,
   });
-  response.cookies.set('shopify_connected', '1', {
+  response.cookies.set(shopifyCookieName('shopify_connected', workspaceId), '1', {
     httpOnly: true,
     sameSite: 'lax',
     secure: process.env.NODE_ENV === 'production',

--- a/src/app/api/integrations/shopify/disconnect/route.ts
+++ b/src/app/api/integrations/shopify/disconnect/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAuthScope } from '@/lib/auth/data-scope';
 import { getWorkspaceIdForUser } from '@/lib/auth/workspace-scope';
+import { shopifyCookieName } from '@/lib/integrations/shopify';
 
 const CLEAR = { path: '/', maxAge: 0 } as const;
 
@@ -16,16 +17,19 @@ export async function POST(request: NextRequest) {
   }
 
   const response = NextResponse.json({ success: true, message: 'Shopify disconnected.' });
-  for (const name of [
+  for (const base of [
     'shopify_connected',
     'shopify_shop_domain',
     'shopify_access_token',
     'shopify_api_key',
     'shopify_api_secret',
     'shopify_webhook_secret',
-    'shopify_oauth_state',
-    'shopify_oauth_shop',
   ]) {
+    response.cookies.set(shopifyCookieName(base, workspaceId), '', CLEAR);
+  }
+  // Transient OAuth CSRF-state cookies are short-lived and not per-workspace credentials;
+  // clear the legacy (unnamespaced) names too in case a stale flow was interrupted.
+  for (const name of ['shopify_oauth_state', 'shopify_oauth_shop']) {
     response.cookies.set(name, '', CLEAR);
   }
   return response;

--- a/src/app/api/integrations/shopify/import-order/[orderId]/route.ts
+++ b/src/app/api/integrations/shopify/import-order/[orderId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db/prisma';
 import { requireAuthScopeOrCronIntegrationJob } from '@/lib/auth/data-scope';
+import { getWorkspaceIdForUser } from '@/lib/auth/workspace-scope';
 import { getConfiguredShopifyFromRequest } from '@/lib/integrations/shopify';
 import { importShopifyOrderToErp } from '@/lib/integrations/shopify-ops';
 
@@ -19,6 +20,11 @@ export async function POST(
     );
   }
 
+  const workspaceId = await getWorkspaceIdForUser(scope.userId);
+  if (!workspaceId) {
+    return NextResponse.json({ detail: 'No workspace found for this user' }, { status: 403 });
+  }
+
   const { orderId } = await context.params;
   const id = String(orderId || '').trim();
   if (!id || !/^\d+$/.test(id)) {
@@ -28,7 +34,7 @@ export async function POST(
     );
   }
 
-  const creds = getConfiguredShopifyFromRequest(request);
+  const creds = getConfiguredShopifyFromRequest(request, workspaceId);
   if (!creds) {
     return NextResponse.json({ detail: 'Shopify is not configured or token is missing.' }, { status: 401 });
   }

--- a/src/app/api/integrations/shopify/import-orders/route.ts
+++ b/src/app/api/integrations/shopify/import-orders/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAuthScopeOrCronIntegrationJob } from '@/lib/auth/data-scope';
+import { getWorkspaceIdForUser } from '@/lib/auth/workspace-scope';
 import { getConfiguredShopifyFromRequest, shopifyAdminJson } from '@/lib/integrations/shopify';
 import { importShopifyOrderToErp } from '@/lib/integrations/shopify-ops';
 
@@ -15,7 +16,12 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const creds = getConfiguredShopifyFromRequest(request);
+  const workspaceId = await getWorkspaceIdForUser(scope.userId);
+  if (!workspaceId) {
+    return NextResponse.json({ detail: 'No workspace found for this user' }, { status: 403 });
+  }
+
+  const creds = getConfiguredShopifyFromRequest(request, workspaceId);
   if (!creds) {
     return NextResponse.json({ detail: 'Shopify is not configured or token is missing.' }, { status: 401 });
   }

--- a/src/app/api/integrations/shopify/status/route.ts
+++ b/src/app/api/integrations/shopify/status/route.ts
@@ -7,6 +7,7 @@ import {
   getShopifyApiVersion,
   getShopifyMode,
   resolveMyshopifyHost,
+  shopifyCookieName,
 } from '@/lib/integrations/shopify';
 
 export async function GET(request: NextRequest) {
@@ -21,14 +22,15 @@ export async function GET(request: NextRequest) {
   }
 
   const configuredMode = getShopifyMode();
-  const connectedCookie = request.cookies.get('shopify_connected')?.value === '1';
+  const connectedCookie =
+    request.cookies.get(shopifyCookieName('shopify_connected', workspaceId))?.value === '1';
 
   const rawShop =
-    request.cookies.get('shopify_shop_domain')?.value?.trim() ||
+    request.cookies.get(shopifyCookieName('shopify_shop_domain', workspaceId))?.value?.trim() ||
     process.env.SHOPIFY_SHOP_DOMAIN?.trim() ||
     '';
   const cookieToken =
-    request.cookies.get('shopify_access_token')?.value?.trim() ||
+    request.cookies.get(shopifyCookieName('shopify_access_token', workspaceId))?.value?.trim() ||
     process.env.SHOPIFY_ACCESS_TOKEN?.trim() ||
     '';
 
@@ -46,7 +48,7 @@ export async function GET(request: NextRequest) {
     });
   }
 
-  const creds = getConfiguredShopifyFromRequest(request);
+  const creds = getConfiguredShopifyFromRequest(request, workspaceId);
   if (!creds) {
     return NextResponse.json({
       connected: false,

--- a/src/app/api/integrations/shopify/sync-all-inventory/route.ts
+++ b/src/app/api/integrations/shopify/sync-all-inventory/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db/prisma';
 import { requireAuthScopeOrCronIntegrationJob } from '@/lib/auth/data-scope';
+import { getWorkspaceIdForUser } from '@/lib/auth/workspace-scope';
 import { getConfiguredShopifyFromRequest } from '@/lib/integrations/shopify';
 import { findVariantInventoryItemId, setInventoryLevel } from '@/lib/integrations/shopify-ops';
 
@@ -16,7 +17,12 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const creds = getConfiguredShopifyFromRequest(request);
+  const workspaceId = await getWorkspaceIdForUser(scope.userId);
+  if (!workspaceId) {
+    return NextResponse.json({ detail: 'No workspace found for this user' }, { status: 403 });
+  }
+
+  const creds = getConfiguredShopifyFromRequest(request, workspaceId);
   if (!creds) {
     return NextResponse.json({ detail: 'Shopify is not configured or token is missing.' }, { status: 401 });
   }

--- a/src/app/api/integrations/shopify/sync-inventory/[productId]/route.ts
+++ b/src/app/api/integrations/shopify/sync-inventory/[productId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db/prisma';
 import { requireAuthScope } from '@/lib/auth/data-scope';
+import { getWorkspaceIdForUser } from '@/lib/auth/workspace-scope';
 import { getConfiguredShopifyFromRequest } from '@/lib/integrations/shopify';
 import { findVariantInventoryItemId, setInventoryLevel } from '@/lib/integrations/shopify-ops';
 
@@ -13,8 +14,13 @@ export async function POST(
     return NextResponse.json({ detail: 'Not authenticated' }, { status: 401 });
   }
 
+  const workspaceId = await getWorkspaceIdForUser(scope.userId);
+  if (!workspaceId) {
+    return NextResponse.json({ detail: 'No workspace found for this user' }, { status: 403 });
+  }
+
   const { productId } = await context.params;
-  const creds = getConfiguredShopifyFromRequest(request);
+  const creds = getConfiguredShopifyFromRequest(request, workspaceId);
   if (!creds) {
     return NextResponse.json({ detail: 'Shopify is not configured or token is missing.' }, { status: 401 });
   }

--- a/src/app/api/integrations/shopify/sync-product/[productId]/route.ts
+++ b/src/app/api/integrations/shopify/sync-product/[productId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/db/prisma';
 import { requireAuthScope } from '@/lib/auth/data-scope';
+import { getWorkspaceIdForUser } from '@/lib/auth/workspace-scope';
 import { getConfiguredShopifyFromRequest, shopifyAdminJson } from '@/lib/integrations/shopify';
 import { findProductVariantBySku } from '@/lib/integrations/shopify-ops';
 
@@ -16,8 +17,13 @@ export async function POST(
     return NextResponse.json({ detail: 'Not authenticated' }, { status: 401 });
   }
 
+  const workspaceId = await getWorkspaceIdForUser(scope.userId);
+  if (!workspaceId) {
+    return NextResponse.json({ detail: 'No workspace found for this user' }, { status: 403 });
+  }
+
   const { productId } = await context.params;
-  const creds = getConfiguredShopifyFromRequest(request);
+  const creds = getConfiguredShopifyFromRequest(request, workspaceId);
   if (!creds) {
     return NextResponse.json({ detail: 'Shopify is not configured or token is missing.' }, { status: 401 });
   }

--- a/src/lib/integrations/__tests__/shopify-workspace-scope.test.ts
+++ b/src/lib/integrations/__tests__/shopify-workspace-scope.test.ts
@@ -1,0 +1,52 @@
+/**
+ * UNI-2106: Shopify credentials must be scoped to the authenticated user's workspace/org,
+ * mirroring the Xero cross-tenant token leak fixed for getValidXeroTokens() (PR #229).
+ *
+ * Bug: getConfiguredShopifyFromRequest() reads `shopify_shop_domain` / `shopify_access_token`
+ * straight off plain, non-namespaced request cookies (or global env vars) with no workspace
+ * check at all. Every Shopify route (status, connect, sync-inventory, sync-product,
+ * import-order(s)) calls this helper directly. On a shared browser/session (agency staff
+ * managing multiple client workspaces, a user who is a member of multiple workspaces, or a
+ * kiosk machine that never cleared a previous org's session), Org B's authenticated request
+ * silently picks up Org A's Shopify shop domain + Admin API access token — an org-context
+ * leak across workspaces. This is worse than the Xero case because Shopify has no
+ * workspace-scoped connection storage at all (unlike WorkspaceXeroConnection): the cookie
+ * *is* the only storage, and it is never namespaced per workspace.
+ */
+import { describe, it, expect } from 'vitest';
+import { NextRequest } from 'next/server';
+import { getConfiguredShopifyFromRequest } from '../shopify';
+
+function requestWithOrgACookies(url = 'http://localhost/api/integrations/shopify/status'): NextRequest {
+  // Simulates a browser that still carries Org A's Shopify session cookies (set by an
+  // earlier OAuth callback/configure call) while the *currently authenticated* user is
+  // now a member of Org B.
+  const req = new NextRequest(url);
+  req.cookies.set('shopify_shop_domain', 'org-a-shop.myshopify.com');
+  req.cookies.set('shopify_access_token', 'ORG-A-ACCESS-TOKEN');
+  req.cookies.set('shopify_connected', '1');
+  return req;
+}
+
+describe('getConfiguredShopifyFromRequest workspace scoping', () => {
+  it('must NOT hand back Org A cookie credentials to a request authenticated for Org B', () => {
+    const req = requestWithOrgACookies();
+
+    // Org B has never connected its own Shopify store. The resolver must not read/act on
+    // Org A's leftover credentials just because they happen to be present on the request.
+    const credsForOrgB = getConfiguredShopifyFromRequest(req, 'workspace-org-b');
+
+    expect(credsForOrgB).toBeNull();
+  });
+
+  it('returns the matching workspace credentials when the cookie was namespaced for that workspace', () => {
+    const req = new NextRequest('http://localhost/api/integrations/shopify/status');
+    req.cookies.set('shopify_shop_domain__workspace-org-b', 'org-b-shop.myshopify.com');
+    req.cookies.set('shopify_access_token__workspace-org-b', 'ORG-B-ACCESS-TOKEN');
+
+    const creds = getConfiguredShopifyFromRequest(req, 'workspace-org-b');
+
+    expect(creds?.adminHost).toBe('org-b-shop.myshopify.com');
+    expect(creds?.accessToken).toBe('ORG-B-ACCESS-TOKEN');
+  });
+});

--- a/src/lib/integrations/shopify.ts
+++ b/src/lib/integrations/shopify.ts
@@ -76,17 +76,48 @@ export function resolveMyshopifyHost(shopInput: string): { adminHost: string; so
   return { adminHost: primary, source: 'input' };
 }
 
-export function getConfiguredShopifyFromRequest(request: NextRequest): {
+/**
+ * Namespaces a Shopify credential cookie name to a workspace, so one workspace's stored
+ * shop/token cannot be read back for a different, authenticated workspace on a shared
+ * browser/session. Callers that genuinely have no workspace context (none of the current
+ * API routes — see below) get the legacy, unscoped name.
+ */
+export function shopifyCookieName(base: string, workspaceId?: string): string {
+  return workspaceId ? `${base}__${workspaceId}` : base;
+}
+
+/**
+ * Resolves the configured Shopify shop/token for this request.
+ *
+ * IMPORTANT (org-context scoping): Shopify has no workspace-scoped connection table
+ * (unlike WorkspaceXeroConnection) — the browser cookie set by the OAuth callback /
+ * configure route *is* the only storage. Once a `workspaceId` is known, credentials must
+ * be read from that workspace's namespaced cookies (`shopify_shop_domain__<workspaceId>`,
+ * `shopify_access_token__<workspaceId>`) only. We must NOT fall back to the legacy,
+ * unnamespaced cookies in that case — those could belong to a *different* workspace
+ * (e.g. a user who is a member of multiple workspaces, or a shared/kiosk browser that
+ * never cleared a previous org's session), mirroring the Xero cross-tenant token leak
+ * fixed in getValidXeroTokens(). The global `SHOPIFY_SHOP_DOMAIN` / `SHOPIFY_ACCESS_TOKEN`
+ * env vars remain a valid fallback in both cases — they are operator-configured
+ * single-tenant deployment config, not per-user browser state.
+ */
+export function getConfiguredShopifyFromRequest(
+  request: NextRequest,
+  workspaceId?: string
+): {
   shopDomain: string;
   accessToken: string;
   adminHost: string;
 } | null {
+  const shopCookieName = shopifyCookieName('shopify_shop_domain', workspaceId);
+  const tokenCookieName = shopifyCookieName('shopify_access_token', workspaceId);
+
   const cookieShop =
-    request.cookies.get('shopify_shop_domain')?.value?.trim() ||
+    request.cookies.get(shopCookieName)?.value?.trim() ||
     process.env.SHOPIFY_SHOP_DOMAIN?.trim() ||
     '';
   const token =
-    request.cookies.get('shopify_access_token')?.value?.trim() ||
+    request.cookies.get(tokenCookieName)?.value?.trim() ||
     process.env.SHOPIFY_ACCESS_TOKEN?.trim() ||
     '';
   const { adminHost } = resolveMyshopifyHost(cookieShop);


### PR DESCRIPTION
## Summary
- `getConfiguredShopifyFromRequest()` read `shopify_shop_domain`/`shopify_access_token` from plain, non-namespaced request cookies (falling back to global env vars) with zero workspace check. Shopify has no workspace-scoped connection table at all (unlike Xero's `WorkspaceXeroConnection`) — the cookie *is* the only credential storage, making this structurally worse than the Xero bug fixed in #229.
- Five routes (`sync-inventory`, `sync-all-inventory`, `sync-product`, `import-order`, `import-orders`) never called `getWorkspaceIdForUser` before using these credentials at all — completely workspace-blind.
- Impact: on a shared browser/session (agency staff managing multiple client workspaces, a user in multiple workspaces, or a kiosk machine with a stale session), an authenticated request for Org B could silently pick up Org A's Shopify shop domain and Admin API access token, and could import Org A's Shopify orders into Org B's ERP data.

## Fix
Added `shopifyCookieName(base, workspaceId)` to namespace every Shopify credential cookie per workspace (e.g. `shopify_access_token__<workspaceId>`), threaded `workspaceId` through `getConfiguredShopifyFromRequest()` and all 9 route handlers that read/write these cookies, and added the missing `getWorkspaceIdForUser` calls to the 5 routes that lacked them. Transient OAuth CSRF-state cookies were left unscoped (short-lived, cleared immediately post-callback — not credentials). Global `SHOPIFY_SHOP_DOMAIN`/`SHOPIFY_ACCESS_TOKEN` env vars remain valid fallbacks in both paths since they're operator-configured deployment config, not per-user browser state.

## Test plan
- [x] New test reproduces the leak against pre-fix code (namespaced cookies not recognized, cross-workspace token returned instead of `null`), then verifies the fix
- [x] Targeted tests (new + existing `shopify-route-auth.test.ts` + `shopify-oauth.test.ts`) — 13/13 pass
- [x] Full suite (`npx vitest run`) — no regressions (independently re-verified after merge: 48/48 files, 353/353 tests)
- [x] `npx tsc --noEmit` — 0 errors

No real Shopify credentials used anywhere — all verification via mocked/in-process vitest tests, no live Shopify API calls.

Linear: [UNI-2106](https://linear.app/unite-group/issue/UNI-2106/ccw-p0-build-loop-promote-shopifyxerosendgridsentry-from-demo-to)

🤖 Generated with [Claude Code](https://claude.com/claude-code)