### PR TITLE
feat(cin7): env-gated product visibility tally groundwork (UNI-2259)

### DIFF
--- a/src/app/api/integrations/cin7/sync/[entityType]/route.ts
+++ b/src/app/api/integrations/cin7/sync/[entityType]/route.ts
@@ -21,6 +21,12 @@ import {
   shouldContinueCin7SyncPage,
 } from '@/lib/integrations/cin7-sync-config';
 import {
+  addVisibilityCounts,
+  getCin7VisibilityConfig,
+  tallyProductVisibility,
+  type Cin7VisibilityCounts,
+} from '@/lib/integrations/cin7-visibility';
+import {
   batchUpsertCustomers,
   batchUpsertProducts,
   batchUpsertSuppliers,
@@ -78,6 +84,14 @@ export async function POST(
   const pageSize = getCin7PageSize();
   let recordsProcessed = 0;
   let recordsSkipped = 0;
+  // UNI-2259 groundwork: env-gated visibility tally (null = feature off, response unchanged).
+  // Only armed where a tally can actually run — Core products/inventory — so other entity
+  // types and the Omni path never return misleading all-zero counts.
+  const visibilityConfig = getCin7VisibilityConfig();
+  const visibilityCounts: Cin7VisibilityCounts | null =
+    visibilityConfig && useCore && (entityType === 'products' || entityType === 'inventory')
+      ? { secure_internal: 0, show_public: 0, unknown: 0 }
+      : null;
   const startedAt = Date.now();
 
   if (entityType === 'products' || entityType === 'inventory') {
@@ -85,6 +99,10 @@ export async function POST(
       for (let page = 1; page <= MAX_PAGES; page += 1) {
         const { rows, total } = await fetchCin7ProductPage(coreCreds, page, pageSize);
         if (rows.length === 0) break;
+        if (visibilityConfig && visibilityCounts) {
+          // Tally on the raw rows — the mapper drops the arbitrary Cin7 fields.
+          addVisibilityCounts(visibilityCounts, tallyProductVisibility(rows, visibilityConfig));
+        }
         const mapped = mapCoreProductRows(rows);
         recordsSkipped += mapped.skipped.length;
         recordsProcessed += await batchUpsertProducts(scope.userId, mapped.rows);
@@ -163,8 +181,11 @@ export async function POST(
   }
 
   const durationMs = Date.now() - startedAt;
+  const visibilitySummary = visibilityCounts
+    ? ` | visibility: ${visibilityCounts.secure_internal} secure, ${visibilityCounts.show_public} public, ${visibilityCounts.unknown} unknown`
+    : '';
   console.log(
-    `[Cin7 sync] ${entityType}: ${recordsProcessed} records, ${recordsSkipped} skipped in ${durationMs}ms (${useCore ? 'core' : 'omni'})`
+    `[Cin7 sync] ${entityType}: ${recordsProcessed} records, ${recordsSkipped} skipped in ${durationMs}ms (${useCore ? 'core' : 'omni'})${visibilitySummary}`
   );
 
   return NextResponse.json({
@@ -173,5 +194,7 @@ export async function POST(
     records_skipped: recordsSkipped,
     duration_ms: durationMs,
     page_size: pageSize,
+    // Present only when CIN7_PRODUCT_VISIBILITY_FIELD is configured (UNI-2259).
+    ...(visibilityCounts ? { visibility_counts: visibilityCounts } : {}),
   });
 }

--- a/src/lib/api/cin7.ts
+++ b/src/lib/api/cin7.ts
@@ -127,12 +127,15 @@ export async function disconnectCin7(): Promise<{ status: string }> {
  * Trigger manual sync for a specific entity type
  */
 export async function triggerCin7Sync(
-  entityType: 'products' | 'customers' | 'orders' | 'inventory'
+  entityType: 'products' | 'customers' | 'orders' | 'inventory' | 'suppliers'
 ): Promise<{
   status: string;
   records_processed?: number;
+  records_skipped?: number;
   duration_ms?: number;
   page_size?: number;
+  /** Present only when CIN7_PRODUCT_VISIBILITY_FIELD is configured (UNI-2259). */
+  visibility_counts?: { secure_internal: number; show_public: number; unknown: number };
 }> {
   return apiClient.post(`/api/integrations/cin7/sync/${entityType}`, undefined, undefined, 300_000);
 }

--- a/src/lib/integrations/__tests__/cin7-sync-route-visibility.test.ts
+++ b/src/lib/integrations/__tests__/cin7-sync-route-visibility.test.ts
@@ -1,0 +1,143 @@
+/**
+ * UNI-2259: route-level contract tests for the env-gated visibility tally.
+ * Pins clause 1 (flag off => response shape byte-identical to before the feature)
+ * and the gating rule (counts only on the Core products/inventory path).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('@/lib/auth/data-scope', () => ({
+  requireAuthScopeOrCronIntegrationJob: vi.fn(),
+}));
+
+vi.mock('@/lib/integrations/cin7-core', () => ({
+  getCin7CoreCredentials: vi.fn(),
+  pingCin7Core: vi.fn(),
+  fetchCin7ProductPage: vi.fn(),
+  fetchCin7CustomerPage: vi.fn(),
+  fetchCin7SupplierPage: vi.fn(),
+  fetchCin7SaleTotal: vi.fn(),
+}));
+
+vi.mock('@/lib/integrations/cin7-omni', () => ({
+  getCin7OmniCredentials: vi.fn(),
+  pingCin7Omni: vi.fn(),
+  fetchOmniProductPage: vi.fn(),
+  fetchOmniContactsPage: vi.fn(),
+  fetchOmniSalesOrderCount: vi.fn(),
+}));
+
+vi.mock('@/lib/integrations/cin7-sync-persist', () => ({
+  batchUpsertProducts: vi.fn().mockResolvedValue(0),
+  batchUpsertCustomers: vi.fn().mockResolvedValue(0),
+  batchUpsertSuppliers: vi.fn().mockResolvedValue(0),
+  mapCoreProductRows: vi.fn(() => ({ rows: [], skipped: [] })),
+  mapCoreSupplierRows: vi.fn(() => ({ rows: [], skipped: [] })),
+  mapCoreCustomerRows: vi.fn(() => []),
+  mapOmniProductRows: vi.fn(() => ({ rows: [], skipped: [] })),
+  mapOmniCustomerRows: vi.fn(() => []),
+}));
+
+import { requireAuthScopeOrCronIntegrationJob } from '@/lib/auth/data-scope';
+import {
+  getCin7CoreCredentials,
+  pingCin7Core,
+  fetchCin7ProductPage,
+  fetchCin7CustomerPage,
+} from '@/lib/integrations/cin7-core';
+import {
+  getCin7OmniCredentials,
+  pingCin7Omni,
+  fetchOmniProductPage,
+} from '@/lib/integrations/cin7-omni';
+import { POST } from '@/app/api/integrations/cin7/sync/[entityType]/route';
+
+const CORE_CREDS = { accountId: 'acc', applicationKey: 'key' };
+
+function callSync(entityType: string) {
+  const req = new Request(`http://localhost/api/integrations/cin7/sync/${entityType}`, {
+    method: 'POST',
+  });
+  return POST(req as never, { params: Promise.resolve({ entityType }) });
+}
+
+function armCorePath() {
+  vi.mocked(requireAuthScopeOrCronIntegrationJob).mockResolvedValue({ userId: 'user-1' } as never);
+  vi.mocked(getCin7CoreCredentials).mockReturnValue(CORE_CREDS);
+  vi.mocked(pingCin7Core).mockResolvedValue(true);
+  vi.mocked(getCin7OmniCredentials).mockReturnValue(null);
+  vi.mocked(pingCin7Omni).mockResolvedValue(false);
+  // One short page of raw rows carrying the (hypothetical) visibility field.
+  vi.mocked(fetchCin7ProductPage).mockResolvedValue({
+    rows: [
+      { Sku: 'A', Status: 'Secure Internal' },
+      { Sku: 'B', Status: 'Show Public' },
+      { Sku: 'C' },
+    ],
+    total: 3,
+  });
+  vi.mocked(fetchCin7CustomerPage).mockResolvedValue({ rows: [{ Name: 'X' }], total: 1 });
+}
+
+describe('cin7 sync route — visibility flag OFF (contract clause 1)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('CIN7_PRODUCT_VISIBILITY_FIELD', '');
+    armCorePath();
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('products response has exactly the pre-feature keys — no visibility_counts', async () => {
+    const res = await callSync('products');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Object.keys(body).sort()).toEqual([
+      'duration_ms',
+      'page_size',
+      'records_processed',
+      'records_skipped',
+      'status',
+    ]);
+  });
+});
+
+describe('cin7 sync route — visibility flag ON', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('CIN7_PRODUCT_VISIBILITY_FIELD', 'Status');
+    vi.stubEnv('CIN7_PRODUCT_VISIBILITY_SECURE_VALUES', 'Secure Internal');
+    armCorePath();
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('Core products response includes correct visibility_counts tallied on raw rows', async () => {
+    const res = await callSync('products');
+    const body = await res.json();
+    expect(body.visibility_counts).toEqual({
+      secure_internal: 1,
+      show_public: 1,
+      unknown: 1, // row C has no Status field
+    });
+  });
+
+  it('non-product entity types never return visibility_counts (no misleading zeros)', async () => {
+    const res = await callSync('customers');
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).not.toHaveProperty('visibility_counts');
+  });
+
+  it('the Omni products path never returns visibility_counts (raw fields are flattened away)', async () => {
+    vi.mocked(pingCin7Core).mockResolvedValue(false);
+    vi.mocked(getCin7OmniCredentials).mockReturnValue({ username: 'u', apiKey: 'k' });
+    vi.mocked(pingCin7Omni).mockResolvedValue(true);
+    vi.mocked(fetchOmniProductPage).mockResolvedValue({
+      rows: [],
+      total: null,
+      sourceRowCount: 0,
+    });
+    const res = await callSync('products');
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).not.toHaveProperty('visibility_counts');
+  });
+});

--- a/src/lib/integrations/cin7-visibility.test.ts
+++ b/src/lib/integrations/cin7-visibility.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  addVisibilityCounts,
+  classifyProductVisibility,
+  getCin7VisibilityConfig,
+  tallyProductVisibility,
+  type Cin7VisibilityConfig,
+} from './cin7-visibility';
+
+describe('getCin7VisibilityConfig (UNI-2259)', () => {
+  beforeEach(() => {
+    vi.stubEnv('CIN7_PRODUCT_VISIBILITY_FIELD', '');
+    vi.stubEnv('CIN7_PRODUCT_VISIBILITY_SECURE_VALUES', '');
+    vi.stubEnv('CIN7_PRODUCT_VISIBILITY_PUBLIC_VALUES', '');
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('returns null (feature off) when the field env is unset or blank', () => {
+    expect(getCin7VisibilityConfig()).toBeNull();
+    vi.stubEnv('CIN7_PRODUCT_VISIBILITY_FIELD', '   ');
+    expect(getCin7VisibilityConfig()).toBeNull();
+  });
+
+  it('parses the field and comma-separated value lists (trimmed, lowercased, empties dropped)', () => {
+    vi.stubEnv('CIN7_PRODUCT_VISIBILITY_FIELD', 'Status');
+    vi.stubEnv('CIN7_PRODUCT_VISIBILITY_SECURE_VALUES', ' Secure Internal , HIDDEN ,, ');
+    vi.stubEnv('CIN7_PRODUCT_VISIBILITY_PUBLIC_VALUES', 'Show Public');
+    expect(getCin7VisibilityConfig()).toEqual({
+      field: 'Status',
+      secureValues: ['secure internal', 'hidden'],
+      publicValues: ['show public'],
+    });
+  });
+
+  it('enables with only a secure list (public list optional)', () => {
+    vi.stubEnv('CIN7_PRODUCT_VISIBILITY_FIELD', 'Status');
+    vi.stubEnv('CIN7_PRODUCT_VISIBILITY_SECURE_VALUES', 'secure');
+    expect(getCin7VisibilityConfig()).toEqual({
+      field: 'Status',
+      secureValues: ['secure'],
+      publicValues: [],
+    });
+  });
+});
+
+describe('classifyProductVisibility (UNI-2259)', () => {
+  const cfg = (over?: Partial<Cin7VisibilityConfig>): Cin7VisibilityConfig => ({
+    field: 'Status',
+    secureValues: ['secure internal'],
+    publicValues: [],
+    ...over,
+  });
+
+  it('classifies secure values case-insensitively', () => {
+    expect(classifyProductVisibility({ Status: 'SECURE INTERNAL' }, cfg())).toBe('secure_internal');
+    expect(classifyProductVisibility({ Status: '  secure internal  ' }, cfg())).toBe(
+      'secure_internal'
+    );
+  });
+
+  it('defaults any non-secure, non-empty value to show_public when no public list is set (binary split)', () => {
+    expect(classifyProductVisibility({ Status: 'Show Public' }, cfg())).toBe('show_public');
+    expect(classifyProductVisibility({ Status: 'anything-else' }, cfg())).toBe('show_public');
+  });
+
+  it('requires membership in the public list when one is configured', () => {
+    const c = cfg({ publicValues: ['show public'] });
+    expect(classifyProductVisibility({ Status: 'Show Public' }, c)).toBe('show_public');
+    expect(classifyProductVisibility({ Status: 'archived' }, c)).toBe('unknown');
+  });
+
+  it('secure list takes precedence even when a public list is also configured', () => {
+    const c = cfg({ secureValues: ['secure internal'], publicValues: ['show public'] });
+    expect(classifyProductVisibility({ Status: 'Secure Internal' }, c)).toBe('secure_internal');
+    // ...and a value in both lists is secure, never public
+    const both = cfg({ secureValues: ['x'], publicValues: ['x'] });
+    expect(classifyProductVisibility({ Status: 'x' }, both)).toBe('secure_internal');
+  });
+
+  it('treats non-primitive field values (objects, arrays, functions) as unknown, not public', () => {
+    expect(classifyProductVisibility({ Status: { nested: true } }, cfg())).toBe('unknown');
+    expect(classifyProductVisibility({ Status: ['secure internal'] }, cfg())).toBe('unknown');
+    expect(classifyProductVisibility({ Status: () => 'x' }, cfg())).toBe('unknown');
+  });
+
+  it('ignores prototype-inherited properties (misconfigured field like "toString") — unknown, not public', () => {
+    expect(classifyProductVisibility({}, cfg({ field: 'toString' }))).toBe('unknown');
+    expect(classifyProductVisibility({ Status: 'irrelevant' }, cfg({ field: 'constructor' }))).toBe(
+      'unknown'
+    );
+  });
+
+  it('returns unknown when the field is missing, null, or empty', () => {
+    expect(classifyProductVisibility({}, cfg())).toBe('unknown');
+    expect(classifyProductVisibility({ Status: null }, cfg())).toBe('unknown');
+    expect(classifyProductVisibility({ Status: '   ' }, cfg())).toBe('unknown');
+  });
+
+  it('stringifies non-string raw values (e.g. booleans) before matching', () => {
+    const c = cfg({ secureValues: ['true'] });
+    expect(classifyProductVisibility({ Status: true }, c)).toBe('secure_internal');
+    expect(classifyProductVisibility({ Status: false }, c)).toBe('show_public');
+  });
+});
+
+describe('tallyProductVisibility + addVisibilityCounts (UNI-2259)', () => {
+  const config: Cin7VisibilityConfig = {
+    field: 'Status',
+    secureValues: ['secure internal'],
+    publicValues: [],
+  };
+
+  it('tallies a page of raw rows into per-visibility counts', () => {
+    const counts = tallyProductVisibility(
+      [
+        { Status: 'Secure Internal' },
+        { Status: 'Show Public' },
+        { Status: 'Show Public' },
+        { NoStatusField: 1 },
+      ],
+      config
+    );
+    expect(counts).toEqual({ secure_internal: 1, show_public: 2, unknown: 1 });
+  });
+
+  it('accumulates page tallies (mirrors the route aggregation)', () => {
+    const total = { secure_internal: 1, show_public: 2, unknown: 0 };
+    addVisibilityCounts(total, { secure_internal: 0, show_public: 3, unknown: 2 });
+    expect(total).toEqual({ secure_internal: 1, show_public: 5, unknown: 2 });
+  });
+});

--- a/src/lib/integrations/cin7-visibility.ts
+++ b/src/lib/integrations/cin7-visibility.ts
@@ -1,0 +1,96 @@
+/**
+ * UNI-2259 groundwork: env-gated product visibility classification.
+ *
+ * Cin7 distinguishes "Secure Internal" from "Show Public" products, but the raw
+ * field that carries this is not yet identified (Cin7ProductRow only has a
+ * `[key: string]: unknown` catch-all). Rather than guess, the mapping is fully
+ * env-driven and OFF by default:
+ *
+ *   CIN7_PRODUCT_VISIBILITY_FIELD          — raw Cin7 product field to read (enables the feature)
+ *   CIN7_PRODUCT_VISIBILITY_SECURE_VALUES  — comma-separated values meaning Secure Internal
+ *   CIN7_PRODUCT_VISIBILITY_PUBLIC_VALUES  — optional; values meaning Show Public. When unset,
+ *                                            any non-empty value not in the secure list counts
+ *                                            as Show Public (Cin7's split is binary).
+ *
+ * When enabled, the sync tallies per-visibility counts and surfaces them in the
+ * sync response (`visibility_counts`) so Toby's 95 / 5,616 split can be
+ * reconciled — no schema change, no import behaviour change. Persisting
+ * visibility onto Product (migration) is the follow-up step tracked in UNI-2259.
+ */
+
+export type Cin7ProductVisibility = 'secure_internal' | 'show_public' | 'unknown';
+
+export type Cin7VisibilityConfig = {
+  /** Raw Cin7 product field name to read (e.g. a status/attribute field). */
+  field: string;
+  /** Normalized (trimmed, lowercased) values that mean Secure Internal. */
+  secureValues: string[];
+  /** Normalized values that mean Show Public; empty = "anything non-secure". */
+  publicValues: string[];
+};
+
+export type Cin7VisibilityCounts = Record<Cin7ProductVisibility, number>;
+
+function parseValueList(raw: string | undefined): string[] {
+  return (raw ?? '')
+    .split(',')
+    .map((v) => v.trim().toLowerCase())
+    .filter((v) => v.length > 0);
+}
+
+/** Returns null (feature off) unless CIN7_PRODUCT_VISIBILITY_FIELD is set. */
+export function getCin7VisibilityConfig(): Cin7VisibilityConfig | null {
+  const field = process.env.CIN7_PRODUCT_VISIBILITY_FIELD?.trim();
+  if (!field) return null;
+  return {
+    field,
+    secureValues: parseValueList(process.env.CIN7_PRODUCT_VISIBILITY_SECURE_VALUES),
+    publicValues: parseValueList(process.env.CIN7_PRODUCT_VISIBILITY_PUBLIC_VALUES),
+  };
+}
+
+/** Classify one raw Cin7 product row. Pure — config decides everything. */
+export function classifyProductVisibility(
+  row: Record<string, unknown>,
+  config: Cin7VisibilityConfig
+): Cin7ProductVisibility {
+  // Own-property + primitive guards: a field name colliding with Object.prototype
+  // members ('toString', 'constructor', …) or a non-scalar value (nested object,
+  // array) must land in 'unknown', not silently inflate the public tally.
+  if (!Object.hasOwn(row, config.field)) return 'unknown';
+  const raw = row[config.field];
+  if (raw != null && typeof raw !== 'string' && typeof raw !== 'number' && typeof raw !== 'boolean') {
+    return 'unknown';
+  }
+  const value = raw == null ? '' : String(raw).trim().toLowerCase();
+  if (!value) return 'unknown';
+  if (config.secureValues.includes(value)) return 'secure_internal';
+  if (config.publicValues.length > 0) {
+    return config.publicValues.includes(value) ? 'show_public' : 'unknown';
+  }
+  // No explicit public list: Cin7's split is binary, so any non-secure value is public.
+  return 'show_public';
+}
+
+/** Tally visibility across a page of raw Cin7 product rows. */
+export function tallyProductVisibility(
+  rows: Array<Record<string, unknown>>,
+  config: Cin7VisibilityConfig
+): Cin7VisibilityCounts {
+  const counts: Cin7VisibilityCounts = { secure_internal: 0, show_public: 0, unknown: 0 };
+  for (const row of rows) {
+    counts[classifyProductVisibility(row, config)] += 1;
+  }
+  return counts;
+}
+
+/** Accumulate `add` into `into` (page-by-page aggregation in the sync route). */
+export function addVisibilityCounts(
+  into: Cin7VisibilityCounts,
+  add: Cin7VisibilityCounts
+): Cin7VisibilityCounts {
+  into.secure_internal += add.secure_internal;
+  into.show_public += add.show_public;
+  into.unknown += add.unknown;
+  return into;
+}


### PR DESCRIPTION
## What (UNI-2259 groundwork, parent UNI-2254)

Env-gated **product visibility tally** — the zero-risk slice of UNI-2259 that ships *before* the two blockers resolve (the Cin7 field is unidentified, and persisting visibility needs a schema change).

**OFF by default.** With `CIN7_PRODUCT_VISIBILITY_FIELD` unset, route behavior and response are byte-identical to today (pinned by a route-level test). Once Toby/Rana identify the Cin7 field, setting env vars starts producing reconciliation counts — **no code change**:

```
CIN7_PRODUCT_VISIBILITY_FIELD=<raw Cin7 product field>
CIN7_PRODUCT_VISIBILITY_SECURE_VALUES=<csv values meaning Secure Internal>
CIN7_PRODUCT_VISIBILITY_PUBLIC_VALUES=<optional csv; unset = any non-secure non-empty value is Show Public>
```

When enabled, the Core products/inventory sync tallies raw rows per page and returns `visibility_counts: { secure_internal, show_public, unknown }` — enough to reconcile the **95 / 5,616** split from Toby's 2026-07-02 email.

## Adversarial review (3-lens workflow) — findings addressed

- **Own-property + primitive guards**: field names colliding with `Object.prototype` (`toString`) and non-scalar values (nested objects/arrays) classify as `unknown` — they can no longer silently inflate the public tally.
- **No misleading zeros**: counts are armed only on the Core products/inventory path; customers/orders/suppliers and the Omni path never return all-zero `visibility_counts`.
- **Typed client**: `triggerCin7Sync` gains `'suppliers'` in its entity union (missed in UNI-2256) + optional `records_skipped` / `visibility_counts`.
- **Test majors closed**: route-level tests pin the exact flag-off response key set; secure-list precedence over a configured public list is pinned (incl. value-in-both-lists).

**Known limitation (inherited, not expanded here):** a mid-run Cin7 fetch failure truncates the tally exactly the way it already truncates `records_processed` — the route discards page-fetch errors. Proper error propagation is a separate change.

## Verification (clean current-`main` checkout)

- `npm run type-check` — clean
- `npx eslint` on all changed files — clean
- `npx vitest run` — **34/34 pass** (10 new unit: config parsing, precedence, binary default, non-primitives, prototype collision, tally/aggregation; 4 new route-level: flag-off exact shape, correct tally, no counts for non-product entities, no counts on Omni path)

Diff: 5 files — new `cin7-visibility.ts` (+96) + 2 test files (+274), route (+24/−1), typed client (+4/−1). No schema change, no contract break.

Refs UNI-2259 (groundwork — the ticket stays open for field identification + `Product.visibility` persistence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
