### PR TITLE
feat(cin7): sync Suppliers from Cin7 Core (UNI-2256)

### DIFF
--- a/src/app/api/integrations/cin7/sync/[entityType]/route.ts
+++ b/src/app/api/integrations/cin7/sync/[entityType]/route.ts
@@ -4,6 +4,7 @@ import {
   fetchCin7CustomerPage,
   fetchCin7ProductPage,
   fetchCin7SaleTotal,
+  fetchCin7SupplierPage,
   getCin7CoreCredentials,
   pingCin7Core,
 } from '@/lib/integrations/cin7-core';
@@ -22,8 +23,10 @@ import {
 import {
   batchUpsertCustomers,
   batchUpsertProducts,
+  batchUpsertSuppliers,
   mapCoreCustomerRows,
   mapCoreProductRows,
+  mapCoreSupplierRows,
   mapOmniCustomerRows,
   mapOmniProductRows,
 } from '@/lib/integrations/cin7-sync-persist';
@@ -48,7 +51,7 @@ export async function POST(
   }
 
   const { entityType } = await context.params;
-  const allowed = ['products', 'customers', 'orders', 'inventory'] as const;
+  const allowed = ['products', 'customers', 'orders', 'inventory', 'suppliers'] as const;
   if (!allowed.includes(entityType as (typeof allowed)[number])) {
     return NextResponse.json({ detail: 'Unsupported entity type' }, { status: 400 });
   }
@@ -138,6 +141,24 @@ export async function POST(
       recordsProcessed = await fetchCin7SaleTotal(coreCreds);
     } else if (useOmni && omniCreds) {
       recordsProcessed = await fetchOmniSalesOrderCount(omniCreds);
+    }
+  } else if (entityType === 'suppliers') {
+    if (useCore && coreCreds) {
+      for (let page = 1; page <= MAX_PAGES; page += 1) {
+        const { rows, total } = await fetchCin7SupplierPage(coreCreds, page, pageSize);
+        if (rows.length === 0) break;
+        const mapped = mapCoreSupplierRows(rows);
+        recordsSkipped += mapped.skipped.length;
+        recordsProcessed += await batchUpsertSuppliers(scope.userId, mapped.rows);
+        if (!shouldContinueCin7SyncPage(page, pageSize, rows.length, total, MAX_PAGES)) break;
+      }
+    } else if (useOmni && omniCreds) {
+      // Supplier sync via Cin7 Omni is not implemented yet — Omni exposes suppliers as
+      // supplier-type Contacts, which needs a distinct filter/mapping. Core is the
+      // supported path (UNI-2256). Follow-up: add Omni supplier support if needed.
+      console.warn(
+        '[Cin7 sync] suppliers: Omni supplier sync not implemented; connect Cin7 Core to sync suppliers'
+      );
     }
   }
 

--- a/src/lib/integrations/cin7-core.ts
+++ b/src/lib/integrations/cin7-core.ts
@@ -166,6 +166,31 @@ export async function fetchCin7CustomerPage(
   return { rows, total };
 }
 
+export type Cin7SupplierRow = {
+  /** Cin7 Core (DEAR) supplier GUID — stable, used as the dedup key. */
+  ID?: string;
+  Name?: string;
+  Contact?: string;
+  Phone?: string;
+  Email?: string;
+  [key: string]: unknown;
+};
+
+export async function fetchCin7SupplierPage(
+  creds: { accountId: string; applicationKey: string },
+  page: number,
+  limit: number
+): Promise<{ rows: Cin7SupplierRow[]; total: number; error?: string }> {
+  const { ok, data, error } = await cin7CoreGet<{
+    SupplierList?: Cin7SupplierRow[];
+    Total?: number;
+  }>(`/Supplier?Page=${page}&Limit=${limit}`, creds);
+  if (!ok) return { rows: [], total: 0, error };
+  const rows = Array.isArray(data.SupplierList) ? data.SupplierList : [];
+  const total = typeof data.Total === 'number' ? data.Total : rows.length;
+  return { rows, total };
+}
+
 export async function fetchCin7SaleTotal(
   creds: { accountId: string; applicationKey: string }
 ): Promise<number> {

--- a/src/lib/integrations/cin7-sync-persist.test.ts
+++ b/src/lib/integrations/cin7-sync-persist.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   customerNaturalKey,
   mapCoreProductRows,
+  mapCoreSupplierRows,
   mapOmniProductRows,
   planNoEmailCustomerBatch,
 } from './cin7-sync-persist';
@@ -130,6 +131,55 @@ describe('planNoEmailCustomerBatch (UNI-2252)', () => {
     );
     expect(plan.toCreate).toHaveLength(2);
     expect(plan.matchedExisting).toBe(0);
+  });
+});
+
+describe('mapCoreSupplierRows (UNI-2256)', () => {
+  beforeEach(() => vi.spyOn(console, 'warn').mockImplementation(() => {}));
+  afterEach(() => vi.restoreAllMocks());
+
+  it('maps suppliers using Cin7 ID as supplierCode', () => {
+    const result = mapCoreSupplierRows([
+      { ID: 'sup-guid-1', Name: 'Acme Supplies', Contact: 'Jane', Phone: '07 1234', Email: 'j@acme.com' },
+    ]);
+    expect(result.skipped).toHaveLength(0);
+    expect(result.rows[0]).toEqual({
+      supplierCode: 'sup-guid-1',
+      companyName: 'Acme Supplies',
+      contactName: 'Jane',
+      phone: '07 1234',
+      email: 'j@acme.com',
+    });
+  });
+
+  it('skips suppliers with a missing ID (would otherwise duplicate every run) with a reason', () => {
+    const result = mapCoreSupplierRows([
+      { ID: 'sup-1', Name: 'Kept' },
+      { Name: 'No Id Supplier' },
+      { ID: '   ', Name: 'Whitespace Id' },
+    ]);
+    expect(result.rows.map((r) => r.supplierCode)).toEqual(['sup-1']);
+    expect(result.skipped).toEqual([
+      { reason: 'missing_id', identifier: 'No Id Supplier' },
+      { reason: 'missing_id', identifier: 'Whitespace Id' },
+    ]);
+  });
+
+  it('normalizes blank optional fields to undefined and falls back companyName to the code', () => {
+    const result = mapCoreSupplierRows([{ ID: 'sup-2', Name: '  ', Contact: '', Phone: '  ' }]);
+    expect(result.rows[0]).toEqual({
+      supplierCode: 'sup-2',
+      companyName: 'sup-2',
+      contactName: undefined,
+      email: undefined,
+      phone: undefined,
+    });
+  });
+
+  it('logs a summary when suppliers are skipped', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mapCoreSupplierRows([{ Name: 'No Id' }]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('skipped 1 supplier row'));
   });
 });
 

--- a/src/lib/integrations/cin7-sync-persist.ts
+++ b/src/lib/integrations/cin7-sync-persist.ts
@@ -96,6 +96,17 @@ export function planNoEmailCustomerBatch(
 /** Result of mapping product source rows: the rows that will be imported plus the ones skipped. */
 export type ProductMapResult = { rows: Cin7ProductSyncRow[]; skipped: SkippedRow[] };
 
+export type Cin7SupplierSyncRow = {
+  supplierCode: string;
+  companyName: string;
+  contactName?: string;
+  email?: string;
+  phone?: string;
+};
+
+/** Result of mapping supplier source rows: the rows that will be imported plus the ones skipped. */
+export type SupplierMapResult = { rows: Cin7SupplierSyncRow[]; skipped: SkippedRow[] };
+
 /** Batch upsert products by owner+sku — concurrent upserts, no multi-statement transaction. */
 export async function batchUpsertProducts(
   ownerUserId: string,
@@ -125,6 +136,45 @@ export async function batchUpsertProducts(
           name: row.name,
           price: row.price,
           stock: row.stock,
+        },
+      })
+    );
+    processed += chunk.length;
+  }
+
+  return processed;
+}
+
+/** Batch upsert suppliers by owner+supplierCode — concurrent upserts, idempotent on re-run. */
+export async function batchUpsertSuppliers(
+  ownerUserId: string,
+  rows: Cin7SupplierSyncRow[]
+): Promise<number> {
+  if (rows.length === 0) return 0;
+
+  const batchSize = getCin7DbBatchSize();
+  const concurrency = getCin7DbConcurrency();
+  let processed = 0;
+
+  for (let i = 0; i < rows.length; i += batchSize) {
+    const chunk = rows.slice(i, i + batchSize);
+    await runInConcurrency(chunk, concurrency, (row) =>
+      prisma.supplier.upsert({
+        where: { ownerUserId_supplierCode: { ownerUserId, supplierCode: row.supplierCode } },
+        create: {
+          ownerUserId,
+          supplierCode: row.supplierCode,
+          companyName: row.companyName,
+          contactName: row.contactName,
+          email: row.email,
+          phone: row.phone,
+          isActive: true,
+        },
+        update: {
+          companyName: row.companyName,
+          contactName: row.contactName,
+          email: row.email,
+          phone: row.phone,
         },
       })
     );
@@ -259,6 +309,42 @@ export function mapCoreProductRows(
   if (skipped.length > 0) {
     console.warn(
       `[Cin7 sync] mapCoreProductRows: skipped ${skipped.length} product row(s) with missing SKU`
+    );
+  }
+  return { rows: out, skipped };
+}
+
+export function mapCoreSupplierRows(
+  rows: Array<{ ID?: string; Name?: string; Contact?: string; Phone?: string; Email?: string }>
+): SupplierMapResult {
+  const out: Cin7SupplierSyncRow[] = [];
+  const skipped: SkippedRow[] = [];
+  for (const row of rows) {
+    // Cin7 Core exposes a stable supplier GUID (ID). Without it we can't dedup, so skip
+    // rather than risk the duplicate-on-every-run bug (cf. UNI-2252).
+    const supplierCode = String(row.ID ?? '').trim();
+    if (!supplierCode) {
+      skipped.push({
+        reason: 'missing_id',
+        identifier: String(row.Name ?? '').trim() || '(unnamed)',
+      });
+      continue;
+    }
+    const clean = (v?: string) => {
+      const s = v == null ? '' : String(v).trim();
+      return s || undefined;
+    };
+    out.push({
+      supplierCode,
+      companyName: String(row.Name ?? supplierCode).trim() || supplierCode,
+      contactName: clean(row.Contact),
+      email: clean(row.Email),
+      phone: clean(row.Phone),
+    });
+  }
+  if (skipped.length > 0) {
+    console.warn(
+      `[Cin7 sync] mapCoreSupplierRows: skipped ${skipped.length} supplier row(s) with missing ID`
     );
   }
   return { rows: out, skipped };


### PR DESCRIPTION
## What (UNI-2256, parent UNI-2254)

Adds a **Suppliers** sync path from Cin7 Core. Toby's 2026-07-02 reconciliation showed **553 suppliers in Cin7, not synced** into Optix. The `Supplier` model already exists (`prisma/schema.prisma`), so **no schema change / migration**.

## Changes

- **`cin7-core.ts`** — `fetchCin7SupplierPage` (`/Supplier` → `SupplierList` + `Total` envelope, mirrors `fetchCin7CustomerPage`) + `Cin7SupplierRow` type.
- **`cin7-sync-persist.ts`**
  - `Cin7SupplierSyncRow` + `SupplierMapResult`
  - `mapCoreSupplierRows` — keys on Cin7's **stable supplier `ID`** as `supplierCode`; rows without an ID are **skipped and logged** (reusing the UNI-2253 skip pattern) rather than dropped silently, so we don't reintroduce the duplicate-on-every-run bug UNI-2252 just fixed.
  - `batchUpsertSuppliers` — `upsert` on the existing `@@unique([ownerUserId, supplierCode])`, so re-runs are **idempotent** (mirrors `batchUpsertProducts`).
- **`route.ts`** — `'suppliers'` added to `allowed`; Core branch wired with `records_skipped` reporting.

## Scope decision: Core only

Cin7 **Core** is the deployed/primary path (DEAR `inventory.dearsystems.com`; Toby's exports are Core-style) and Core suppliers carry a stable `ID`. **Omni** exposes suppliers as supplier-type Contacts, which needs a distinct filter/mapping — shipping a guess there risks importing wrong data, so the Omni branch is an **explicit logged no-op** for now (documented in-code; follow-up if Omni supplier sync is ever needed). This fully addresses the 553-supplier Core gap.

## Verification (clean current-`main` checkout)

- `npm run type-check` — clean (confirms `prisma.supplier.upsert` + compound key resolve)
- `npx eslint` on all changed files — clean
- `npx vitest run` — **17/17 pass** (4 new: ID→supplierCode mapping, ID-less skip+reason, blank-field normalization + companyName fallback, skip summary logged)

Diff: 4 files, `core.ts` +25, `persist.ts` +86, `route.ts` +22/−1, test +50. No migration, no API contract break (additive entity + additive `records_skipped`).

Closes UNI-2256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
