### PR TITLE
fix(ci): remove workflow_run auto-trigger from deploy-staging (UNI-2251)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,12 +1,9 @@
 name: Deploy to Staging
 
 on:
-  # Only deploy after CI has passed — prevents broken code reaching staging (UNI-664 SUB-5)
-  workflow_run:
-    workflows: ['CI']
-    branches: [main]
-    types:
-      - completed
+  # Auto-trigger (workflow_run after CI) removed - it fired on every push to main
+  # and failed at the SSH step because STAGING_SSH_HOST/USER are unset, marking a
+  # red X on every commit. Manual-only until a staging VPS exists. See UNI-2251.
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
## Problem

`Deploy to Staging` showed a **red X on every push to `main`**. It triggered via `workflow_run` after each `CI` completion, then failed at the **"Add staging server to known hosts"** step:

```
ssh-keyscan -H  >> ~/.ssh/known_hosts      # empty host argument
usage: ssh-keyscan [-46cDHv] ...
##[error]Process completed with exit code 1.
```

`${{ secrets.STAGING_SSH_HOST }}` expands to empty — the `STAGING_SSH_HOST` / `STAGING_SSH_USER` secrets don't exist (only `STAGING_SSH_KEY` / `PRODUCTION_SSH_KEY` do). So every commit produced a failed deploy run, masking real CI signal.

## Fix (UNI-2251 Option A)

Remove the `workflow_run` auto-trigger so `deploy-staging.yml` runs **manual-only** (`workflow_dispatch`). This stops the red-X-on-every-push immediately while keeping the workflow available if a staging VPS is ever provisioned.

The SSH + `docker-compose` VPS deploy is legacy NodeJS-Starter-template infra; the app actually deploys via **Vercel**. There is no staging VPS today.

## Safety

- The `guard` (CI Gate) job already handles manual runs — `if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'` — so **manual dispatch is unaffected**.
- Fixed file parses cleanly (PyYAML): trigger is now `workflow_dispatch` only; all 7 jobs intact.
- Diff scoped to one file: **+3 / −6**.
- Post-merge, expect no more "Deploy to Staging" runs (and no red X) on pushes to `main`.

Refs UNI-2251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
