### PR TITLE
ci: run deepsec on Node 22 — fixes webidl.util.markAsUncloneable crash

### DIFF
--- a/.github/workflows/deepsec-weekly.yml
+++ b/.github/workflows/deepsec-weekly.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
       - name: Install dependencies
         run: |
           cd .deepsec


### PR DESCRIPTION
The weekly Deepsec scan has been failing with `TypeError: webidl.util.markAsUncloneable is not a function` — an undici/Node version mismatch; deepsec's dependency expects an API Node 20's runtime doesn't expose. One-line fix: setup-node 20 → 22.

**Tested before this PR existed:** workflow_dispatch of this exact branch — run 28885441099 — completed SUCCESS on Node 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the weekly scan environment to use a newer Node.js version for improved compatibility and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->