### PR TITLE
fix(ci): remove invalid secrets-in-if from rollback.yml (UNI-2240)

### DIFF
--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -338,52 +338,8 @@ jobs:
             echo "- :x: Verification: ${{ needs.verify.result }}" >> $GITHUB_STEP_SUMMARY
           fi
 
-      - name: Send Slack notification
-        if: ${{ secrets.SLACK_WEBHOOK_URL != '' }}
-        uses: slackapi/slack-github-action@v3.0.1
-        with:
-          payload: |
-            {
-              "attachments": [
-                {
-                  "color": "${{ steps.status.outputs.color }}",
-                  "blocks": [
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": ":warning: *Emergency Rollback - ${{ needs.validate.outputs.environment }}*"
-                      }
-                    },
-                    {
-                      "type": "section",
-                      "fields": [
-                        {
-                          "type": "mrkdwn",
-                          "text": "*Environment:*\n${{ needs.validate.outputs.environment }}"
-                        },
-                        {
-                          "type": "mrkdwn",
-                          "text": "*Rollback Type:*\n${{ needs.validate.outputs.rollback_type }}"
-                        },
-                        {
-                          "type": "mrkdwn",
-                          "text": "*Rolled back to:*\n${{ needs.validate.outputs.short_sha }}"
-                        },
-                        {
-                          "type": "mrkdwn",
-                          "text": "*Initiated by:*\n${{ github.actor }}"
-                        },
-                        {
-                          "type": "mrkdwn",
-                          "text": "*Status:*\n${{ steps.status.outputs.emoji }} ${{ steps.status.outputs.status }}"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      # Slack notification removed - same fix as deploy-production.yml and
+      # deploy-staging.yml: `if: secrets.X != ''` is invalid (GitHub disallows
+      # `secrets.*` in if-conditions, so this workflow failed validation on every
+      # push and showed a red X in 0s) and no-Slack is portfolio standard. Status
+      # surfaces in the GITHUB_STEP_SUMMARY block above.


### PR DESCRIPTION
## Problem

The **Emergency Rollback** workflow (`.github/workflows/rollback.yml`) failed on **every push to `main`** — a persistent red X labelled "This run likely failed because of a workflow file issue," with no jobs ever running (0s failure).

Root cause: the `notify` job's Slack step used

```yaml
if: ${{ secrets.SLACK_WEBHOOK_URL != '' }}
```

GitHub **disallows the `secrets.*` context in `if:` conditions** (`Unrecognized named-value: 'secrets'`), which fails the workflow at validation time. Because validation runs on every push, the workflow was auto-rejected on each commit even though it is `workflow_dispatch`-only.

## Why this is the right fix

This is the **identical bug already resolved** in `deploy-production.yml` and `deploy-staging.yml` — both carry an explicit comment documenting the same `secrets`-in-`if` rejection and the same resolution. `rollback.yml` was simply missed in that cleanup. Following the established precedent:

- **Remove the Slack step entirely** (no-Slack is the stated portfolio standard).
- Rollback status still surfaces in the `GITHUB_STEP_SUMMARY` block.
- The workflow remains `workflow_dispatch`-only for genuine emergency rollbacks.

## Verification

- ✅ Confirmed via GitHub API scan that `rollback.yml:342` was the **only** workflow file with `secrets.*` in an `if:` condition.
- ✅ Fixed file parses cleanly (PyYAML): jobs `validate → rollback → verify → notify` intact; `notify` now has steps `Set status`, `Create rollback summary`; trigger `workflow_dispatch` only.
- ✅ Diff scoped to a single file: **+6 / −50**.
- Post-merge, expect the "Emergency Rollback" red X to stop appearing on pushes to `main`.

## Scope note

The separate **"Deploy to Staging"** failures on `main` are a distinct runtime/infra issue (SSH-based deploy), not a workflow-file validation error, and are **out of scope** for this ticket.

Closes UNI-2240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined rollback workflow notifications by removing an extra messaging step.
  * Status updates now rely on the existing job summary output, keeping rollback progress information available in one place.
  * Added clarifying notes to make the notification behavior easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->