### PR TITLE
Default-deny public privileged registration

### DIFF
--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,56 +1,9 @@
-import { countAppUsers, findAppUserByEmail, insertAppUser } from '@/lib/auth/app-user-repo';
-import { jsonDetail, jsonOk, jsonValidationError, readJsonBody } from '@/lib/auth/http';
-import { signTokenPair } from '@/lib/auth/jwt-tokens';
-import { mapAppUserRowToPublic } from '@/lib/auth/map-user';
-import { hashPassword } from '@/lib/auth/password';
-import { registerBodySchema } from '@/lib/auth/schemas';
-import { setAuthSessionCookies } from '@/lib/auth/session-cookies';
+import { jsonDetail } from '@/lib/auth/http';
 import { NextRequest } from 'next/server';
 
-function isPrismaUniqueViolation(e: unknown): boolean {
-  return (
-    typeof e === 'object' && e !== null && 'code' in e && (e as { code: string }).code === 'P2002'
+export async function POST(_request: NextRequest) {
+  return jsonDetail(
+    'Public registration is disabled. Ask an owner or admin for an invitation.',
+    403
   );
-}
-
-export async function POST(request: NextRequest) {
-  const parsedBody = await readJsonBody(request);
-  if (!parsedBody.ok) return parsedBody.response;
-
-  const parsed = registerBodySchema.safeParse(parsedBody.body);
-  if (!parsed.success) return jsonValidationError(parsed.error);
-
-  try {
-    const existing = await findAppUserByEmail(parsed.data.email);
-    if (existing) {
-      return jsonDetail('An account with this email already exists', 409);
-    }
-
-    const password_hash = await hashPassword(parsed.data.password);
-    const isFirst = (await countAppUsers()) === 0;
-    const defaultRole = isFirst ? 'owner' : 'admin';
-    const row = await insertAppUser({
-      email: parsed.data.email,
-      password_hash,
-      full_name: parsed.data.full_name ?? null,
-      is_admin: defaultRole === 'owner' || defaultRole === 'admin',
-      role: defaultRole,
-    });
-
-    const tokens = await signTokenPair(row.id, row.email, row.isAdmin, row.role);
-    const response = jsonOk({
-      user: mapAppUserRowToPublic(row),
-      message: 'User registered successfully',
-      access_token: tokens.access_token,
-      token_type: 'bearer',
-    });
-    setAuthSessionCookies(response, tokens);
-    return response;
-  } catch (e: unknown) {
-    if (isPrismaUniqueViolation(e)) {
-      return jsonDetail('An account with this email already exists', 409);
-    }
-    console.error('[auth/register]', e);
-    return jsonDetail('Registration service unavailable', 503);
-  }
 }

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -197,14 +197,14 @@ export function LoginForm({ variant = 'default' }: LoginFormProps) {
         >
           <p className={isMarketing ? 'text-zinc-400' : undefined}>
             <Link
-              href="/register"
+              href="/contact"
               className={
                 isMarketing
                   ? 'font-medium text-sky-300 underline-offset-4 transition-colors hover:text-sky-200 hover:underline'
                   : 'font-medium text-primary hover:underline'
               }
             >
-              Create an account
+              Request access
             </Link>
             <span className={isMarketing ? 'text-zinc-600' : 'text-muted-foreground'}> · </span>
             <Link

--- a/src/components/landing/__tests__/public-account-links.test.tsx
+++ b/src/components/landing/__tests__/public-account-links.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+beforeAll(() => {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  );
+});
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+import { LoginForm } from '@/components/auth/login-form';
+import { MarketingHeader } from '@/components/landing/marketing-header';
+
+describe('public account links', () => {
+  it('does not advertise public signup in the marketing header', () => {
+    render(<MarketingHeader />);
+
+    expect(screen.queryByRole('link', { name: /sign up/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /log in/i })).toHaveAttribute('href', '/login');
+  });
+
+  it('routes login-page access requests to contact instead of registration', () => {
+    render(<LoginForm />);
+
+    expect(screen.queryByRole('link', { name: /create an account/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /request access/i })).toHaveAttribute(
+      'href',
+      '/contact'
+    );
+  });
+});

--- a/src/components/landing/marketing-header.tsx
+++ b/src/components/landing/marketing-header.tsx
@@ -61,15 +61,6 @@ export function MarketingHeader() {
 
         <div className="flex shrink-0 flex-wrap items-center justify-center gap-2 md:justify-end">
           <Link
-            href="/register"
-            className={cn(
-              buttonVariants({ variant: 'outline', size: 'sm' }),
-              'min-h-9 rounded-full border-white/15 bg-white/[0.03] px-4 text-sm font-semibold text-zinc-200 hover:border-white/25 hover:bg-white/[0.07] hover:text-white'
-            )}
-          >
-            Sign up
-          </Link>
-          <Link
             href="/login"
             className={cn(
               buttonVariants({ variant: 'gradient', size: 'sm' }),

--- a/src/lib/auth/__tests__/onboarding-routes.test.ts
+++ b/src/lib/auth/__tests__/onboarding-routes.test.ts
@@ -32,6 +32,9 @@ import {
   insertAppUser,
   setPasswordResetFields,
 } from '@/lib/auth/app-user-repo';
+import { signTokenPair } from '@/lib/auth/jwt-tokens';
+import { hashPassword } from '@/lib/auth/password';
+import { setAuthSessionCookies } from '@/lib/auth/session-cookies';
 import { POST as registerPost } from '@/app/api/auth/register/route';
 import { POST as forgotPasswordPost } from '@/app/api/auth/forgot-password/route';
 
@@ -40,29 +43,7 @@ describe('auth onboarding routes', () => {
     vi.clearAllMocks();
   });
 
-  it('register rejects duplicate email with 409', async () => {
-    vi.mocked(findAppUserByEmail).mockResolvedValue({
-      id: 'u1',
-      email: 'a@example.com',
-      isActive: true,
-    } as never);
-
-    const res = await registerPost(
-      new NextRequest('http://localhost/api/auth/register', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          email: 'a@example.com',
-          password: 'Password123!',
-          full_name: 'Alex',
-        }),
-      })
-    );
-
-    expect(res.status).toBe(409);
-  });
-
-  it('register creates the first user as owner', async () => {
+  it('register denies anonymous account creation before any user or token work', async () => {
     vi.mocked(findAppUserByEmail).mockResolvedValue(null);
     vi.mocked(countAppUsers).mockResolvedValue(0);
     vi.mocked(insertAppUser).mockResolvedValue({
@@ -89,10 +70,16 @@ describe('auth onboarding routes', () => {
       })
     );
 
-    expect(res.status).toBe(200);
-    expect(insertAppUser).toHaveBeenCalledWith(
-      expect.objectContaining({ role: 'owner', is_admin: true })
-    );
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({
+      detail: 'Public registration is disabled. Ask an owner or admin for an invitation.',
+    });
+    expect(findAppUserByEmail).not.toHaveBeenCalled();
+    expect(countAppUsers).not.toHaveBeenCalled();
+    expect(hashPassword).not.toHaveBeenCalled();
+    expect(insertAppUser).not.toHaveBeenCalled();
+    expect(signTokenPair).not.toHaveBeenCalled();
+    expect(setAuthSessionCookies).not.toHaveBeenCalled();
   });
 
   it('forgot-password returns generic success when email is unknown', async () => {

--- a/src/lib/auth/__tests__/team-invite-route.test.ts
+++ b/src/lib/auth/__tests__/team-invite-route.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/auth/request-token', () => ({
+  getAuthClaimsFromRequest: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/app-user-repo', () => ({
+  findAppUserByEmail: vi.fn(),
+  findAppUserById: vi.fn(),
+  insertAppUser: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/password', () => ({
+  hashPassword: vi.fn().mockResolvedValue('hashed-temporary-password'),
+}));
+
+import { POST as invitePost } from '@/app/api/team/invite/route';
+import { findAppUserByEmail, findAppUserById, insertAppUser } from '@/lib/auth/app-user-repo';
+import { hashPassword } from '@/lib/auth/password';
+import { getAuthClaimsFromRequest } from '@/lib/auth/request-token';
+
+const inviteRequest = () =>
+  new NextRequest('http://localhost/api/team/invite', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email: 'new.member@example.com',
+      full_name: 'New Member',
+      role: 'member',
+    }),
+  });
+
+const claimsFor = (role: 'owner' | 'admin' | 'member' | 'billing') => ({
+  sub: `${role}-1`,
+  email: `${role}@example.com`,
+  is_admin: role === 'owner' || role === 'admin',
+  role,
+});
+
+describe('team invite role matrix', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(findAppUserById).mockResolvedValue({
+      id: 'inviter-1',
+      isActive: true,
+      workspaceId: 'workspace-1',
+    } as never);
+    vi.mocked(findAppUserByEmail).mockResolvedValue(null);
+    vi.mocked(insertAppUser).mockResolvedValue({
+      id: 'new-user-1',
+      email: 'new.member@example.com',
+      isAdmin: false,
+      role: 'member',
+      fullName: 'New Member',
+      isActive: true,
+      workspaceId: 'workspace-1',
+      createdAt: new Date(),
+      lastLoginAt: null,
+    } as never);
+  });
+
+  it.each(['owner', 'admin'] as const)('allows authenticated %s invitations', async (role) => {
+    vi.mocked(getAuthClaimsFromRequest).mockResolvedValue(claimsFor(role));
+
+    const response = await invitePost(inviteRequest());
+
+    expect(response.status).toBe(201);
+    expect(hashPassword).toHaveBeenCalledOnce();
+    expect(insertAppUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'new.member@example.com',
+        role: 'member',
+        workspace_id: 'workspace-1',
+      })
+    );
+  });
+
+  it.each(['member', 'billing'] as const)('denies authenticated %s invitations', async (role) => {
+    vi.mocked(getAuthClaimsFromRequest).mockResolvedValue(claimsFor(role));
+
+    const response = await invitePost(inviteRequest());
+
+    expect(response.status).toBe(403);
+    expect(findAppUserById).not.toHaveBeenCalled();
+    expect(hashPassword).not.toHaveBeenCalled();
+    expect(insertAppUser).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/auth/__tests__/update-session.test.ts
+++ b/src/lib/auth/__tests__/update-session.test.ts
@@ -39,6 +39,10 @@ describe('middleware public-path matching', () => {
     }
   });
 
+  it('redirects unauthenticated registration visits to login', async () => {
+    expectLoginRedirect(await runUnauthenticatedRequest('/register'), '/register');
+  });
+
   it.each([
     '/playground',
     '/playground/example',

--- a/src/lib/auth/update-session.ts
+++ b/src/lib/auth/update-session.ts
@@ -64,7 +64,6 @@ export async function updateSession(request: NextRequest) {
   const publicPaths = [
     '/',
     '/login',
-    '/register',
     // PWA / install metadata must load without a session (browser requests it independently).
     '/manifest.json',
     '/forgot-password',


### PR DESCRIPTION
## Summary
- return deterministic 403 from public registration before body parsing, password hashing, database writes, token signing, or cookie work
- require authentication before visiting `/register` and remove public signup advertising
- preserve owner/admin team invitations while proving member/billing denial

## Verification
- focused auth/UI suite: 25/25 passed
- full Vitest suite: 47 files, 364/364 passed
- `npm run type-check`: passed
- `npm run lint`: passed with 32 pre-existing warnings and 0 errors
- `npm run build`: passed on Node 22.22.3
- Gitleaks staged diff scan: no leaks
- macOS smoke: `GET /register` -> 307 `/login?redirect=%2Fregister`; anonymous `POST /api/auth/register` -> 403

## Scope
No migration, dependency, environment, provider, or production change. This PR must remain unmerged pending independent review and Phill approval.