### PR TITLE
fix(cin7): dedup no-email customers on natural key (UNI-2252)

### DIFF
--- a/src/lib/integrations/cin7-sync-persist.test.ts
+++ b/src/lib/integrations/cin7-sync-persist.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mapCoreProductRows, mapOmniProductRows } from './cin7-sync-persist';
+import {
+  customerNaturalKey,
+  mapCoreProductRows,
+  mapOmniProductRows,
+  planNoEmailCustomerBatch,
+} from './cin7-sync-persist';
 
 describe('mapCoreProductRows — skip reporting (UNI-2253)', () => {
   beforeEach(() => vi.spyOn(console, 'warn').mockImplementation(() => {}));
@@ -42,6 +47,89 @@ describe('mapCoreProductRows — skip reporting (UNI-2253)', () => {
   it('uses "(unnamed)" as the identifier when both SKU and Name are missing', () => {
     const result = mapCoreProductRows([{ Price: 5 }]);
     expect(result.skipped).toEqual([{ reason: 'missing_sku', identifier: '(unnamed)' }]);
+  });
+});
+
+describe('customerNaturalKey (UNI-2252)', () => {
+  it('normalizes case, whitespace, and missing fields', () => {
+    expect(customerNaturalKey(' Acme Pty Ltd ', ' 0400 111 222 ', ' Brisbane ')).toBe(
+      customerNaturalKey('acme pty ltd', '0400 111 222', 'brisbane')
+    );
+    expect(customerNaturalKey('Acme', null, undefined)).toBe('acme||');
+  });
+
+  it('distinguishes customers that differ in any component', () => {
+    expect(customerNaturalKey('Acme', '111', 'Brisbane')).not.toBe(
+      customerNaturalKey('Acme', '222', 'Brisbane')
+    );
+    expect(customerNaturalKey('Acme', '111', 'Brisbane')).not.toBe(
+      customerNaturalKey('Acme', '111', 'Sydney')
+    );
+  });
+});
+
+describe('planNoEmailCustomerBatch (UNI-2252)', () => {
+  const row = (companyName: string, phone?: string, city?: string) => ({
+    companyName,
+    email: '',
+    phone,
+    city,
+  });
+
+  it('creates rows whose key is not in the DB and skips ones that are', () => {
+    const plan = planNoEmailCustomerBatch(
+      [row('Acme', '111', 'Brisbane'), row('NewCo', '333', 'Perth')],
+      [{ companyName: 'Acme', phone: '111', city: 'Brisbane' }]
+    );
+    expect(plan.toCreate.map((r) => r.companyName)).toEqual(['NewCo']);
+    expect(plan.matchedExisting).toBe(1);
+    expect(plan.duplicatesInBatch).toBe(0);
+  });
+
+  it('is idempotent: re-running the same batch against its own output creates nothing', () => {
+    const batch = [row('Acme', '111', 'Brisbane'), row('Beta', '222', 'Sydney')];
+    const first = planNoEmailCustomerBatch(batch, []);
+    expect(first.toCreate).toHaveLength(2);
+    const second = planNoEmailCustomerBatch(
+      batch,
+      first.toCreate.map((r) => ({ companyName: r.companyName, phone: r.phone, city: r.city }))
+    );
+    expect(second.toCreate).toHaveLength(0);
+    expect(second.matchedExisting).toBe(2);
+  });
+
+  it('matches case/whitespace variants of existing rows', () => {
+    const plan = planNoEmailCustomerBatch(
+      [row('  ACME  ', '111', 'BRISBANE')],
+      [{ companyName: 'Acme', phone: '111', city: 'Brisbane' }]
+    );
+    expect(plan.toCreate).toHaveLength(0);
+    expect(plan.matchedExisting).toBe(1);
+  });
+
+  it('collapses repeated keys within one batch to a single create', () => {
+    const plan = planNoEmailCustomerBatch(
+      [row('Acme', '111', 'Brisbane'), row('Acme', '111', 'Brisbane')],
+      []
+    );
+    expect(plan.toCreate).toHaveLength(1);
+    expect(plan.duplicatesInBatch).toBe(1);
+  });
+
+  it('tolerates pre-existing duplicates in the DB (first match wins, still no create)', () => {
+    const dupe = { companyName: 'Acme', phone: '111', city: 'Brisbane' };
+    const plan = planNoEmailCustomerBatch([row('Acme', '111', 'Brisbane')], [dupe, dupe, dupe]);
+    expect(plan.toCreate).toHaveLength(0);
+    expect(plan.matchedExisting).toBe(1);
+  });
+
+  it('does NOT merge customers that differ in phone or city (false-merge guard)', () => {
+    const plan = planNoEmailCustomerBatch(
+      [row('Acme', '222', 'Brisbane'), row('Acme', '111', 'Sydney')],
+      [{ companyName: 'Acme', phone: '111', city: 'Brisbane' }]
+    );
+    expect(plan.toCreate).toHaveLength(2);
+    expect(plan.matchedExisting).toBe(0);
   });
 });
 

--- a/src/lib/integrations/cin7-sync-persist.ts
+++ b/src/lib/integrations/cin7-sync-persist.ts
@@ -46,6 +46,53 @@ export type Cin7CustomerSyncRow = {
 /** A source row dropped during mapping, with why and a best-effort identifier for the logs. */
 export type SkippedRow = { reason: string; identifier: string };
 
+/**
+ * Natural key for customers that have no email (UNI-2252). Cin7 exposes no stable
+ * customer ID, so dedup keys on normalized companyName|phone|city. Two genuinely
+ * distinct customers sharing all three fields would merge — accepted trade-off.
+ */
+export function customerNaturalKey(
+  companyName: string,
+  phone?: string | null,
+  city?: string | null
+): string {
+  const norm = (v?: string | null) => (v ?? '').trim().toLowerCase();
+  return `${norm(companyName)}|${norm(phone)}|${norm(city)}`;
+}
+
+/**
+ * Pure planning step for the no-email customer branch: given incoming rows and the
+ * existing no-email rows already in the DB, decide which rows are genuinely new.
+ * First match wins against existing (tolerates pre-existing duplicates in the DB);
+ * repeats of the same key within one batch are collapsed to a single create.
+ */
+export function planNoEmailCustomerBatch(
+  rows: Cin7CustomerSyncRow[],
+  existing: Array<{ companyName: string; phone?: string | null; city?: string | null }>
+): { toCreate: Cin7CustomerSyncRow[]; matchedExisting: number; duplicatesInBatch: number } {
+  const existingKeys = new Set(
+    existing.map((e) => customerNaturalKey(e.companyName, e.phone, e.city))
+  );
+  const toCreate: Cin7CustomerSyncRow[] = [];
+  const seenInBatch = new Set<string>();
+  let matchedExisting = 0;
+  let duplicatesInBatch = 0;
+
+  for (const row of rows) {
+    const key = customerNaturalKey(row.companyName, row.phone, row.city);
+    if (existingKeys.has(key)) {
+      matchedExisting += 1;
+    } else if (seenInBatch.has(key)) {
+      duplicatesInBatch += 1;
+    } else {
+      seenInBatch.add(key);
+      toCreate.push(row);
+    }
+  }
+
+  return { toCreate, matchedExisting, duplicatesInBatch };
+}
+
 /** Result of mapping product source rows: the rows that will be imported plus the ones skipped. */
 export type ProductMapResult = { rows: Cin7ProductSyncRow[]; skipped: SkippedRow[] };
 
@@ -143,14 +190,36 @@ export async function batchUpsertCustomers(
     }
 
     if (withoutEmail.length > 0) {
-      await prisma.customer.createMany({
-        data: withoutEmail.map((r) => ({
+      // UNI-2252: previously an unconditional createMany that re-inserted every
+      // no-email customer on every sync run. Cin7 has no stable customer ID, so
+      // dedup on the normalized companyName|phone|city natural key instead.
+      const names = [...new Set(withoutEmail.map((r) => r.companyName.trim()))];
+      const existing = await prisma.customer.findMany({
+        where: {
           ownerUserId,
-          companyName: r.companyName,
-          phone: r.phone,
-          city: r.city,
-        })),
+          companyName: { in: names },
+          OR: [{ email: null }, { email: '' }],
+        },
+        select: { companyName: true, phone: true, city: true },
       });
+
+      const plan = planNoEmailCustomerBatch(withoutEmail, existing);
+      if (plan.matchedExisting > 0 || plan.duplicatesInBatch > 0) {
+        console.log(
+          `[Cin7 sync] customers(no-email): ${plan.toCreate.length} new, ${plan.matchedExisting} already present, ${plan.duplicatesInBatch} duplicate in batch`
+        );
+      }
+
+      if (plan.toCreate.length > 0) {
+        await prisma.customer.createMany({
+          data: plan.toCreate.map((r) => ({
+            ownerUserId,
+            companyName: r.companyName.trim(),
+            phone: r.phone?.trim(),
+            city: r.city?.trim(),
+          })),
+        });
+      }
     }
 
     processed += chunk.length;


### PR DESCRIPTION
## Problem (UNI-2252 — Urgent)

The no-email branch of `batchUpsertCustomers` did an **unconditional `createMany`** — every Cin7 customer without an email was re-inserted on every sync run. With a nightly sync this grows the duplicate count monotonically, and it is the primary reason Toby's reconciliation never matches (**Optix 28,003 vs Cin7 22,640**).

## Fix (Option A — app-level dedup, no schema change)

Cin7 exposes **no stable customer ID** (confirmed by owner), so dedup keys on a normalized `companyName|phone|city` natural key:

- **`customerNaturalKey()`** — pure: trim + lowercase composite key.
- **`planNoEmailCustomerBatch()`** — pure planning step: skips keys already in the DB (first match wins, so pre-existing duplicates don't break it), collapses repeated keys within a batch, returns only genuinely new rows + counts.
- The no-email branch now looks up existing **no-email** rows (`email` null/`''`) by companyName for the chunk, runs the planner, logs `new / already present / duplicate in batch` counts, and `createMany`s only the planned rows — storing trimmed values so future runs keep matching. Matching against email-carrying customers is deliberately out of scope (that's a different merge decision).

## Accepted trade-off (owner sign-off)

Two genuinely distinct customers with identical company name + phone + city would be treated as one. Owner accepted this risk (2026-07-03) given Cin7 provides no stable ID.

## Not in scope

- **Existing duplicates already in the DB are not cleaned up** — this stops new ones. Remediation of the ~5,363 existing dupes is a separate task (needs a merge strategy for FK-linked orders/quotes/invoices).
- Schema change (`cin7Id` column) — explicitly rejected in favour of Option A since there's no Cin7 value to store.

## Verification (clean current-`main` checkout)

- `npm run type-check` — clean
- `npx eslint` on changed files — clean
- `npx vitest run` — **13/13 pass** (8 new: key normalization, create-vs-skip, **idempotency** (re-run creates nothing), case/whitespace matching, in-batch collapse, pre-existing-dupe tolerance, **false-merge guard** (different phone/city stays separate))

Diff: `cin7-sync-persist.ts` +75/−6, test file +89/−1. No route/API contract change.

Closes UNI-2252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
