### PR TITLE
Eliminate public registration privilege escalation

### DIFF
--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,4 +1,4 @@
-import { countAppUsers, findAppUserByEmail, insertAppUser } from '@/lib/auth/app-user-repo';
+import { findAppUserByEmail, insertAppUser } from '@/lib/auth/app-user-repo';
 import { jsonDetail, jsonOk, jsonValidationError, readJsonBody } from '@/lib/auth/http';
 import { signTokenPair } from '@/lib/auth/jwt-tokens';
 import { mapAppUserRowToPublic } from '@/lib/auth/map-user';
@@ -27,17 +27,19 @@ export async function POST(request: NextRequest) {
     }
 
     const password_hash = await hashPassword(parsed.data.password);
-    const isFirst = (await countAppUsers()) === 0;
-    const defaultRole = isFirst ? 'owner' : 'admin';
     const row = await insertAppUser({
       email: parsed.data.email,
       password_hash,
       full_name: parsed.data.full_name ?? null,
-      is_admin: defaultRole === 'owner' || defaultRole === 'admin',
-      role: defaultRole,
+      is_admin: false,
+      role: 'member',
     });
 
     const tokens = await signTokenPair(row.id, row.email, row.isAdmin, row.role);
+    console.info('[auth/register] registration completed', {
+      role: row.role,
+      is_admin: row.isAdmin,
+    });
     const response = jsonOk({
       user: mapAppUserRowToPublic(row),
       message: 'User registered successfully',
@@ -50,7 +52,7 @@ export async function POST(request: NextRequest) {
     if (isPrismaUniqueViolation(e)) {
       return jsonDetail('An account with this email already exists', 409);
     }
-    console.error('[auth/register]', e);
+    console.error('[auth/register] registration failed');
     return jsonDetail('Registration service unavailable', 503);
   }
 }

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -52,7 +52,9 @@ export async function POST(request: NextRequest) {
     if (isPrismaUniqueViolation(e)) {
       return jsonDetail('An account with this email already exists', 409);
     }
-    console.error('[auth/register] registration failed');
+    console.error('[auth/register] registration failed', {
+      errorType: e instanceof Error ? e.name : typeof e,
+    });
     return jsonDetail('Registration service unavailable', 503);
   }
 }

--- a/src/app/api/team/invite/route.ts
+++ b/src/app/api/team/invite/route.ts
@@ -30,6 +30,9 @@ export async function POST(request: NextRequest) {
 
   const inviter = await findAppUserById(claims.sub);
   if (!inviter?.isActive) return jsonDetail('Not authenticated', 401);
+  const inviterIsPrivileged =
+    (inviter.role === 'owner' || inviter.role === 'admin') && inviter.isAdmin;
+  if (!inviterIsPrivileged) return jsonDetail('Forbidden', 403);
 
   const parsedBody = await readJsonBody(request);
   if (!parsedBody.ok) return parsedBody.response;

--- a/src/lib/auth/__tests__/onboarding-routes.test.ts
+++ b/src/lib/auth/__tests__/onboarding-routes.test.ts
@@ -62,15 +62,15 @@ describe('auth onboarding routes', () => {
     expect(res.status).toBe(409);
   });
 
-  it('register creates the first user as owner', async () => {
+  it('register does not bootstrap privilege when the user table is empty', async () => {
     vi.mocked(findAppUserByEmail).mockResolvedValue(null);
     vi.mocked(countAppUsers).mockResolvedValue(0);
     vi.mocked(insertAppUser).mockResolvedValue({
       id: 'u-new',
-      email: 'owner@example.com',
-      isAdmin: true,
-      role: 'owner',
-      fullName: 'Owner',
+      email: 'member@example.com',
+      isAdmin: false,
+      role: 'member',
+      fullName: 'Member',
       isActive: true,
       workspaceId: 'u-new',
       createdAt: new Date(),
@@ -82,16 +82,17 @@ describe('auth onboarding routes', () => {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          email: 'owner@example.com',
+          email: 'member@example.com',
           password: 'Password123!',
-          full_name: 'Owner',
+          full_name: 'Member',
         }),
       })
     );
 
     expect(res.status).toBe(200);
+    expect(countAppUsers).not.toHaveBeenCalled();
     expect(insertAppUser).toHaveBeenCalledWith(
-      expect.objectContaining({ role: 'owner', is_admin: true })
+      expect.objectContaining({ role: 'member', is_admin: false })
     );
   });
 

--- a/src/lib/auth/__tests__/public-registration-route.test.ts
+++ b/src/lib/auth/__tests__/public-registration-route.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/auth/app-user-repo', () => ({
+  findAppUserByEmail: vi.fn(),
+  countAppUsers: vi.fn(),
+  insertAppUser: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/password', () => ({
+  hashPassword: vi.fn().mockResolvedValue('hashed'),
+}));
+
+vi.mock('@/lib/auth/jwt-tokens', () => ({
+  signTokenPair: vi.fn().mockResolvedValue({
+    access_token: 'access',
+    refresh_token: 'refresh',
+  }),
+}));
+
+vi.mock('@/lib/auth/session-cookies', () => ({
+  setAuthSessionCookies: vi.fn(),
+}));
+
+import { POST as registerPost } from '@/app/api/auth/register/route';
+import { countAppUsers, findAppUserByEmail, insertAppUser } from '@/lib/auth/app-user-repo';
+import { signTokenPair } from '@/lib/auth/jwt-tokens';
+
+function registerRequest(body: Record<string, unknown>) {
+  return new NextRequest('http://localhost/api/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function memberRow(email: string, id = 'u-member') {
+  return {
+    id,
+    email,
+    isAdmin: false,
+    role: 'member' as const,
+    fullName: 'Member',
+    isActive: true,
+    workspaceId: id,
+    createdAt: new Date(),
+    lastLoginAt: null,
+  };
+}
+
+describe('public registration privilege boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates an ordinary public user with least privilege', async () => {
+    vi.mocked(findAppUserByEmail).mockResolvedValue(null);
+    vi.mocked(insertAppUser).mockResolvedValue(memberRow('member@example.com') as never);
+
+    const res = await registerPost(
+      registerRequest({
+        email: 'member@example.com',
+        password: 'Password123!',
+        full_name: 'Member',
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(insertAppUser).toHaveBeenCalledWith(
+      expect.objectContaining({ role: 'member', is_admin: false })
+    );
+    expect(signTokenPair).toHaveBeenCalledWith(
+      'u-member',
+      'member@example.com',
+      false,
+      'member'
+    );
+  });
+
+  it('ignores forged privilege fields and signs persisted member claims', async () => {
+    vi.mocked(findAppUserByEmail).mockResolvedValue(null);
+    vi.mocked(insertAppUser).mockResolvedValue(
+      memberRow('forged@example.com', 'u-forged') as never
+    );
+
+    const res = await registerPost(
+      registerRequest({
+        email: 'forged@example.com',
+        password: 'Password123!',
+        full_name: 'Forged',
+        role: 'owner',
+        is_admin: true,
+      })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(insertAppUser).toHaveBeenCalledWith({
+      email: 'forged@example.com',
+      password_hash: 'hashed',
+      full_name: 'Forged',
+      role: 'member',
+      is_admin: false,
+    });
+    expect(signTokenPair).toHaveBeenCalledWith(
+      'u-forged',
+      'forged@example.com',
+      false,
+      'member'
+    );
+    expect(body.user).toMatchObject({ role: 'member', is_admin: false });
+    expect(body.access_token).toBe('access');
+  });
+
+  it('parallel public registrations cannot race into privileged claims', async () => {
+    vi.mocked(findAppUserByEmail).mockResolvedValue(null);
+    vi.mocked(insertAppUser).mockImplementation(async (input) => ({
+      ...memberRow(input.email.toLowerCase(), `u-${input.email}`),
+      fullName: input.full_name,
+      isAdmin: input.is_admin,
+      role: input.role ?? 'member',
+    }) as never);
+
+    const responses = await Promise.all(
+      Array.from({ length: 8 }, (_, index) =>
+        registerPost(
+          registerRequest({
+            email: `parallel-${index}@example.com`,
+            password: 'Password123!',
+          })
+        )
+      )
+    );
+
+    expect(responses.every((response) => response.status === 200)).toBe(true);
+    expect(countAppUsers).not.toHaveBeenCalled();
+    expect(insertAppUser).toHaveBeenCalledTimes(8);
+    for (const [input] of vi.mocked(insertAppUser).mock.calls) {
+      expect(input).toMatchObject({ role: 'member', is_admin: false });
+    }
+    expect(signTokenPair).toHaveBeenCalledTimes(8);
+    for (const [, , isAdmin, role] of vi.mocked(signTokenPair).mock.calls) {
+      expect({ isAdmin, role }).toEqual({ isAdmin: false, role: 'member' });
+    }
+  });
+
+  it('maps a concurrent normalised-email collision to 409', async () => {
+    vi.mocked(findAppUserByEmail).mockResolvedValue(null);
+    vi.mocked(insertAppUser).mockRejectedValue({ code: 'P2002' });
+
+    const res = await registerPost(
+      registerRequest({
+        email: 'Mixed.Case@Example.com',
+        password: 'Password123!',
+      })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(body.detail).toBe('An account with this email already exists');
+    expect(signTokenPair).not.toHaveBeenCalled();
+  });
+
+  it('emits non-identifying privilege telemetry', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    vi.mocked(findAppUserByEmail).mockResolvedValue(null);
+    vi.mocked(insertAppUser).mockResolvedValue(memberRow('telemetry@example.com') as never);
+
+    await registerPost(
+      registerRequest({
+        email: 'telemetry@example.com',
+        password: 'Password123!',
+      })
+    );
+
+    expect(info).toHaveBeenCalledWith('[auth/register] registration completed', {
+      role: 'member',
+      is_admin: false,
+    });
+    expect(JSON.stringify(info.mock.calls)).not.toContain('telemetry@example.com');
+    info.mockRestore();
+  });
+
+  it('does not log internal errors or registration PII', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(findAppUserByEmail).mockResolvedValue(null);
+    vi.mocked(insertAppUser).mockRejectedValue(
+      new Error('database failure for private.person@example.com')
+    );
+
+    const res = await registerPost(
+      registerRequest({
+        email: 'private.person@example.com',
+        password: 'Password123!',
+      })
+    );
+
+    expect(res.status).toBe(503);
+    expect(error).toHaveBeenCalledWith('[auth/register] registration failed');
+    expect(JSON.stringify(error.mock.calls)).not.toContain('private.person@example.com');
+    expect(JSON.stringify(error.mock.calls)).not.toContain('database failure');
+    error.mockRestore();
+  });
+});

--- a/src/lib/auth/__tests__/public-registration-route.test.ts
+++ b/src/lib/auth/__tests__/public-registration-route.test.ts
@@ -196,7 +196,9 @@ describe('public registration privilege boundary', () => {
     );
 
     expect(res.status).toBe(503);
-    expect(error).toHaveBeenCalledWith('[auth/register] registration failed');
+    expect(error).toHaveBeenCalledWith('[auth/register] registration failed', {
+      errorType: 'Error',
+    });
     expect(JSON.stringify(error.mock.calls)).not.toContain('private.person@example.com');
     expect(JSON.stringify(error.mock.calls)).not.toContain('database failure');
     error.mockRestore();

--- a/src/lib/auth/__tests__/registration-postgres-concurrency.test.ts
+++ b/src/lib/auth/__tests__/registration-postgres-concurrency.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST as registerPost } from '@/app/api/auth/register/route';
+import { verifyAccessJwt } from '@/lib/auth/jwt-tokens';
+import { prisma } from '@/lib/db/prisma';
+
+const testDatabaseUrl = process.env.TEST_DATABASE_URL;
+const testDatabaseHost = testDatabaseUrl ? new URL(testDatabaseUrl).hostname : null;
+const isLocalTestDatabase = testDatabaseHost === '127.0.0.1' || testDatabaseHost === 'localhost';
+if (isLocalTestDatabase && testDatabaseUrl) process.env.DATABASE_URL = testDatabaseUrl;
+const describeWithPostgres = isLocalTestDatabase ? describe : describe.skip;
+const emailSuffix = '@registration-concurrency.invalid';
+
+function requestFor(email: string) {
+  return new NextRequest('http://localhost/api/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email,
+      password: 'PostgresTestPassword123!',
+      full_name: 'Concurrency Test',
+      role: 'owner',
+      is_admin: true,
+    }),
+  });
+}
+
+async function removeTestUsers() {
+  await prisma.appUser.deleteMany({ where: { email: { endsWith: emailSuffix } } });
+}
+
+describeWithPostgres('public registration with disposable PostgreSQL', () => {
+  beforeEach(async () => {
+    await removeTestUsers();
+  });
+
+  afterAll(async () => {
+    await removeTestUsers();
+    await prisma.$disconnect();
+  });
+
+  it('persists and signs only least-privilege claims across parallel registrations', async () => {
+    const responses = await Promise.all(
+      Array.from({ length: 8 }, (_, index) =>
+        registerPost(requestFor(`parallel-${index}${emailSuffix}`))
+      )
+    );
+    const bodies = await Promise.all(responses.map((response) => response.json()));
+
+    expect(responses.every((response) => response.status === 200)).toBe(true);
+    expect(bodies.every((body) => body.user.role === 'member' && body.user.is_admin === false)).toBe(
+      true
+    );
+
+    const persisted = await prisma.appUser.findMany({
+      where: { email: { endsWith: emailSuffix } },
+      orderBy: { email: 'asc' },
+    });
+    expect(persisted).toHaveLength(8);
+    expect(persisted.every((row) => row.role === 'member' && row.isAdmin === false)).toBe(true);
+
+    const claims = await Promise.all(
+      bodies.map((body) => verifyAccessJwt(body.access_token as string))
+    );
+    expect(claims.every((claim) => claim?.role === 'member' && claim.is_admin === false)).toBe(true);
+  });
+
+  it('normalises mixed-case email races to one member and one conflict', async () => {
+    const [upper, lower] = await Promise.all([
+      registerPost(requestFor(`Mixed.Case${emailSuffix}`)),
+      registerPost(requestFor(`mixed.case${emailSuffix}`)),
+    ]);
+
+    expect([upper.status, lower.status].sort()).toEqual([200, 409]);
+    const persisted = await prisma.appUser.findMany({
+      where: { email: `mixed.case${emailSuffix}` },
+    });
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0]).toMatchObject({ role: 'member', isAdmin: false });
+  });
+});

--- a/src/lib/auth/__tests__/team-invite-route.test.ts
+++ b/src/lib/auth/__tests__/team-invite-route.test.ts
@@ -41,6 +41,40 @@ describe('team invite route', () => {
     expect(insertAppUser).not.toHaveBeenCalled();
   });
 
+  it('rejects a stale admin token after the inviter is demoted to member', async () => {
+    vi.mocked(getAuthClaimsFromRequest).mockResolvedValue({
+      sub: 'former-admin',
+      email: 'former-admin@example.com',
+      is_admin: true,
+      role: 'admin',
+    });
+    vi.mocked(findAppUserById).mockResolvedValue({
+      id: 'former-admin',
+      workspaceId: 'workspace-1',
+      isActive: true,
+      isAdmin: false,
+      role: 'member',
+    } as never);
+    vi.mocked(findAppUserByEmail).mockResolvedValue(null);
+    vi.mocked(insertAppUser).mockResolvedValue({
+      id: 'invitee-user',
+      email: 'invitee@example.com',
+      fullName: 'Invitee',
+      role: 'admin',
+      isAdmin: true,
+      isActive: true,
+      workspaceId: 'workspace-1',
+      createdAt: new Date(),
+      lastLoginAt: null,
+    } as never);
+
+    const res = await POST(inviteRequest('admin'));
+
+    expect(res.status).toBe(403);
+    expect(findAppUserByEmail).not.toHaveBeenCalled();
+    expect(insertAppUser).not.toHaveBeenCalled();
+  });
+
   it('keeps privileged provisioning behind an authenticated admin boundary', async () => {
     vi.mocked(getAuthClaimsFromRequest).mockResolvedValue({
       sub: 'admin-user',
@@ -52,6 +86,8 @@ describe('team invite route', () => {
       id: 'admin-user',
       workspaceId: 'workspace-1',
       isActive: true,
+      isAdmin: true,
+      role: 'admin',
     } as never);
     vi.mocked(findAppUserByEmail).mockResolvedValue(null);
     vi.mocked(insertAppUser).mockResolvedValue({

--- a/src/lib/auth/__tests__/team-invite-route.test.ts
+++ b/src/lib/auth/__tests__/team-invite-route.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/auth/request-token', () => ({
+  getAuthClaimsFromRequest: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/app-user-repo', () => ({
+  findAppUserByEmail: vi.fn(),
+  findAppUserById: vi.fn(),
+  insertAppUser: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/password', () => ({
+  hashPassword: vi.fn().mockResolvedValue('hashed'),
+}));
+
+import { POST } from '@/app/api/team/invite/route';
+import { getAuthClaimsFromRequest } from '@/lib/auth/request-token';
+import { findAppUserByEmail, findAppUserById, insertAppUser } from '@/lib/auth/app-user-repo';
+
+function inviteRequest(role: 'owner' | 'admin' | 'member' | 'billing' = 'member') {
+  return new NextRequest('http://localhost/api/team/invite', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: 'invitee@example.com', full_name: 'Invitee', role }),
+  });
+}
+
+describe('team invite route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects unauthenticated provisioning', async () => {
+    vi.mocked(getAuthClaimsFromRequest).mockResolvedValue(null);
+
+    const res = await POST(inviteRequest('admin'));
+
+    expect(res.status).toBe(401);
+    expect(insertAppUser).not.toHaveBeenCalled();
+  });
+
+  it('keeps privileged provisioning behind an authenticated admin boundary', async () => {
+    vi.mocked(getAuthClaimsFromRequest).mockResolvedValue({
+      sub: 'admin-user',
+      email: 'admin@example.com',
+      is_admin: true,
+      role: 'admin',
+    });
+    vi.mocked(findAppUserById).mockResolvedValue({
+      id: 'admin-user',
+      workspaceId: 'workspace-1',
+      isActive: true,
+    } as never);
+    vi.mocked(findAppUserByEmail).mockResolvedValue(null);
+    vi.mocked(insertAppUser).mockResolvedValue({
+      id: 'invitee-user',
+      email: 'invitee@example.com',
+      fullName: 'Invitee',
+      role: 'admin',
+      isAdmin: true,
+      isActive: true,
+      workspaceId: 'workspace-1',
+      createdAt: new Date(),
+      lastLoginAt: null,
+    } as never);
+
+    const res = await POST(inviteRequest('admin'));
+
+    expect(res.status).toBe(201);
+    expect(insertAppUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'invitee@example.com',
+        role: 'admin',
+        is_admin: true,
+        workspace_id: 'workspace-1',
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- make unauthenticated public registration always persist `member` / `is_admin=false`
- remove first-user count bootstrap and its TOCTOU privilege race
- keep admin provisioning behind the authenticated `/api/team/invite` route
- add unit, concurrency, JWT-claim, forged-field, duplicate-email, telemetry, and invite-boundary coverage

## Verification
- `npm test`: 349 passed, 2 disposable-PostgreSQL tests skipped by default
- disposable PostgreSQL registration test: 2/2 passed
- `npm run type-check`: passed
- `npm run lint`: passed with 32 pre-existing warnings, 0 errors
- `npm run build`: passed at `4b2b77cdf6248c4efc59defb4f6745c1dccf7863`
- `git diff --check`: passed
- independent pre-commit review: APPROVE_FOR_COMMIT, no blockers

## Security notes
- public request fields cannot select `role` or `is_admin`
- access-token claims are signed from the persisted least-privilege row
- registration logs contain role/admin state only; PII and internal errors are excluded
- no production deployment or merge performed

## Residual risk
- repository-wide `npm audit` reports 21 pre-existing dependency advisories (1 critical, 7 high, 9 moderate, 4 low); this PR does not modify dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Public registration now creates all new accounts with standard member access; administrative privileges are no longer assigned automatically.
  - Registration ignores forged privilege settings and protects against concurrent or duplicate account creation.
  - Team invitations now require an active, authorized administrator.

- **Bug Fixes**
  - Duplicate email registrations return a conflict response.
  - Registration failures provide safer generic error handling without exposing sensitive details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->