### PR TITLE
fix(ci): fail Deploy to Staging run when deploy job did not succeed [UNI-2337]

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -305,3 +305,11 @@ jobs:
       # `if: secrets.X != ''` is invalid (GitHub disallows `secrets.*` in
       # if-conditions) and no-Slack is portfolio standard. Status surfaces
       # in the GITHUB_STEP_SUMMARY block above.
+
+      # notify runs with if: always() so it must re-fail the run — otherwise a
+      # skipped/failed deploy still reports the workflow green (UNI-2337).
+      - name: Propagate deploy outcome
+        if: ${{ steps.status.outputs.status != 'success' }}
+        run: |
+          echo "::error::Deploy job result: ${{ needs.deploy.result }}, smoke tests: ${{ needs.smoke-tests.result }} — failing the run so staging reds are visible"
+          exit 1


### PR DESCRIPTION
## Problem — false-green Deploy to Staging runs [UNI-2337]

The `notify` job runs with `if: always()` and never fails, so the workflow run reports **success** even when every deploy job was skipped (upstream CI failed at the `guard` gate) or the deploy itself failed. Staging reds were invisible.

Evidence: runs [29092199405](https://github.com/CleanExpo/CCW-CRM/actions/runs/29092199405), [28996764565](https://github.com/CleanExpo/CCW-CRM/actions/runs/28996764565), [28962710666](https://github.com/CleanExpo/CCW-CRM/actions/runs/28962710666) — all concluded "success" with every deploy job skipped. Greens on 08–10/07/2026 were false.

## Fix

Add one final step to the `notify` job that propagates the real outcome: it fails the run whenever the already-computed deployment status is not `success` (i.e. `deploy` did not succeed, or smoke tests failed — the same logic the job's own `status` step uses). `if: always()` stays on the job, so the notification/summary still runs on failure; the run just no longer lies about it.

- No deploy behaviour changes — the step only affects the run's reported conclusion.
- Smallest possible diff: 8 added lines at the end of the `notify` job, nothing else touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
