### PR TITLE
fix(cin7): log & report products skipped for missing SKU (UNI-2253)

### DIFF
--- a/src/app/api/integrations/cin7/sync/[entityType]/route.ts
+++ b/src/app/api/integrations/cin7/sync/[entityType]/route.ts
@@ -74,6 +74,7 @@ export async function POST(
 
   const pageSize = getCin7PageSize();
   let recordsProcessed = 0;
+  let recordsSkipped = 0;
   const startedAt = Date.now();
 
   if (entityType === 'products' || entityType === 'inventory') {
@@ -81,7 +82,9 @@ export async function POST(
       for (let page = 1; page <= MAX_PAGES; page += 1) {
         const { rows, total } = await fetchCin7ProductPage(coreCreds, page, pageSize);
         if (rows.length === 0) break;
-        recordsProcessed += await batchUpsertProducts(scope.userId, mapCoreProductRows(rows));
+        const mapped = mapCoreProductRows(rows);
+        recordsSkipped += mapped.skipped.length;
+        recordsProcessed += await batchUpsertProducts(scope.userId, mapped.rows);
         if (!shouldContinueCin7SyncPage(page, pageSize, rows.length, total, MAX_PAGES)) break;
       }
     } else if (useOmni && omniCreds) {
@@ -98,7 +101,9 @@ export async function POST(
             ? fetchOmniProductPage(omniCreds, nextPage, pageSize)
             : Promise.resolve({ rows: [], total: null, sourceRowCount: 0 });
 
-        recordsProcessed += await batchUpsertProducts(scope.userId, mapOmniProductRows(rows));
+        const mapped = mapOmniProductRows(rows);
+        recordsSkipped += mapped.skipped.length;
+        recordsProcessed += await batchUpsertProducts(scope.userId, mapped.rows);
         if (!shouldContinueCin7SyncPage(page, pageSize, sourceRowCount, total, MAX_PAGES)) break;
       }
     }
@@ -138,12 +143,13 @@ export async function POST(
 
   const durationMs = Date.now() - startedAt;
   console.log(
-    `[Cin7 sync] ${entityType}: ${recordsProcessed} records in ${durationMs}ms (${useCore ? 'core' : 'omni'})`
+    `[Cin7 sync] ${entityType}: ${recordsProcessed} records, ${recordsSkipped} skipped in ${durationMs}ms (${useCore ? 'core' : 'omni'})`
   );
 
   return NextResponse.json({
     status: 'ok',
     records_processed: recordsProcessed,
+    records_skipped: recordsSkipped,
     duration_ms: durationMs,
     page_size: pageSize,
   });

--- a/src/lib/integrations/cin7-sync-persist.test.ts
+++ b/src/lib/integrations/cin7-sync-persist.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mapCoreProductRows, mapOmniProductRows } from './cin7-sync-persist';
+
+describe('mapCoreProductRows — skip reporting (UNI-2253)', () => {
+  beforeEach(() => vi.spyOn(console, 'warn').mockImplementation(() => {}));
+  afterEach(() => vi.restoreAllMocks());
+
+  it('maps rows with a SKU and reports none skipped', () => {
+    const result = mapCoreProductRows([
+      { Sku: 'ABC-1', Name: 'Widget', Price: 10, Available: 5 },
+      { Sku: 'ABC-2', Name: 'Gadget', SellPrice: 20, Available: 0 },
+    ]);
+    expect(result.rows).toHaveLength(2);
+    expect(result.skipped).toHaveLength(0);
+    expect(result.rows[0]).toMatchObject({ sku: 'ABC-1', name: 'Widget', price: 10, stock: 5 });
+  });
+
+  it('skips rows with a missing/empty SKU and records them with a reason instead of dropping silently', () => {
+    const result = mapCoreProductRows([
+      { Sku: 'HAS-SKU', Name: 'Kept' },
+      { Sku: '', Name: 'No Sku Product' },
+      { Name: 'Undefined Sku Product' },
+      { Sku: '   ', Name: 'Whitespace Sku' },
+    ]);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].sku).toBe('HAS-SKU');
+    expect(result.skipped).toHaveLength(3);
+    expect(result.skipped.every((s) => s.reason === 'missing_sku')).toBe(true);
+    expect(result.skipped.map((s) => s.identifier)).toEqual([
+      'No Sku Product',
+      'Undefined Sku Product',
+      'Whitespace Sku',
+    ]);
+  });
+
+  it('logs a summary when rows are skipped', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mapCoreProductRows([{ Name: 'No Sku' }]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('skipped 1 product row'));
+  });
+
+  it('uses "(unnamed)" as the identifier when both SKU and Name are missing', () => {
+    const result = mapCoreProductRows([{ Price: 5 }]);
+    expect(result.skipped).toEqual([{ reason: 'missing_sku', identifier: '(unnamed)' }]);
+  });
+});
+
+describe('mapOmniProductRows — skip reporting (UNI-2253)', () => {
+  beforeEach(() => vi.spyOn(console, 'warn').mockImplementation(() => {}));
+  afterEach(() => vi.restoreAllMocks());
+
+  it('maps valid rows and reports skipped ones separately', () => {
+    const result = mapOmniProductRows([
+      { sku: 'OMNI-1', name: 'Alpha', price: 3, stock: 7 },
+      { sku: '', name: 'No Sku', price: 1, stock: 1 },
+      { sku: '  ', name: 'Blank Sku', price: 2, stock: 2 },
+    ]);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]).toMatchObject({ sku: 'OMNI-1', name: 'Alpha', category: 'Cin7 Omni' });
+    expect(result.skipped).toHaveLength(2);
+    expect(result.skipped.every((s) => s.reason === 'missing_sku')).toBe(true);
+  });
+});

--- a/src/lib/integrations/cin7-sync-persist.ts
+++ b/src/lib/integrations/cin7-sync-persist.ts
@@ -43,6 +43,12 @@ export type Cin7CustomerSyncRow = {
   city?: string;
 };
 
+/** A source row dropped during mapping, with why and a best-effort identifier for the logs. */
+export type SkippedRow = { reason: string; identifier: string };
+
+/** Result of mapping product source rows: the rows that will be imported plus the ones skipped. */
+export type ProductMapResult = { rows: Cin7ProductSyncRow[]; skipped: SkippedRow[] };
+
 /** Batch upsert products by owner+sku — concurrent upserts, no multi-statement transaction. */
 export async function batchUpsertProducts(
   ownerUserId: string,
@@ -161,11 +167,18 @@ export function mapCoreProductRows(
     SellPrice?: number;
     Available?: number;
   }>
-): Cin7ProductSyncRow[] {
+): ProductMapResult {
   const out: Cin7ProductSyncRow[] = [];
+  const skipped: SkippedRow[] = [];
   for (const row of rows) {
     const sku = String(row.Sku ?? '').trim();
-    if (!sku) continue;
+    if (!sku) {
+      skipped.push({
+        reason: 'missing_sku',
+        identifier: String(row.Name ?? '').trim() || '(unnamed)',
+      });
+      continue;
+    }
     out.push({
       sku,
       name: String(row.Name ?? sku).trim() || sku,
@@ -174,7 +187,12 @@ export function mapCoreProductRows(
       category: 'Cin7',
     });
   }
-  return out;
+  if (skipped.length > 0) {
+    console.warn(
+      `[Cin7 sync] mapCoreProductRows: skipped ${skipped.length} product row(s) with missing SKU`
+    );
+  }
+  return { rows: out, skipped };
 }
 
 export function mapCoreCustomerRows(
@@ -190,16 +208,29 @@ export function mapCoreCustomerRows(
 
 export function mapOmniProductRows(
   rows: Array<{ sku: string; name: string; price: number; stock: number }>
-): Cin7ProductSyncRow[] {
-  return rows
-    .map((row) => ({
-      sku: row.sku.trim(),
-      name: row.name.trim() || row.sku.trim(),
+): ProductMapResult {
+  const out: Cin7ProductSyncRow[] = [];
+  const skipped: SkippedRow[] = [];
+  for (const row of rows) {
+    const sku = row.sku.trim();
+    if (!sku) {
+      skipped.push({ reason: 'missing_sku', identifier: row.name?.trim() || '(unnamed)' });
+      continue;
+    }
+    out.push({
+      sku,
+      name: row.name.trim() || sku,
       price: row.price,
       stock: row.stock,
       category: 'Cin7 Omni',
-    }))
-    .filter((row) => row.sku);
+    });
+  }
+  if (skipped.length > 0) {
+    console.warn(
+      `[Cin7 sync] mapOmniProductRows: skipped ${skipped.length} product row(s) with missing SKU`
+    );
+  }
+  return { rows: out, skipped };
 }
 
 export function mapOmniCustomerRows(


### PR DESCRIPTION
## Problem (UNI-2253)

`mapCoreProductRows` and `mapOmniProductRows` in `cin7-sync-persist.ts` dropped any Cin7 product row with a missing/empty SKU **silently** — a bare `continue` (core) and a trailing `.filter(r => r.sku)` (omni). Nothing was logged, counted, or surfaced, so imported product counts could never be reconciled against Cin7 (contributes to the mismatches in Toby's 2026-07-02 reconciliation).

## Fix

- Both mappers now collect each dropped row as `{ reason: 'missing_sku', identifier }`, log a one-line summary, and return `{ rows, skipped }` instead of a bare array.
- The sync route accumulates `recordsSkipped` across pages and surfaces it as **`records_skipped`** in the JSON response (additive field — existing `records_processed` / `duration_ms` / `page_size` unchanged, no contract break). The per-run `console.log` now includes the skipped count.
- **No schema change.** (The customer-dedup schema question is tracked separately in UNI-2252.)

## Verification (run locally against a clean `main` checkout)

- `npm run type-check` (`tsc --noEmit`) — clean.
- `npx eslint` on all changed files — clean.
- `npx vitest run src/lib/integrations/cin7-sync-persist.test.ts` — **5/5 pass**, covering: valid rows mapped; missing / empty / whitespace / undefined SKU skipped with reason; summary logged; `(unnamed)` fallback identifier; omni path.

## Scope

Only the two product mappers + the sync route + a new unit test. Sibling Cin7 tickets: UNI-2252 (customer dedup, Urgent — blocked on Cin7-ID question + schema approval) and UNI-2254 (Suppliers/Branches/Internal Customer Types scope gap).

Closes UNI-2253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
