### PR TITLE
feat(governance): CODEOWNERS for supply-chain-critical paths (RA-3026)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,7 @@
-# CODEOWNERS — sole owner is the CleanExpo account (solo founder workflow)
-# Self-review is acceptable for this single-owner setup.
-* @CleanExpo
+# RA-3026 — require founder review on supply-chain and infra-critical paths.
+# Binding via require_code_owner_reviews=true in main branch protection.
+.npmrc @CleanExpo
+/.github/workflows/ @CleanExpo
+/prisma/ @CleanExpo
+package.json @CleanExpo
+package-lock.json @CleanExpo


### PR DESCRIPTION
Item 2 of RA-3026. Founder (@CleanExpo) becomes required reviewer for `.npmrc`, `.github/workflows/`, `prisma/`, and package manifests — the exact files silently dropped in the 2026-05-10 stale-base direct push. Binding immediately: `require_code_owner_reviews: true` is live in main branch protection as of this morning.

Protection state (verified via REST + GraphQL this morning): 1 required review, code-owner reviews required, strict checks (`Frontend Tests`, `Validation Gates`, `Security Scan`, `Test Suite`), linear history, no deletions, `allowsForcePushes=false` (GraphQL truth; the REST GET mis-reports this field on this repo), `enforce_admins=false` per ticket spec so the founder keeps override.

Verification probe result (honest record): a plain direct push from the admin credential was **not** rejected — GitHub logged "Bypassed rule violations … Changes must be made through a pull request" and landed an empty, tree-identical probe commit (`f0d63614`) on main. Protection therefore blocks write-level users (the incident's actor class) but not admin tokens — that is the `enforce_admins: false` trade the ticket chose, now documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership rules for critical configuration, workflow, dependency, and database paths.
  * Added review requirements supporting protected-branch governance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->